### PR TITLE
feat: CLI output select method

### DIFF
--- a/cli/output/output.go
+++ b/cli/output/output.go
@@ -10,8 +10,12 @@ import (
 	"text/tabwriter"
 )
 
-// ErrUnsupportedType is returned when the input is not a struct or slice of structs.
-var ErrUnsupportedType = errors.New("unsupported type for parsing")
+var (
+	// ErrUnsupportedType is returned when the input is not a struct or slice of structs.
+	ErrUnsupportedType = errors.New("unsupported type for parsing")
+	// ErrNoRows is returned when there are no rows to select from.
+	ErrNoRows = errors.New("no rows to select from")
+)
 
 // Format specifies the output format for rendering.
 type Format int
@@ -25,22 +29,26 @@ const (
 // and true if it applied, or nil and false if it doesn't apply.
 type Formatter func(name string, value any) (any, bool)
 
+// Selector is a function that handles interactive selection from rows.
+// Returns the selected index or -1 and an error if selection is cancelled or fails.
+type Selector func(rows Rows) (int, error)
+
 // Builder constructs formatted output from structured data.
 type Builder struct {
-	grid       *grid
+	rows       Rows
 	format     Format
 	formatters []Formatter
 }
 
 // From parses a struct or slice of structs into a Builder for rendering.
 func From(v any) (*Builder, error) {
-	g, err := parse(v)
+	rows, err := parse(v)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Builder{
-		grid:   g,
+		rows:   rows,
 		format: Tabular,
 	}, nil
 }
@@ -83,31 +91,28 @@ func (b *Builder) To(w io.Writer) error {
 
 	switch b.format {
 	case JSON:
-		return renderJSON(w, b.grid)
+		return b.renderJSON(w)
 	default:
-		return renderTabular(w, b.grid)
+		return b.renderTabular(w)
 	}
 }
 
-type cell struct {
-	name  string
-	value any
+// Select uses the provided selector to let the user choose a row.
+// Returns ErrNoRows if there are no rows.
+func (b *Builder) Select(sel Selector) (int, error) {
+	if len(b.rows) == 0 {
+		return -1, ErrNoRows
+	}
+
+	b.applyFormatters()
+	return sel(b.rows)
 }
 
-type row []*cell
-
-// grid represents structured data as rows.
-// Each row consists of cells, where each cell represents a field of a struct (name and value).
-// A single struct becomes one row; a slice of structs becomes multiple rows.
-type grid struct {
-	rows []row
-}
-
-func parse(v any) (*grid, error) {
+func parse(v any) (Rows, error) {
 	val := unwrap(reflect.ValueOf(v))
 
 	if !val.IsValid() {
-		return &grid{}, nil
+		return Rows{}, nil
 	}
 
 	switch val.Kind() {
@@ -127,15 +132,13 @@ func unwrap(val reflect.Value) reflect.Value {
 	return val
 }
 
-func parseStruct(val reflect.Value) *grid {
-	return &grid{
-		rows: []row{parseRow(val)},
-	}
+func parseStruct(val reflect.Value) Rows {
+	return Rows{parseRow(val)}
 }
 
-func parseSlice(val reflect.Value) (*grid, error) {
+func parseSlice(val reflect.Value) (Rows, error) {
 	if val.Len() == 0 {
-		return &grid{}, nil
+		return Rows{}, nil
 	}
 
 	first := unwrap(val.Index(0))
@@ -143,69 +146,65 @@ func parseSlice(val reflect.Value) (*grid, error) {
 		return nil, ErrUnsupportedType
 	}
 
-	rows := make([]row, val.Len())
+	rows := make(Rows, val.Len())
 	for i := range val.Len() {
 		item := unwrap(val.Index(i))
 		rows[i] = parseRow(item)
 	}
 
-	return &grid{rows: rows}, nil
+	return rows, nil
 }
 
-func parseRow(structVal reflect.Value) row {
-	r := make(row, structVal.NumField())
+func parseRow(structVal reflect.Value) Row {
+	r := make(Row, structVal.NumField())
 	for i := range structVal.NumField() {
-		r[i] = &cell{
-			name:  structVal.Type().Field(i).Name,
-			value: structVal.Field(i).Interface(),
+		r[i] = Cell{
+			Name:  structVal.Type().Field(i).Name,
+			Value: structVal.Field(i).Interface(),
 		}
 	}
 	return r
 }
 
 func (b *Builder) applyFormatters() {
-	for _, r := range b.grid.rows {
-		for _, c := range r {
+	for i := range b.rows {
+		for j := range b.rows[i] {
 			for _, formatter := range b.formatters {
-				if value, ok := formatter(c.name, c.value); ok {
-					c.value = value
+				if value, ok := formatter(b.rows[i][j].Name, b.rows[i][j].Value); ok {
+					b.rows[i][j].Value = value
 				}
 			}
 		}
 	}
 }
 
-func renderTabular(w io.Writer, g *grid) error {
-	if len(g.rows) == 0 {
+func (b *Builder) renderTabular(w io.Writer) error {
+	if len(b.rows) == 0 {
 		return nil
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 
-	headers := make([]string, len(g.rows[0]))
-	for i, c := range g.rows[0] {
-		headers[i] = c.name
+	headers := make([]string, len(b.rows[0]))
+	for i, c := range b.rows[0] {
+		headers[i] = c.Name
 	}
 	fmt.Fprintln(tw, strings.Join(headers, "\t"))
 
-	for _, r := range g.rows {
-		values := make([]string, len(r))
-		for i, c := range r {
-			values[i] = fmt.Sprintf("%v", c.value)
-		}
-		fmt.Fprintln(tw, strings.Join(values, "\t"))
+	for _, line := range b.rows.Tabular() {
+		fmt.Fprintln(tw, line)
 	}
 
 	return tw.Flush()
 }
 
-func renderJSON(w io.Writer, g *grid) error {
-	rows := make([]map[string]any, len(g.rows))
+func (b *Builder) renderJSON(w io.Writer) error {
+	rows := make([]map[string]any, len(b.rows))
 
-	for i, r := range g.rows {
+	for i, r := range b.rows {
 		obj := make(map[string]any)
 		for _, c := range r {
-			obj[c.name] = c.value
+			obj[c.Name] = c.Value
 		}
 		rows[i] = obj
 	}

--- a/cli/output/output_test.go
+++ b/cli/output/output_test.go
@@ -565,3 +565,83 @@ func TestBuilder_Chaining(t *testing.T) {
 		assert.EqualValues(t, 100, got[0]["Age"])
 	})
 }
+
+func TestSelect_ErrNoRows(t *testing.T) {
+	// given
+	builder, err := output.From([]Person{})
+	assert.NoError(t, err)
+
+	mockSel := func(rows output.Rows) (int, error) {
+		return 0, nil
+	}
+
+	// when
+	idx, err := builder.Select(mockSel)
+
+	// then
+	assert.ErrorIs(t, err, output.ErrNoRows)
+	assert.Equal(t, -1, idx)
+}
+
+func TestSelect_CallsSelector(t *testing.T) {
+	// given
+	builder, err := output.From([]Person{{Name: "alice"}, {Name: "bob"}})
+	assert.NoError(t, err)
+
+	var capturedRows output.Rows
+	mockSel := func(rows output.Rows) (int, error) {
+		capturedRows = rows
+		return 1, nil
+	}
+
+	// when
+	idx, err := builder.Select(mockSel)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, 1, idx)
+	assert.Len(t, capturedRows, 2)
+	assert.Equal(t, "alice", capturedRows[0][0].Value)
+	assert.Equal(t, "bob", capturedRows[1][0].Value)
+}
+
+func TestSelect_PropagatesSelectorError(t *testing.T) {
+	// given
+	builder, err := output.From(Person{Name: "alice"})
+	assert.NoError(t, err)
+
+	mockSel := func(rows output.Rows) (int, error) {
+		return -1, assert.AnError
+	}
+
+	// when
+	idx, err := builder.Select(mockSel)
+
+	// then
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, -1, idx)
+}
+
+func TestSelect_AppliesFormatters(t *testing.T) {
+	// given
+	builder, err := output.From(Person{Name: "alice"})
+	assert.NoError(t, err)
+
+	builder.Format(output.ForName("Name", func(v any) any {
+		s, _ := v.(string)
+		return s + "!"
+	}))
+
+	var capturedRows output.Rows
+	mockSel := func(rows output.Rows) (int, error) {
+		capturedRows = rows
+		return 0, nil
+	}
+
+	// when
+	_, err = builder.Select(mockSel)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, "alice!", capturedRows[0][0].Value)
+}

--- a/cli/output/types.go
+++ b/cli/output/types.go
@@ -1,0 +1,31 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Cell represents a single field in a row.
+type Cell struct {
+	Name  string
+	Value any
+}
+
+// Row is a slice of cells representing a single record.
+type Row []Cell
+
+// Rows is a slice of rows.
+type Rows []Row
+
+// Tabular returns each row as a tab-separated string.
+func (r Rows) Tabular() []string {
+	result := make([]string, len(r))
+	for i, row := range r {
+		values := make([]string, len(row))
+		for j, c := range row {
+			values[j] = fmt.Sprintf("%v", c.Value)
+		}
+		result[i] = strings.Join(values, "\t")
+	}
+	return result
+}

--- a/cli/output/types_test.go
+++ b/cli/output/types_test.go
@@ -1,0 +1,57 @@
+package output_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/cli/output"
+)
+
+func TestRows_Tabular(t *testing.T) {
+	tests := []struct {
+		name     string
+		rows     output.Rows
+		expected []string
+	}{
+		{
+			name: "single row all fields",
+			rows: output.Rows{
+				{{Name: "ID", Value: "123"}, {Name: "Name", Value: "alice"}},
+			},
+			expected: []string{"123\talice"},
+		},
+		{
+			name: "multiple rows all fields",
+			rows: output.Rows{
+				{{Name: "ID", Value: "1"}, {Name: "Name", Value: "alice"}},
+				{{Name: "ID", Value: "2"}, {Name: "Name", Value: "bob"}},
+			},
+			expected: []string{"1\talice", "2\tbob"},
+		},
+		{
+			name: "single cell",
+			rows: output.Rows{
+				{{Name: "Name", Value: "alice"}},
+			},
+			expected: []string{"alice"},
+		},
+		{
+			name: "handles various types",
+			rows: output.Rows{
+				{{Name: "String", Value: "hello"}, {Name: "Int", Value: 42}, {Name: "Bool", Value: true}},
+			},
+			expected: []string{"hello\t42\ttrue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			result := tt.rows.Tabular()
+
+			// then
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   CLI output select method

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
This adds a select method to the CLI output builder. The provided function receives `output.Rows` and returns an index.
