### PR TITLE
fix: use kr http client in admin client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ lint:
 
 .PHONY: test
 test: clean
-	@mkdir -p cover/integration cover/unit
+	@mkdir -p cover/integration-cli cover/integration-test cover/unit
 	@go clean -testcache
 
 	go test -count=1 -race -cover ./... -args -test.gocoverdir="${PWD}/cover/unit"
-	GOCOVERDIR="${PWD}/cover/integration" go test -count=1 -race ./integration
+	CLI_GOCOVERDIR="${PWD}/cover/integration-cli" go test -count=1 -race -cover -coverpkg=./... ./integration -args -test.gocoverdir="${PWD}/cover/integration-test"
 
-	@go tool covdata textfmt -i=./cover/unit,./cover/integration -o cover.out
+	@go tool covdata textfmt -i=./cover/unit,./cover/integration-test,./cover/integration-cli -o cover.out
 
 	@echo "On a Mac, you can use the following command to open the coverage report in the browser\ngo tool cover -html=cover.out -o cover.html && open cover.html"
 

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -29,7 +29,10 @@ func createTenantCmd() *cobra.Command {
 		Use:   "tenant",
 		Short: "Create a new tenant",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := admin.NewClient(serverURL)
+			c, err := admin.NewClient(serverURL)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
 
 			resp, err := c.CreateTenant(cmd.Context(), admin.CreateTenantRequest{
 				Name:   name,

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -30,7 +30,10 @@ func getTenantCmd() *cobra.Command {
 		Short: "Get a tenant by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := admin.NewClient(serverURL)
+			c, err := admin.NewClient(serverURL)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
 
 			resp, err := c.GetTenant(cmd.Context(), admin.GetTenantRequest{
 				ID: args[0],
@@ -64,7 +67,10 @@ func getTenantsCmd() *cobra.Command {
 		Short: "Get tenants",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := admin.NewClient(serverURL)
+			c, err := admin.NewClient(serverURL)
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
 
 			resp, err := c.ListTenants(cmd.Context(), admin.ListTenantsRequest{})
 			if err != nil {

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -63,7 +63,7 @@ func setupCLI() ([]func(), error) {
 
 	binaryPath = filepath.Join(tmpDir, "kr")
 
-	coverDir = os.Getenv("GOCOVERDIR")
+	coverDir = os.Getenv("CLI_GOCOVERDIR")
 	buildArgs := []string{"build", "-o", binaryPath}
 	if coverDir != "" {
 		buildArgs = append(buildArgs, "-cover", "-covermode=atomic")

--- a/pkg/api/admin/client.go
+++ b/pkg/api/admin/client.go
@@ -9,22 +9,28 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openkcm/krypton/internal/krhttp"
 	"github.com/openkcm/krypton/pkg/api"
 )
 
-var ErrTenantNotFound = errors.New("tenant not found")
+var (
+	ErrTenantNotFound = errors.New("tenant not found")
+)
 
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL string
+	cli     *krhttp.Client
 }
 
 // NewClient creates a new Krypton admin API client.
-func NewClient(baseURL string) *Client {
-	return &Client{
-		baseURL:    baseURL,
-		httpClient: http.DefaultClient,
+func NewClient(baseURL string) (*Client, error) {
+	if baseURL == "" {
+		return nil, api.ErrBaseURLEmpty
 	}
+	return &Client{
+		baseURL: baseURL,
+		cli:     krhttp.NewClient(),
+	}, nil
 }
 
 func (c *Client) CreateTenant(ctx context.Context, req CreateTenantRequest) (CreateTenantResponse, error) {
@@ -39,7 +45,7 @@ func (c *Client) CreateTenant(ctx context.Context, req CreateTenantRequest) (Cre
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	httpResp, err := c.httpClient.Do(httpReq)
+	httpResp, err := c.cli.Do(httpReq)
 	if err != nil {
 		return CreateTenantResponse{}, fmt.Errorf("%w: %w", api.ErrFailedToSendRequest, err)
 	}
@@ -66,7 +72,7 @@ func (c *Client) GetTenant(ctx context.Context, req GetTenantRequest) (GetTenant
 		return GetTenantResponse{}, fmt.Errorf("%w: %w", api.ErrFailedToCreateRequest, err)
 	}
 
-	httpResp, err := c.httpClient.Do(httpReq)
+	httpResp, err := c.cli.Do(httpReq)
 	if err != nil {
 		return GetTenantResponse{}, fmt.Errorf("%w: %w", api.ErrFailedToSendRequest, err)
 	}
@@ -95,7 +101,7 @@ func (c *Client) ListTenants(ctx context.Context, _ ListTenantsRequest) (ListTen
 		return ListTenantsResponse{}, fmt.Errorf("%w: %w", api.ErrFailedToCreateRequest, err)
 	}
 
-	httpResp, err := c.httpClient.Do(httpReq)
+	httpResp, err := c.cli.Do(httpReq)
 	if err != nil {
 		return ListTenantsResponse{}, fmt.Errorf("%w: %w", api.ErrFailedToSendRequest, err)
 	}

--- a/pkg/api/admin/client_test.go
+++ b/pkg/api/admin/client_test.go
@@ -1,0 +1,198 @@
+package admin_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/pkg/api"
+	"github.com/openkcm/krypton/pkg/api/admin"
+)
+
+func TestClient(t *testing.T) {
+	t.Run("should return error if baseURL is empty", func(t *testing.T) {
+		// given when
+		subj, err := admin.NewClient("")
+
+		// then
+		assert.ErrorIs(t, err, api.ErrBaseURLEmpty)
+		assert.Nil(t, subj)
+	})
+}
+
+func TestCreateTenant_Errors(t *testing.T) {
+	t.Run("should return error if context is canceled", func(t *testing.T) {
+		// given
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		subj, err := admin.NewClient("http://example.com")
+		assert.NoError(t, err)
+
+		// when
+		resp, err := subj.CreateTenant(ctx, admin.CreateTenantRequest{})
+
+		// then
+		assert.ErrorIs(t, err, api.ErrFailedToSendRequest)
+		assert.Equal(t, admin.CreateTenantResponse{}, resp)
+	})
+
+	tts := []struct {
+		name     string
+		handler  http.HandlerFunc
+		expError error
+	}{
+		{
+			name: "should return error if server returns 5xx status code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expError: api.ErrUnexpectedStatusCode,
+		},
+		{
+			name: "should return error if server response cannot be decoded",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte("invalid json"))
+			},
+			expError: api.ErrFailedToDecodeResponse,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			srv := httptest.NewServer(tt.handler)
+			t.Cleanup(srv.Close)
+
+			subj, err := admin.NewClient(srv.URL)
+			assert.NoError(t, err)
+
+			// when
+			resp, err := subj.CreateTenant(t.Context(), admin.CreateTenantRequest{})
+
+			// then
+			assert.ErrorIs(t, err, tt.expError)
+			assert.Equal(t, admin.CreateTenantResponse{}, resp)
+		})
+	}
+}
+
+func TestGetTenant_Errors(t *testing.T) {
+	t.Run("should return error if context is canceled", func(t *testing.T) {
+		// given
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		subj, err := admin.NewClient("http://example.com")
+		assert.NoError(t, err)
+
+		// when
+		resp, err := subj.GetTenant(ctx, admin.GetTenantRequest{ID: "some-id"})
+
+		// then
+		assert.ErrorIs(t, err, api.ErrFailedToSendRequest)
+		assert.Equal(t, admin.GetTenantResponse{}, resp)
+	})
+
+	tts := []struct {
+		name     string
+		handler  http.HandlerFunc
+		expError error
+	}{
+		{
+			name: "should return error if server returns 5xx status code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expError: api.ErrUnexpectedStatusCode,
+		},
+		{
+			name: "should return error if server response cannot be decoded",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("invalid json"))
+			},
+			expError: api.ErrFailedToDecodeResponse,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			srv := httptest.NewServer(tt.handler)
+			t.Cleanup(srv.Close)
+
+			subj, err := admin.NewClient(srv.URL)
+			assert.NoError(t, err)
+
+			// when
+			resp, err := subj.GetTenant(t.Context(), admin.GetTenantRequest{ID: "some-id"})
+
+			// then
+			assert.ErrorIs(t, err, tt.expError)
+			assert.Equal(t, admin.GetTenantResponse{}, resp)
+		})
+	}
+}
+
+func TestListTenants_Errors(t *testing.T) {
+	t.Run("should return error if context is canceled", func(t *testing.T) {
+		// given
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		subj, err := admin.NewClient("http://example.com")
+		assert.NoError(t, err)
+
+		// when
+		resp, err := subj.ListTenants(ctx, admin.ListTenantsRequest{})
+
+		// then
+		assert.ErrorIs(t, err, api.ErrFailedToSendRequest)
+		assert.Equal(t, admin.ListTenantsResponse{}, resp)
+	})
+
+	tts := []struct {
+		name     string
+		handler  http.HandlerFunc
+		expError error
+	}{
+		{
+			name: "should return error if server returns 5xx status code",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expError: api.ErrUnexpectedStatusCode,
+		},
+		{
+			name: "should return error if server response cannot be decoded",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("invalid json"))
+			},
+			expError: api.ErrFailedToDecodeResponse,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			srv := httptest.NewServer(tt.handler)
+			t.Cleanup(srv.Close)
+
+			subj, err := admin.NewClient(srv.URL)
+			assert.NoError(t, err)
+
+			// when
+			resp, err := subj.ListTenants(t.Context(), admin.ListTenantsRequest{})
+
+			// then
+			assert.ErrorIs(t, err, tt.expError)
+			assert.Equal(t, admin.ListTenantsResponse{}, resp)
+		})
+	}
+}

--- a/pkg/api/agents/client.go
+++ b/pkg/api/agents/client.go
@@ -21,7 +21,6 @@ type Client struct {
 var (
 	ErrAgentNameEmpty = errors.New("agent name cannot be empty")
 	ErrAgentNotFound  = errors.New("agent not found in topology")
-	ErrBaseURLEmpty   = errors.New("base URL cannot be empty")
 )
 
 // NewClient creates a new Client with the given base URL and agent name.
@@ -30,7 +29,7 @@ func NewClient(baseURL, agentName string) (*Client, error) {
 		return nil, ErrAgentNameEmpty
 	}
 	if baseURL == "" {
-		return nil, ErrBaseURLEmpty
+		return nil, api.ErrBaseURLEmpty
 	}
 	return &Client{
 		baseURL:   baseURL,

--- a/pkg/api/agents/common_test.go
+++ b/pkg/api/agents/common_test.go
@@ -29,7 +29,7 @@ func TestClient(t *testing.T) {
 		subj, err := agents.NewClient("", "agent-aws")
 
 		// then
-		assert.ErrorIs(t, err, agents.ErrBaseURLEmpty)
+		assert.ErrorIs(t, err, api.ErrBaseURLEmpty)
 		assert.Nil(t, subj)
 	})
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,6 +3,7 @@ package api
 import "errors"
 
 var (
+	ErrBaseURLEmpty           = errors.New("base URL cannot be empty")
 	ErrFailedToEncodeRequest  = errors.New("failed to encode request")
 	ErrFailedToCreateRequest  = errors.New("failed to create request")
 	ErrFailedToSendRequest    = errors.New("failed to send request")


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
The kr HTTP client is now used for the admin client, consistent with the agent client. Additionally, the coverage report has been fixed to display the total coverage percentage.
