### PR TITLE
Feat/add simple worker

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,78 @@
+// Package worker provides a simple periodic task scheduler.
+package worker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// TaskFn is a function executed by a [Scheduler] on each tick.
+type TaskFn func(context.Context) error
+
+// Scheduler runs a [TaskFn] at a fixed interval until stopped via context cancellation or [Scheduler.Stop].
+// [Scheduler.Start] may only be called once; subsequent calls are no-ops.
+type Scheduler struct {
+	interval  time.Duration
+	task      TaskFn
+	isStarted atomic.Bool
+	stopOnce  sync.Once
+	done      chan struct{}
+}
+
+var (
+	ErrTaskFnNil       = errors.New("task function cannot be nil")
+	ErrInvalidInterval = errors.New("interval must be greater than zero")
+)
+
+// New creates a [Scheduler] that executes task every interval.
+// Returns an error if task is nil or interval is not positive.
+func New(interval time.Duration, task TaskFn) (*Scheduler, error) {
+	if task == nil {
+		return nil, ErrTaskFnNil
+	}
+	if interval <= 0 {
+		return nil, ErrInvalidInterval
+	}
+
+	return &Scheduler{
+		interval: interval,
+		task:     task,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Start blocks, running the task on each tick until ctx is cancelled or [Scheduler.Stop] is called.
+// Task errors are logged but do not stop the scheduler.
+func (w *Scheduler) Start(ctx context.Context) {
+	if !w.isStarted.CompareAndSwap(false, true) {
+		slog.Warn("Worker already started")
+		return
+	}
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := w.task(ctx); err != nil {
+				slog.Error("Worker task", slog.String("error", err.Error()))
+			}
+		case <-ctx.Done():
+			return
+		case <-w.done:
+			return
+		}
+	}
+}
+
+// Stop signals the scheduler to stop. It is safe to call multiple times.
+func (w *Scheduler) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.done)
+	})
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -30,17 +30,17 @@ var (
 
 // New creates a [Scheduler] that executes task every interval.
 // Returns an error if task is nil or interval is not positive.
-func New(interval time.Duration, task TaskFn) (*Scheduler, error) {
-	if task == nil {
+func New(d time.Duration, t TaskFn) (*Scheduler, error) {
+	if t == nil {
 		return nil, ErrTaskFnNil
 	}
-	if interval <= 0 {
+	if d <= 0 {
 		return nil, ErrInvalidInterval
 	}
 
 	return &Scheduler{
-		interval: interval,
-		task:     task,
+		interval: d,
+		task:     t,
 		done:     make(chan struct{}),
 	}, nil
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -13,7 +13,7 @@ import (
 // TaskFn is a function executed by a [Scheduler] on each tick.
 type TaskFn func(context.Context) error
 
-// Scheduler runs a [TaskFn] at a fixed interval until stopped via context cancellation or [Scheduler.Stop].
+// Scheduler runs a [TaskFn] at a fixed interval until stopped via context cancellation or [Scheduler.Kill].
 // [Scheduler.Start] may only be called once; subsequent calls are no-ops.
 type Scheduler struct {
 	interval  time.Duration
@@ -45,7 +45,7 @@ func New(d time.Duration, t TaskFn) (*Scheduler, error) {
 	}, nil
 }
 
-// Start blocks, running the task on each tick until ctx is cancelled or [Scheduler.Stop] is called.
+// Start blocks, running the task on each tick until ctx is cancelled or [Scheduler.Kill] is called.
 // Task errors are logged but do not stop the scheduler.
 func (w *Scheduler) Start(ctx context.Context) {
 	if !w.isStarted.CompareAndSwap(false, true) {
@@ -70,8 +70,8 @@ func (w *Scheduler) Start(ctx context.Context) {
 	}
 }
 
-// Stop signals the scheduler to stop. It is safe to call multiple times.
-func (w *Scheduler) Stop() {
+// Kill signals the scheduler to stop. It is safe to call multiple times.
+func (w *Scheduler) Kill() {
 	w.stopOnce.Do(func() {
 		close(w.done)
 	})

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -183,8 +183,8 @@ func TestStart(t *testing.T) {
 	})
 }
 
-func TestStop(t *testing.T) {
-	t.Run("should stop executing the task function when Stop is called", func(t *testing.T) {
+func TestKill(t *testing.T) {
+	t.Run("should kill executing the task function when Kill is called", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			// given
 			ctx := t.Context()
@@ -206,8 +206,8 @@ func TestStop(t *testing.T) {
 
 			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
 			synctest.Wait()
-			subj.Stop()
-			time.Sleep(11 * time.Second) // wait to ensure no more executions after Stop is called
+			subj.Kill()
+			time.Sleep(11 * time.Second) // wait to ensure no more executions after Kill is called
 			synctest.Wait()
 
 			// then
@@ -215,7 +215,7 @@ func TestStop(t *testing.T) {
 		})
 	})
 
-	t.Run("should be safe to call Stop multiple times", func(t *testing.T) {
+	t.Run("should be safe to call Kill multiple times", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			// given
 			ctx := t.Context()
@@ -237,10 +237,10 @@ func TestStop(t *testing.T) {
 
 			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
 			synctest.Wait()
-			// call Stop multiple times
-			subj.Stop()
-			subj.Stop()
-			time.Sleep(11 * time.Second) // wait to ensure no more executions after Stop is called
+			// call Kill multiple times
+			subj.Kill()
+			subj.Kill()
+			time.Sleep(11 * time.Second) // wait to ensure no more executions after Kill is called
 			synctest.Wait()
 
 			// then

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,250 @@
+package worker_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/internal/worker"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("should return an error if the task function is nil", func(t *testing.T) {
+		// given when
+		_, err := worker.New(1*time.Second, nil)
+
+		// then
+		assert.ErrorIs(t, err, worker.ErrTaskFnNil)
+	})
+
+	t.Run("should return a Scheduler instance if the task function is not nil", func(t *testing.T) {
+		// given
+		taskFn := func(_ context.Context) error {
+			return nil
+		}
+
+		// when
+		subj, err := worker.New(1*time.Second, taskFn)
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, subj)
+	})
+
+	t.Run("should return error if scheduler interval is", func(t *testing.T) {
+		// given
+		tts := []struct {
+			name     string
+			interval time.Duration
+		}{
+			{
+				name:     "negative",
+				interval: -1 * time.Second,
+			},
+			{
+				name:     "zero",
+				interval: 0,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				taskFn := func(_ context.Context) error {
+					return nil
+				}
+
+				// when
+				subj, err := worker.New(tt.interval, taskFn)
+
+				// then
+				assert.ErrorIs(t, err, worker.ErrInvalidInterval)
+				assert.Nil(t, subj)
+			})
+		}
+	})
+}
+
+func TestStart(t *testing.T) {
+	t.Run("should execute the task function at the specified schedule", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// given
+			ctx := t.Context()
+			var actExecutedTimes atomic.Int32
+
+			taskFn := func(_ context.Context) error {
+				actExecutedTimes.Add(1)
+				return nil
+			}
+
+			subj, err := worker.New(5*time.Second, taskFn)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// when
+			go subj.Start(ctx)
+
+			// then
+			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
+			synctest.Wait()
+
+			assert.Equal(t, int32(2), actExecutedTimes.Load())
+		})
+	})
+
+	t.Run("should stop executing the task function when the context is canceled", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// given
+			ctx := t.Context()
+			ctx, cancel := context.WithCancel(ctx)
+
+			var actExecutedTimes atomic.Int32
+			taskFn := func(_ context.Context) error {
+				actExecutedTimes.Add(1)
+				cancel()
+				return nil
+			}
+
+			subj, err := worker.New(5*time.Second, taskFn)
+			assert.NoError(t, err)
+
+			// when
+			go subj.Start(ctx)
+
+			// then
+			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
+			synctest.Wait()
+
+			assert.Equal(t, int32(1), actExecutedTimes.Load())
+		})
+	})
+
+	t.Run("should execute the task function at the specified schedule even after taskFn returns an error", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// given
+			ctx := t.Context()
+			var actExecutedTimes atomic.Int32
+
+			taskFn := func(_ context.Context) error {
+				actExecutedTimes.Add(1)
+				return assert.AnError
+			}
+
+			subj, err := worker.New(5*time.Second, taskFn)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// when
+			go subj.Start(ctx)
+
+			// then
+			time.Sleep(11 * time.Second)
+			synctest.Wait()
+
+			assert.Equal(t, int32(2), actExecutedTimes.Load())
+		})
+	})
+
+	t.Run("should start only once if Start is called multiple times", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// given
+			ctx := t.Context()
+
+			var actCalled atomic.Int32
+			taskFn := func(_ context.Context) error {
+				actCalled.Add(1)
+				return nil
+			}
+
+			subj, err := worker.New(5*time.Second, taskFn)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// when
+			go subj.Start(ctx)
+			go subj.Start(ctx)
+
+			time.Sleep(11 * time.Second)
+			synctest.Wait()
+
+			// then
+			assert.Equal(t, int32(2), actCalled.Load())
+		})
+	})
+}
+
+func TestStop(t *testing.T) {
+	t.Run("should stop executing the task function when Stop is called", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// given
+			ctx := t.Context()
+			var actExecutedTimes atomic.Int32
+
+			taskFn := func(_ context.Context) error {
+				actExecutedTimes.Add(1)
+				return nil
+			}
+
+			subj, err := worker.New(5*time.Second, taskFn)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// when
+			go subj.Start(ctx)
+
+			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
+			synctest.Wait()
+			subj.Stop()
+			time.Sleep(11 * time.Second) // wait to ensure no more executions after Stop is called
+			synctest.Wait()
+
+			// then
+			assert.Equal(t, int32(2), actExecutedTimes.Load())
+		})
+	})
+
+	t.Run("should be safe to call Stop multiple times", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// given
+			ctx := t.Context()
+			var actExecutedTimes atomic.Int32
+
+			taskFn := func(_ context.Context) error {
+				actExecutedTimes.Add(1)
+				return nil
+			}
+
+			subj, err := worker.New(5*time.Second, taskFn)
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// when
+			go subj.Start(ctx)
+
+			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
+			synctest.Wait()
+			// call Stop multiple times
+			subj.Stop()
+			subj.Stop()
+			time.Sleep(11 * time.Second) // wait to ensure no more executions after Stop is called
+			synctest.Wait()
+
+			// then
+			assert.Equal(t, int32(2), actExecutedTimes.Load())
+		})
+	})
+}


### PR DESCRIPTION
Add worker scheduler with a Stop method for explicit shutdown,
pass context to task functions, ensure Start is only effective once,
and validate that the interval is positive. 

Shall we add a Name for the Scheduler.