### PR TITLE
add key hierarchy and topology cross validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,14 @@ func (cfg *RootConfig) Validate() error {
 	if len(cfg.KeyBindings) == 0 {
 		return ErrConfigKeyBindingsEmpty
 	}
+
+	if err := spec.ValidateRootSegment(cfg.Hierarchy, cfg.Segment, cfg.KeyBindings); err != nil {
+		return fmt.Errorf("root segment: %w", err)
+	}
+	if err := spec.ValidateTopologyAgainstHierarchy(cfg.Hierarchy, cfg.Topology, cfg.Segment, cfg.KeyBindings); err != nil {
+		return fmt.Errorf("topology: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,10 @@ func validRootConfig() *RootConfig {
 			"K0": {
 				Vault: spec.VaultSpec{Name: "v", Type: "aws-kms"},
 			},
+			"K1": {
+				Vault:             spec.VaultSpec{Name: "v2", Type: "open-bao"},
+				ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"},
+			},
 		},
 		Hierarchy: spec.KeyHierarchy{
 			Name: "h",
@@ -119,6 +123,108 @@ func TestValidateRootConfig(t *testing.T) {
 			modify:  func(c *RootConfig) { c.Topology = spec.Topology{} },
 			wantErr: nil,
 		},
+		{
+			name: "cross-validation: root start not hierarchy first key",
+			modify: func(c *RootConfig) {
+				c.Hierarchy = spec.KeyHierarchy{
+					Name: "h",
+					KeySpecs: []spec.KeySpec{
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+					},
+				}
+				c.Segment = spec.HierarchySegment{StartKind: "K1", EndKind: "K2"}
+				c.KeyBindings = map[string]spec.KeyBinding{
+					"K1": {Vault: spec.VaultSpec{Name: "v", Type: "t"}},
+					"K2": {Vault: spec.VaultSpec{Name: "v2", Type: "t"}},
+				}
+				c.Topology = spec.Topology{}
+			},
+			wantErr: spec.ErrRootSegmentStartNotFirst,
+		},
+		{
+			name: "cross-validation: root end kind is tek",
+			modify: func(c *RootConfig) {
+				c.Hierarchy = spec.KeyHierarchy{
+					Name: "h",
+					KeySpecs: []spec.KeySpec{
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K1", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+					},
+				}
+				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
+				c.KeyBindings = map[string]spec.KeyBinding{
+					"K0": {Vault: spec.VaultSpec{Name: "v", Type: "t"}},
+					"K1": {Vault: spec.VaultSpec{Name: "v2", Type: "t"}},
+				}
+				c.Topology = spec.Topology{}
+			},
+			wantErr: spec.ErrRootSegmentEndIsTek,
+		},
+		{
+			name: "cross-validation: agent start not tek",
+			modify: func(c *RootConfig) {
+				c.Hierarchy = spec.KeyHierarchy{
+					Name: "h",
+					KeySpecs: []spec.KeySpec{
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+					},
+				}
+				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
+				c.KeyBindings = map[string]spec.KeyBinding{
+					"K0": {Vault: spec.VaultSpec{Name: "v", Type: "t"}},
+					"K1": {Vault: spec.VaultSpec{Name: "v2", Type: "t"}, ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				}
+				c.Topology = spec.Topology{
+					Segments: []spec.TopologySegment{
+						{
+							Name:    "agent-bad",
+							Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K2"}, // K2 is dek, not tek
+							KeyBindings: map[string]spec.KeyBinding{
+								"K2": {Vault: spec.VaultSpec{Name: "v", Type: "t"}, ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							},
+						},
+					},
+				}
+			},
+			wantErr: spec.ErrAgentSegmentStartNotTek,
+		},
+		{
+			name: "cross-validation: valid full config with topology",
+			modify: func(c *RootConfig) {
+				c.Hierarchy = spec.KeyHierarchy{
+					Name: "h",
+					KeySpecs: []spec.KeySpec{
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
+						{Kind: "K3", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+					},
+				}
+				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
+				c.KeyBindings = map[string]spec.KeyBinding{
+					"K0": {Vault: spec.VaultSpec{Name: "v", Type: "t"}},
+					"K1": {Vault: spec.VaultSpec{Name: "v2", Type: "t"}, ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				}
+				c.Topology = spec.Topology{
+					Segments: []spec.TopologySegment{
+						{
+							Name:    "agent-aws",
+							Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
+							KeyBindings: map[string]spec.KeyBinding{
+								"K2": {Vault: spec.VaultSpec{Name: "v", Type: "t"}, ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+								"K3": {Vault: spec.VaultSpec{Name: "v2", Type: "t"}},
+							},
+						},
+					},
+				}
+			},
+			wantErr: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -208,6 +314,9 @@ hierarchy:
       role: "kek"
       algorithm: "AES256"
     - kind: "K2"
+      role: "tek"
+      algorithm: "AES256"
+    - kind: "K3"
       role: "dek"
       algorithm: "AES256"
 topology:
@@ -215,7 +324,7 @@ topology:
     - name: "agent-aws"
       segment:
         start_kind: "K2"
-        end_kind: "K2"
+        end_kind: "K3"
       key_bindings:
         K2:
           vault:
@@ -223,6 +332,10 @@ topology:
             type: "aws-kms"
           parent_key_provider:
             agent_name: "root"
+        K3:
+          vault:
+            name: "aws-dek-vault"
+            type: "aws-kms"
       labels:
         cloud: "aws"
 `
@@ -249,7 +362,7 @@ topology:
 				assert.Equal(t, "root-vault", cfg.KeyBindings["K1"].Vault.Name)
 				assert.Equal(t, "root", cfg.KeyBindings["K1"].ParentKeyProvider.AgentName)
 				assert.Equal(t, "production-hierarchy", cfg.Hierarchy.Name)
-				assert.Len(t, cfg.Hierarchy.KeySpecs, 3)
+				assert.Len(t, cfg.Hierarchy.KeySpecs, 4)
 				assert.Equal(t, spec.KeyKind("K0"), cfg.Hierarchy.KeySpecs[0].Kind)
 				assert.Len(t, cfg.Topology.Segments, 1)
 				assert.Equal(t, "agent-aws", cfg.Topology.Segments[0].Name)

--- a/internal/spec/hierarchy_validation.go
+++ b/internal/spec/hierarchy_validation.go
@@ -27,15 +27,14 @@ var (
 	ErrParentKeyProviderKeyNotInParentSegment = errors.New("parent key provider's segment does not contain the parent key kind")
 )
 
-// ValidateSegmentAgainstHierarchy checks that a segment's endpoints exist in the hierarchy are in the correct order,
-// and that bindings cover exactly the segment range.
+// ValidateSegmentAgainstHierarchy checks that a segment's endpoints exist in the hierarchy are in the correct order, and that bindings cover exactly the segment range.
 func ValidateSegmentAgainstHierarchy(h KeyHierarchy, seg HierarchySegment, bindings map[string]KeyBinding) error {
-	startIdx, ok := h.IndexOf(KeyKind(seg.StartKind))
-	if !ok {
+	startIdx := h.IndexOf(KeyKind(seg.StartKind))
+	if startIdx < 0 {
 		return fmt.Errorf("%w: %q", ErrSegmentStartKindNotInHierarchy, seg.StartKind)
 	}
-	endIdx, ok := h.IndexOf(KeyKind(seg.EndKind))
-	if !ok {
+	endIdx := h.IndexOf(KeyKind(seg.EndKind))
+	if endIdx < 0 {
 		return fmt.Errorf("%w: %q", ErrSegmentEndKindNotInHierarchy, seg.EndKind)
 	}
 	if startIdx > endIdx {
@@ -62,14 +61,13 @@ func ValidateSegmentAgainstHierarchy(h KeyHierarchy, seg HierarchySegment, bindi
 	return nil
 }
 
-// ValidateRootSegment validates the root's segment against the hierarchy,
-// enforcing root-specific constraints.
+// ValidateRootSegment validates the root's segment against the hierarchy, enforcing root-specific constraints.
 func ValidateRootSegment(h KeyHierarchy, seg HierarchySegment, bindings map[string]KeyBinding) error {
 	if err := ValidateSegmentAgainstHierarchy(h, seg, bindings); err != nil {
 		return err
 	}
 
-	startIdx, _ := h.IndexOf(KeyKind(seg.StartKind))
+	startIdx := h.IndexOf(KeyKind(seg.StartKind))
 	if startIdx != 0 {
 		return ErrRootSegmentStartNotFirst
 	}
@@ -126,24 +124,24 @@ func ValidateAgentSegment(h KeyHierarchy, seg HierarchySegment, bindings map[str
 
 // ValidateTopologyAgainstHierarchy validates the entire topology against the hierarchy checking agent segment rules,
 // name uniqueness, and parent key provider resolution.
-func ValidateTopologyAgainstHierarchy(h KeyHierarchy, topology Topology, rootSeg HierarchySegment, rootBindings map[string]KeyBinding) error {
-	segmentMap := make(map[string]TopologySegment, len(topology.Segments))
-	for _, seg := range topology.Segments {
-		if _, exists := segmentMap[seg.Name]; exists {
+func ValidateTopologyAgainstHierarchy(h KeyHierarchy, t Topology, rootSeg HierarchySegment, rootBindings map[string]KeyBinding) error {
+	uniqSegs := make(map[string]struct{}, len(t.Segments))
+	for _, seg := range t.Segments {
+		if _, exists := uniqSegs[seg.Name]; exists {
 			return fmt.Errorf("%w: %q", ErrTopologyDuplicateSegmentName, seg.Name)
 		}
-		segmentMap[seg.Name] = seg
+		uniqSegs[seg.Name] = struct{}{}
 	}
 
-	for i, seg := range topology.Segments {
+	for i, seg := range t.Segments {
 		if err := ValidateAgentSegment(h, seg.Segment, seg.KeyBindings); err != nil {
 			return fmt.Errorf("segment %q (index %d): %w", seg.Name, i, err)
 		}
 	}
 
-	providers := make(map[string]HierarchySegment, len(topology.Segments)+1)
+	providers := make(map[string]HierarchySegment, len(t.Segments)+1)
 	providers["root"] = rootSeg
-	for _, seg := range topology.Segments {
+	for _, seg := range t.Segments {
 		providers[seg.Name] = seg.Segment
 	}
 
@@ -151,7 +149,7 @@ func ValidateTopologyAgainstHierarchy(h KeyHierarchy, topology Topology, rootSeg
 		return fmt.Errorf("root bindings: %w", err)
 	}
 
-	for _, seg := range topology.Segments {
+	for _, seg := range t.Segments {
 		if err := validateBindingsParentProviders(h, seg.KeyBindings, seg.Segment, providers); err != nil {
 			return fmt.Errorf("segment %q: %w", seg.Name, err)
 		}
@@ -160,8 +158,7 @@ func ValidateTopologyAgainstHierarchy(h KeyHierarchy, topology Topology, rootSeg
 	return nil
 }
 
-// validateBindingsParentProviders checks that all ParentKeyProvider references in a set of bindings
-// resolve to known providers and that the parent key falls within the provider's segment.
+// validateBindingsParentProviders checks that all ParentKeyProvider references in a set of bindings resolve to known providers and that the parent key falls within the provider's segment.
 func validateBindingsParentProviders(h KeyHierarchy, bindings map[string]KeyBinding, ownerSeg HierarchySegment, providers map[string]HierarchySegment) error {
 	for kind, binding := range bindings {
 		if binding.ParentKeyProvider == nil {
@@ -173,16 +170,16 @@ func validateBindingsParentProviders(h KeyHierarchy, bindings map[string]KeyBind
 			return fmt.Errorf("%w: %q (referenced by key kind %q)", ErrParentKeyProviderNotResolvable, providerName, kind)
 		}
 
-		kindIdx, ok := h.IndexOf(KeyKind(kind))
-		if !ok || kindIdx == 0 {
+		kindIdx := h.IndexOf(KeyKind(kind))
+		if kindIdx <= 0 {
 			continue
 		}
 
 		parentKind := h.KeySpecs[kindIdx-1].Kind
-		parentIdx, _ := h.IndexOf(parentKind)
-		providerStartIdx, providerStartOk := h.IndexOf(KeyKind(providerSeg.StartKind))
-		providerEndIdx, providerEndOk := h.IndexOf(KeyKind(providerSeg.EndKind))
-		if providerStartOk && providerEndOk {
+		parentIdx := h.IndexOf(parentKind)
+		providerStartIdx := h.IndexOf(KeyKind(providerSeg.StartKind))
+		providerEndIdx := h.IndexOf(KeyKind(providerSeg.EndKind))
+		if providerStartIdx >= 0 && providerEndIdx >= 0 {
 			if parentIdx < providerStartIdx || parentIdx > providerEndIdx {
 				return fmt.Errorf("%w: parent key kind %q not in segment %q (%s→%s)",
 					ErrParentKeyProviderKeyNotInParentSegment, parentKind, providerName, providerSeg.StartKind, providerSeg.EndKind)

--- a/internal/spec/hierarchy_validation.go
+++ b/internal/spec/hierarchy_validation.go
@@ -1,0 +1,193 @@
+package spec
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrSegmentStartKindNotInHierarchy = errors.New("segment start kind not found in hierarchy")
+	ErrSegmentEndKindNotInHierarchy   = errors.New("segment end kind not found in hierarchy")
+	ErrSegmentStartAfterEnd           = errors.New("segment start kind must not come after end kind in hierarchy")
+	ErrSegmentBindingsMissing         = errors.New("key binding missing for key kind in segment range")
+	ErrSegmentBindingsExtra           = errors.New("key binding found for key kind outside segment range")
+
+	ErrRootSegmentStartNotFirst        = errors.New("root segment must start at hierarchy's first key")
+	ErrRootSegmentEndIsTek             = errors.New("root segment end kind must not have role tek")
+	ErrRootBindingHasParentKeyProvider = errors.New("root key binding must not have a parent key provider")
+
+	ErrAgentSegmentStartNotTek                   = errors.New("agent segment must start with a tek role key")
+	ErrAgentSegmentEndIsTek                      = errors.New("agent segment end kind must not have role tek unless single-key segment")
+	ErrAgentSegmentEndIsRoot                     = errors.New("agent segment end kind must not have role root")
+	ErrAgentSegmentContainsRoot                  = errors.New("agent segment must not contain the root role key")
+	ErrAgentSegmentStartMissingParentKeyProvider = errors.New("agent segment tek start key must have a parent key provider")
+
+	ErrTopologyDuplicateSegmentName           = errors.New("duplicate topology segment name")
+	ErrParentKeyProviderNotResolvable         = errors.New("parent key provider agent name does not resolve to root or any topology segment")
+	ErrParentKeyProviderKeyNotInParentSegment = errors.New("parent key provider's segment does not contain the parent key kind")
+)
+
+// ValidateSegmentAgainstHierarchy checks that a segment's endpoints exist in the hierarchy are in the correct order,
+// and that bindings cover exactly the segment range.
+func ValidateSegmentAgainstHierarchy(h KeyHierarchy, seg HierarchySegment, bindings map[string]KeyBinding) error {
+	startIdx, ok := h.IndexOf(KeyKind(seg.StartKind))
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSegmentStartKindNotInHierarchy, seg.StartKind)
+	}
+	endIdx, ok := h.IndexOf(KeyKind(seg.EndKind))
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSegmentEndKindNotInHierarchy, seg.EndKind)
+	}
+	if startIdx > endIdx {
+		return ErrSegmentStartAfterEnd
+	}
+
+	kindsInRange := h.KeySpecs[startIdx : endIdx+1]
+
+	rangeSet := make(map[string]struct{}, len(kindsInRange))
+	for _, ks := range kindsInRange {
+		kind := string(ks.Kind)
+		rangeSet[kind] = struct{}{}
+		if _, exists := bindings[kind]; !exists {
+			return fmt.Errorf("%w: %q", ErrSegmentBindingsMissing, kind)
+		}
+	}
+
+	for kind := range bindings {
+		if _, inRange := rangeSet[kind]; !inRange {
+			return fmt.Errorf("%w: %q", ErrSegmentBindingsExtra, kind)
+		}
+	}
+
+	return nil
+}
+
+// ValidateRootSegment validates the root's segment against the hierarchy,
+// enforcing root-specific constraints.
+func ValidateRootSegment(h KeyHierarchy, seg HierarchySegment, bindings map[string]KeyBinding) error {
+	if err := ValidateSegmentAgainstHierarchy(h, seg, bindings); err != nil {
+		return err
+	}
+
+	startIdx, _ := h.IndexOf(KeyKind(seg.StartKind))
+	if startIdx != 0 {
+		return ErrRootSegmentStartNotFirst
+	}
+
+	endSpec, _ := h.FindKeySpec(KeyKind(seg.EndKind))
+	if endSpec.Role == KeyRoleTek {
+		return ErrRootSegmentEndIsTek
+	}
+
+	rootBinding, exists := bindings[seg.StartKind]
+	if exists && rootBinding.ParentKeyProvider != nil {
+		return ErrRootBindingHasParentKeyProvider
+	}
+
+	return nil
+}
+
+// ValidateAgentSegment validates an agent's topology segment against the hierarchy enforcing agent-specific constraints.
+func ValidateAgentSegment(h KeyHierarchy, seg HierarchySegment, bindings map[string]KeyBinding) error {
+	if err := ValidateSegmentAgainstHierarchy(h, seg, bindings); err != nil {
+		return err
+	}
+
+	startSpec, _ := h.FindKeySpec(KeyKind(seg.StartKind))
+	if startSpec.Role != KeyRoleTek {
+		return ErrAgentSegmentStartNotTek
+	}
+
+	isSingleKey := seg.StartKind == seg.EndKind
+	if !isSingleKey {
+		endSpec, _ := h.FindKeySpec(KeyKind(seg.EndKind))
+		if endSpec.Role == KeyRoleRoot {
+			return ErrAgentSegmentEndIsRoot
+		}
+		if endSpec.Role == KeyRoleTek {
+			return ErrAgentSegmentEndIsTek
+		}
+	}
+
+	kindsInRange, _ := h.KindsBetween(KeyKind(seg.StartKind), KeyKind(seg.EndKind))
+	for _, ks := range kindsInRange {
+		if ks.Role == KeyRoleRoot {
+			return ErrAgentSegmentContainsRoot
+		}
+	}
+
+	startBinding, exists := bindings[seg.StartKind]
+	if !exists || startBinding.ParentKeyProvider == nil {
+		return ErrAgentSegmentStartMissingParentKeyProvider
+	}
+
+	return nil
+}
+
+// ValidateTopologyAgainstHierarchy validates the entire topology against the hierarchy checking agent segment rules,
+// name uniqueness, and parent key provider resolution.
+func ValidateTopologyAgainstHierarchy(h KeyHierarchy, topology Topology, rootSeg HierarchySegment, rootBindings map[string]KeyBinding) error {
+	segmentMap := make(map[string]TopologySegment, len(topology.Segments))
+	for _, seg := range topology.Segments {
+		if _, exists := segmentMap[seg.Name]; exists {
+			return fmt.Errorf("%w: %q", ErrTopologyDuplicateSegmentName, seg.Name)
+		}
+		segmentMap[seg.Name] = seg
+	}
+
+	for i, seg := range topology.Segments {
+		if err := ValidateAgentSegment(h, seg.Segment, seg.KeyBindings); err != nil {
+			return fmt.Errorf("segment %q (index %d): %w", seg.Name, i, err)
+		}
+	}
+
+	providers := make(map[string]HierarchySegment, len(topology.Segments)+1)
+	providers["root"] = rootSeg
+	for _, seg := range topology.Segments {
+		providers[seg.Name] = seg.Segment
+	}
+
+	if err := validateBindingsParentProviders(h, rootBindings, rootSeg, providers); err != nil {
+		return fmt.Errorf("root bindings: %w", err)
+	}
+
+	for _, seg := range topology.Segments {
+		if err := validateBindingsParentProviders(h, seg.KeyBindings, seg.Segment, providers); err != nil {
+			return fmt.Errorf("segment %q: %w", seg.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// validateBindingsParentProviders checks that all ParentKeyProvider references in a set of bindings
+// resolve to known providers and that the parent key falls within the provider's segment.
+func validateBindingsParentProviders(h KeyHierarchy, bindings map[string]KeyBinding, ownerSeg HierarchySegment, providers map[string]HierarchySegment) error {
+	for kind, binding := range bindings {
+		if binding.ParentKeyProvider == nil {
+			continue
+		}
+		providerName := binding.ParentKeyProvider.AgentName
+		providerSeg, exists := providers[providerName]
+		if !exists {
+			return fmt.Errorf("%w: %q (referenced by key kind %q)", ErrParentKeyProviderNotResolvable, providerName, kind)
+		}
+
+		kindIdx, ok := h.IndexOf(KeyKind(kind))
+		if !ok || kindIdx == 0 {
+			continue
+		}
+
+		parentKind := h.KeySpecs[kindIdx-1].Kind
+		parentIdx, _ := h.IndexOf(parentKind)
+		providerStartIdx, providerStartOk := h.IndexOf(KeyKind(providerSeg.StartKind))
+		providerEndIdx, providerEndOk := h.IndexOf(KeyKind(providerSeg.EndKind))
+		if providerStartOk && providerEndOk {
+			if parentIdx < providerStartIdx || parentIdx > providerEndIdx {
+				return fmt.Errorf("%w: parent key kind %q not in segment %q (%s→%s)",
+					ErrParentKeyProviderKeyNotInParentSegment, parentKind, providerName, providerSeg.StartKind, providerSeg.EndKind)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/spec/hierarchy_validation_test.go
+++ b/internal/spec/hierarchy_validation_test.go
@@ -1,0 +1,523 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/internal/spec"
+)
+
+// testHierarchy returns a 5-key hierarchy: K0(root) → K1(kek) → K2(tek) → K3(kek) → K4(dek)
+func testHierarchy() spec.KeyHierarchy {
+	return spec.KeyHierarchy{
+		Name: "test-hierarchy",
+		KeySpecs: []spec.KeySpec{
+			{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+			{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+			{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
+			{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+			{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+		},
+	}
+}
+
+func validVault() spec.VaultSpec {
+	return spec.VaultSpec{Name: "v", Type: "aws-kms"}
+}
+
+func TestValidateSegmentAgainstHierarchy(t *testing.T) {
+	h := testHierarchy()
+
+	tests := []struct {
+		name     string
+		seg      spec.HierarchySegment
+		bindings map[string]spec.KeyBinding
+		wantErr  error
+	}{
+		{
+			name: "valid segment K0-K2 with correct bindings",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault()},
+				"K2": {Vault: validVault()},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid single-key segment",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault()},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "start kind not in hierarchy",
+			seg:  spec.HierarchySegment{StartKind: "UNKNOWN", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"UNKNOWN": {Vault: validVault()},
+				"K2":      {Vault: validVault()},
+			},
+			wantErr: spec.ErrSegmentStartKindNotInHierarchy,
+		},
+		{
+			name: "end kind not in hierarchy",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "UNKNOWN"},
+			bindings: map[string]spec.KeyBinding{
+				"K0":      {Vault: validVault()},
+				"UNKNOWN": {Vault: validVault()},
+			},
+			wantErr: spec.ErrSegmentEndKindNotInHierarchy,
+		},
+		{
+			name: "start after end in hierarchy order",
+			seg:  spec.HierarchySegment{StartKind: "K3", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K1": {Vault: validVault()},
+				"K3": {Vault: validVault()},
+			},
+			wantErr: spec.ErrSegmentStartAfterEnd,
+		},
+		{
+			name: "missing binding for key in range",
+			seg:  spec.HierarchySegment{StartKind: "K1", EndKind: "K3"},
+			bindings: map[string]spec.KeyBinding{
+				"K1": {Vault: validVault()},
+				"K3": {Vault: validVault()},
+				// K2 missing
+			},
+			wantErr: spec.ErrSegmentBindingsMissing,
+		},
+		{
+			name: "extra binding for key outside range",
+			seg:  spec.HierarchySegment{StartKind: "K1", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"K1": {Vault: validVault()},
+				"K2": {Vault: validVault()},
+				"K4": {Vault: validVault()}, // outside range
+			},
+			wantErr: spec.ErrSegmentBindingsExtra,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := spec.ValidateSegmentAgainstHierarchy(h, tt.seg, tt.bindings)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateRootSegment(t *testing.T) {
+	h := testHierarchy()
+
+	tests := []struct {
+		name     string
+		seg      spec.HierarchySegment
+		bindings map[string]spec.KeyBinding
+		wantErr  error
+	}{
+		{
+			name: "valid root segment K0-K1",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid root segment covers everything (0-agent deploy)",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault()},
+				"K2": {Vault: validVault()},
+				"K3": {Vault: validVault()},
+				"K4": {Vault: validVault()},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "root start not hierarchy first key",
+			seg:  spec.HierarchySegment{StartKind: "K1", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"K1": {Vault: validVault()},
+				"K2": {Vault: validVault()},
+			},
+			wantErr: spec.ErrRootSegmentStartNotFirst,
+		},
+		{
+			name: "root end kind is tek",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault()},
+				"K2": {Vault: validVault()},
+			},
+			wantErr: spec.ErrRootSegmentEndIsTek,
+		},
+		{
+			name: "root key binding has parent key provider",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "someone"}},
+				"K1": {Vault: validVault()},
+			},
+			wantErr: spec.ErrRootBindingHasParentKeyProvider,
+		},
+		{
+			name: "root end is dek valid for 0-agent deployment",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault()},
+				"K2": {Vault: validVault()},
+				"K3": {Vault: validVault()},
+				"K4": {Vault: validVault()},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "non-root key in root segment has parent key provider referencing root is valid",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "root segment with missing binding fails generic check",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				// K1 missing
+			},
+			wantErr: spec.ErrSegmentBindingsMissing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := spec.ValidateRootSegment(h, tt.seg, tt.bindings)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAgentSegment(t *testing.T) {
+	h := testHierarchy()
+
+	tests := []struct {
+		name     string
+		seg      spec.HierarchySegment
+		bindings map[string]spec.KeyBinding
+		wantErr  error
+	}{
+		{
+			name: "valid agent segment K2-K4 (tek to dek)",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K3": {Vault: validVault()},
+				"K4": {Vault: validVault()},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid agent segment K2-K3 (tek to kek)",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K3": {Vault: validVault()},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid single-key agent segment (tek only)",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K2"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "agent start kind not tek (kek start)",
+			seg:  spec.HierarchySegment{StartKind: "K1", EndKind: "K3"},
+			bindings: map[string]spec.KeyBinding{
+				"K1": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K2": {Vault: validVault()},
+				"K3": {Vault: validVault()},
+			},
+			wantErr: spec.ErrAgentSegmentStartNotTek,
+		},
+		{
+			name: "agent start kind not tek (dek start)",
+			seg:  spec.HierarchySegment{StartKind: "K4", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K4": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+			},
+			wantErr: spec.ErrAgentSegmentStartNotTek,
+		},
+		{
+			name: "agent segment contains root key",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K1": {Vault: validVault()},
+			},
+			// Root key is not tek, so this fails on start-not-tek first
+			wantErr: spec.ErrAgentSegmentStartNotTek,
+		},
+		{
+			name: "agent start binding missing parent key provider",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault()}, // no ParentKeyProvider
+				"K3": {Vault: validVault()},
+				"K4": {Vault: validVault()},
+			},
+			wantErr: spec.ErrAgentSegmentStartMissingParentKeyProvider,
+		},
+		{
+			name: "agent segment with missing binding fails generic check",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K4": {Vault: validVault()},
+				// K3 missing
+			},
+			wantErr: spec.ErrSegmentBindingsMissing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := spec.ValidateAgentSegment(h, tt.seg, tt.bindings)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateTopologyAgainstHierarchy(t *testing.T) {
+	h := testHierarchy()
+
+	rootSeg := spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
+	rootBindings := map[string]spec.KeyBinding{
+		"K0": {Vault: validVault()},
+		"K1": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+	}
+
+	validAgentSegment := func(name string) spec.TopologySegment {
+		return spec.TopologySegment{
+			Name:    name,
+			Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			KeyBindings: map[string]spec.KeyBinding{
+				"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K3": {Vault: validVault()},
+				"K4": {Vault: validVault()},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		topology     spec.Topology
+		rootSeg      spec.HierarchySegment
+		rootBindings map[string]spec.KeyBinding
+		wantErr      error
+	}{
+		{
+			name:         "valid topology with one agent",
+			topology:     spec.Topology{Segments: []spec.TopologySegment{validAgentSegment("agent-aws")}},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      nil,
+		},
+		{
+			name:         "empty topology (0 agents) is valid",
+			topology:     spec.Topology{},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      nil,
+		},
+		{
+			name: "valid topology with multiple agents sharing same segment",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					validAgentSegment("agent-aws"),
+					validAgentSegment("agent-gcp"),
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      nil,
+		},
+		{
+			name: "duplicate segment names",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					validAgentSegment("agent-aws"),
+					validAgentSegment("agent-aws"),
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      spec.ErrTopologyDuplicateSegmentName,
+		},
+		{
+			name: "parent key provider references nonexistent agent",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					{
+						Name:    "agent-aws",
+						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+						KeyBindings: map[string]spec.KeyBinding{
+							"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "nonexistent"}},
+							"K3": {Vault: validVault()},
+							"K4": {Vault: validVault()},
+						},
+					},
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      spec.ErrParentKeyProviderNotResolvable,
+		},
+		{
+			name: "parent key provider references root is valid",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					{
+						Name:    "agent-aws",
+						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+						KeyBindings: map[string]spec.KeyBinding{
+							"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K3": {Vault: validVault()},
+							"K4": {Vault: validVault()},
+						},
+					},
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      nil,
+		},
+		{
+			name: "parent key provider references another topology segment is valid",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					{
+						Name:    "agent-mid",
+						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
+						KeyBindings: map[string]spec.KeyBinding{
+							"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K3": {Vault: validVault()},
+						},
+					},
+					{
+						Name:    "agent-leaf",
+						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+						KeyBindings: map[string]spec.KeyBinding{
+							"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K3": {Vault: validVault()},
+							"K4": {Vault: validVault()},
+						},
+					},
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      nil,
+		},
+		{
+			name: "agent segment fails validation is cascaded",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					{
+						Name:    "agent-bad",
+						Segment: spec.HierarchySegment{StartKind: "K1", EndKind: "K3"}, // K1 is kek, not tek
+						KeyBindings: map[string]spec.KeyBinding{
+							"K1": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K2": {Vault: validVault()},
+							"K3": {Vault: validVault()},
+						},
+					},
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      spec.ErrAgentSegmentStartNotTek,
+		},
+		{
+			name: "parent key provider segment does not contain parent key kind",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{
+					{
+						Name:    "agent-mid",
+						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
+						KeyBindings: map[string]spec.KeyBinding{
+							// K2's parent is K1, which is in root segment K0-K1 — referencing agent-leaf which manages K2-K4
+							"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "agent-leaf"}},
+							"K3": {Vault: validVault()},
+						},
+					},
+					{
+						Name:    "agent-leaf",
+						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+						KeyBindings: map[string]spec.KeyBinding{
+							"K2": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K3": {Vault: validVault()},
+							"K4": {Vault: validVault()},
+						},
+					},
+				},
+			},
+			rootSeg:      rootSeg,
+			rootBindings: rootBindings,
+			wantErr:      spec.ErrParentKeyProviderKeyNotInParentSegment,
+		},
+		{
+			name: "root binding parent key provider references nonexistent agent",
+			topology: spec.Topology{
+				Segments: []spec.TopologySegment{validAgentSegment("agent-aws")},
+			},
+			rootSeg: rootSeg,
+			rootBindings: map[string]spec.KeyBinding{
+				"K0": {Vault: validVault()},
+				"K1": {Vault: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "nonexistent"}},
+			},
+			wantErr: spec.ErrParentKeyProviderNotResolvable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := spec.ValidateTopologyAgainstHierarchy(h, tt.topology, tt.rootSeg, tt.rootBindings)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/spec/keyhierarchy.go
+++ b/internal/spec/keyhierarchy.go
@@ -20,6 +20,10 @@ var (
 	ErrKeyHierarchyLastKeyNotDek = errors.New("last key must have role 'dek'")
 	// ErrKeyHierarchyInvalidIntermediateKey is returned when an intermediate key in a KeyHierarchy does not have role 'kek' or 'tek'.
 	ErrKeyHierarchyInvalidIntermediateKey = errors.New("intermediate keys must have role 'kek' or 'tek'")
+	// ErrKeyHierarchyKindNotFound is returned when a key kind is not found in the hierarchy.
+	ErrKeyHierarchyKindNotFound = errors.New("key kind not found in hierarchy")
+	// ErrKeyHierarchyInvalidRange is returned when start kind comes after end kind in the hierarchy.
+	ErrKeyHierarchyInvalidRange = errors.New("start kind must come before or equal to end kind in hierarchy")
 )
 
 // KeyHierarchy defines an ordered arrangement of cryptographic keys and their roles.
@@ -89,4 +93,34 @@ func (h KeyHierarchy) FindKeySpec(kind KeyKind) (KeySpec, bool) {
 		}
 	}
 	return KeySpec{}, false
+}
+
+// IndexOf returns the position of the given kind in the hierarchy's KeySpecs slice.
+// Returns the index and true if found, or -1 and false if not found.
+func (h KeyHierarchy) IndexOf(kind KeyKind) (int, bool) {
+	for i, k := range h.KeySpecs {
+		if k.Kind == kind {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
+// KindsBetween returns the sub-slice of KeySpecs from start to end (inclusive).
+// Returns an error if either kind is not found or if start comes after end in the hierarchy.
+func (h KeyHierarchy) KindsBetween(start, end KeyKind) ([]KeySpec, error) {
+	startIdx, ok := h.IndexOf(start)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrKeyHierarchyKindNotFound, start)
+	}
+	endIdx, ok := h.IndexOf(end)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrKeyHierarchyKindNotFound, end)
+	}
+	if startIdx > endIdx {
+		return nil, ErrKeyHierarchyInvalidRange
+	}
+
+	return h.KeySpecs[startIdx : endIdx+1], nil
 }

--- a/internal/spec/keyhierarchy.go
+++ b/internal/spec/keyhierarchy.go
@@ -95,27 +95,26 @@ func (h KeyHierarchy) FindKeySpec(kind KeyKind) (KeySpec, bool) {
 	return KeySpec{}, false
 }
 
-// IndexOf returns the position of the given kind in the hierarchy's KeySpecs slice.
-// Returns the index and true if found, or -1 and false if not found.
-func (h KeyHierarchy) IndexOf(kind KeyKind) (int, bool) {
+// IndexOf returns the position of the given kind in the hierarchy's KeySpecs slice. Returns -1 if not found.
+func (h KeyHierarchy) IndexOf(kind KeyKind) int {
 	for i, k := range h.KeySpecs {
 		if k.Kind == kind {
-			return i, true
+			return i
 		}
 	}
 
-	return -1, false
+	return -1
 }
 
 // KindsBetween returns the sub-slice of KeySpecs from start to end (inclusive).
 // Returns an error if either kind is not found or if start comes after end in the hierarchy.
 func (h KeyHierarchy) KindsBetween(start, end KeyKind) ([]KeySpec, error) {
-	startIdx, ok := h.IndexOf(start)
-	if !ok {
+	startIdx := h.IndexOf(start)
+	if startIdx < 0 {
 		return nil, fmt.Errorf("%w: %q", ErrKeyHierarchyKindNotFound, start)
 	}
-	endIdx, ok := h.IndexOf(end)
-	if !ok {
+	endIdx := h.IndexOf(end)
+	if endIdx < 0 {
 		return nil, fmt.Errorf("%w: %q", ErrKeyHierarchyKindNotFound, end)
 	}
 	if startIdx > endIdx {

--- a/internal/spec/keyhierarchy_test.go
+++ b/internal/spec/keyhierarchy_test.go
@@ -477,18 +477,16 @@ func TestKeyHierarchy(t *testing.T) {
 			name     string
 			kind     spec.KeyKind
 			expIndex int
-			expFound bool
 		}{
-			{name: "found at index 0", kind: "K0", expIndex: 0, expFound: true},
-			{name: "found at middle index", kind: "K2", expIndex: 2, expFound: true},
-			{name: "found at last index", kind: "K4", expIndex: 4, expFound: true},
-			{name: "not found", kind: "nonexistent", expIndex: -1, expFound: false},
+			{name: "found at index 0", kind: "K0", expIndex: 0},
+			{name: "found at middle index", kind: "K2", expIndex: 2},
+			{name: "found at last index", kind: "K4", expIndex: 4},
+			{name: "not found", kind: "nonexistent", expIndex: -1},
 		}
 
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
-				idx, ok := hierarchy.IndexOf(tt.kind)
-				assert.Equal(t, tt.expFound, ok)
+				idx := hierarchy.IndexOf(tt.kind)
 				assert.Equal(t, tt.expIndex, idx)
 			})
 		}

--- a/internal/spec/keyhierarchy_test.go
+++ b/internal/spec/keyhierarchy_test.go
@@ -460,4 +460,90 @@ func TestKeyHierarchy(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("IndexOf", func(t *testing.T) {
+		hierarchy := &spec.KeyHierarchy{
+			Name: "test-hierarchy",
+			KeySpecs: []spec.KeySpec{
+				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+			},
+		}
+
+		tts := []struct {
+			name     string
+			kind     spec.KeyKind
+			expIndex int
+			expFound bool
+		}{
+			{name: "found at index 0", kind: "K0", expIndex: 0, expFound: true},
+			{name: "found at middle index", kind: "K2", expIndex: 2, expFound: true},
+			{name: "found at last index", kind: "K4", expIndex: 4, expFound: true},
+			{name: "not found", kind: "nonexistent", expIndex: -1, expFound: false},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				idx, ok := hierarchy.IndexOf(tt.kind)
+				assert.Equal(t, tt.expFound, ok)
+				assert.Equal(t, tt.expIndex, idx)
+			})
+		}
+	})
+
+	t.Run("KindsBetween", func(t *testing.T) {
+		hierarchy := &spec.KeyHierarchy{
+			Name: "test-hierarchy",
+			KeySpecs: []spec.KeySpec{
+				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+			},
+		}
+
+		t.Run("valid range returns correct sub-slice", func(t *testing.T) {
+			specs, err := hierarchy.KindsBetween("K1", "K3")
+			assert.NoError(t, err)
+			assert.Len(t, specs, 3)
+			assert.Equal(t, spec.KeyKind("K1"), specs[0].Kind)
+			assert.Equal(t, spec.KeyKind("K2"), specs[1].Kind)
+			assert.Equal(t, spec.KeyKind("K3"), specs[2].Kind)
+		})
+
+		t.Run("single element range", func(t *testing.T) {
+			specs, err := hierarchy.KindsBetween("K2", "K2")
+			assert.NoError(t, err)
+			assert.Len(t, specs, 1)
+			assert.Equal(t, spec.KeyKind("K2"), specs[0].Kind)
+		})
+
+		t.Run("full range returns entire slice", func(t *testing.T) {
+			specs, err := hierarchy.KindsBetween("K0", "K4")
+			assert.NoError(t, err)
+			assert.Len(t, specs, 5)
+		})
+
+		t.Run("start kind not found", func(t *testing.T) {
+			_, err := hierarchy.KindsBetween("nonexistent", "K3")
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, spec.ErrKeyHierarchyKindNotFound)
+		})
+
+		t.Run("end kind not found", func(t *testing.T) {
+			_, err := hierarchy.KindsBetween("K0", "nonexistent")
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, spec.ErrKeyHierarchyKindNotFound)
+		})
+
+		t.Run("start after end", func(t *testing.T) {
+			_, err := hierarchy.KindsBetween("K3", "K1")
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, spec.ErrKeyHierarchyInvalidRange)
+		})
+	})
 }


### PR DESCRIPTION
 - Add cross validation between key hierarchy, segments, and topology that catches configuration errors at load time 
  - Enforce root segment rules (must start at hierarchy root, cannot end on tek, root key cannot have parent provider) and agent segment rules (must start on tek, tek must have parent provider, cannot contain root key)
  - Validate topology level : no duplicate segment names, all ParentKeyProvider references resolve to known agents, and referenced parent agents actually manage the parent key kind
