### PR TITLE
fix: worker for correct context cancel

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -6,21 +6,16 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
-// TaskFn is a function executed by a [Scheduler] on each tick.
 type TaskFn func(context.Context) error
 
-// Scheduler runs a [TaskFn] at a fixed interval until stopped via context cancellation or [Scheduler.Kill].
-// [Scheduler.Start] may only be called once; subsequent calls are no-ops.
 type Scheduler struct {
-	interval  time.Duration
-	task      TaskFn
-	isStarted atomic.Bool
-	stopOnce  sync.Once
-	done      chan struct{}
+	interval time.Duration
+	task     TaskFn
+	cFn      context.CancelFunc
+	mu       sync.Mutex
 }
 
 var (
@@ -28,8 +23,6 @@ var (
 	ErrInvalidInterval = errors.New("interval must be greater than zero")
 )
 
-// New creates a [Scheduler] that executes task every interval.
-// Returns an error if task is nil or interval is not positive.
 func New(d time.Duration, t TaskFn) (*Scheduler, error) {
 	if t == nil {
 		return nil, ErrTaskFnNil
@@ -41,15 +34,12 @@ func New(d time.Duration, t TaskFn) (*Scheduler, error) {
 	return &Scheduler{
 		interval: d,
 		task:     t,
-		done:     make(chan struct{}),
 	}, nil
 }
 
-// Start blocks, running the task on each tick until ctx is cancelled or [Scheduler.Kill] is called.
-// Task errors are logged but do not stop the scheduler.
 func (w *Scheduler) Start(ctx context.Context) {
-	if !w.isStarted.CompareAndSwap(false, true) {
-		slog.Warn("Worker already started")
+	nCtx, ok := w.canStart(ctx)
+	if !ok {
 		return
 	}
 
@@ -59,20 +49,32 @@ func (w *Scheduler) Start(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			if err := w.task(ctx); err != nil {
+			if err := w.task(nCtx); err != nil {
 				slog.Error("Worker task", slog.String("error", err.Error()))
 			}
-		case <-ctx.Done():
-			return
-		case <-w.done:
+		case <-nCtx.Done():
 			return
 		}
 	}
 }
 
-// Kill signals the scheduler to stop. It is safe to call multiple times.
-func (w *Scheduler) Kill() {
-	w.stopOnce.Do(func() {
-		close(w.done)
-	})
+func (w *Scheduler) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cFn != nil {
+		w.cFn()
+		w.cFn = nil
+	}
+}
+
+func (w *Scheduler) canStart(ctx context.Context) (context.Context, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cFn != nil {
+		slog.Warn("Scheduler already started; ignoring duplicate Start call")
+		return nil, false
+	}
+	nCtx, cancel := context.WithCancel(ctx)
+	w.cFn = cancel
+	return nCtx, true
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -9,8 +9,13 @@ import (
 	"time"
 )
 
+// TaskFn is a function executed periodically by the Scheduler.
+// It receives a context that is cancelled when the scheduler stops.
 type TaskFn func(context.Context) error
 
+// Scheduler runs a TaskFn at a fixed interval. It is safe for concurrent use.
+// Use [New] to create a Scheduler, [Scheduler.Start] to begin execution in a
+// goroutine, and [Scheduler.Stop] to shut down.
 type Scheduler struct {
 	interval time.Duration
 	task     TaskFn
@@ -23,6 +28,7 @@ var (
 	ErrInvalidInterval = errors.New("interval must be greater than zero")
 )
 
+// New creates a Scheduler that calls t [TaskFn] every d [time.Duration].
 func New(d time.Duration, t TaskFn) (*Scheduler, error) {
 	if t == nil {
 		return nil, ErrTaskFnNil
@@ -37,6 +43,9 @@ func New(d time.Duration, t TaskFn) (*Scheduler, error) {
 	}, nil
 }
 
+// Start begins periodic execution of the task. It blocks until the scheduler
+// is stopped via [Scheduler.Stop] or the parent ctx is cancelled. Intended to
+// be called in a goroutine. Duplicate calls while running are no-ops.
 func (w *Scheduler) Start(ctx context.Context) {
 	nCtx, ok := w.canStart(ctx)
 	if !ok {
@@ -58,6 +67,7 @@ func (w *Scheduler) Start(ctx context.Context) {
 	}
 }
 
+// Stop cancels the running scheduler. It is safe to call multiple times.
 func (w *Scheduler) Stop() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -67,6 +77,8 @@ func (w *Scheduler) Stop() {
 	}
 }
 
+// canStart guards against duplicate starts. Returns a derived context and true
+// if the scheduler was not already running.
 func (w *Scheduler) canStart(ctx context.Context) (context.Context, bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -183,8 +183,8 @@ func TestStart(t *testing.T) {
 	})
 }
 
-func TestKill(t *testing.T) {
-	t.Run("should kill executing the task function when Kill is called", func(t *testing.T) {
+func TestStop(t *testing.T) {
+	t.Run("should stop executing the task function when Stop is called", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			// given
 			ctx := t.Context()
@@ -206,8 +206,8 @@ func TestKill(t *testing.T) {
 
 			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
 			synctest.Wait()
-			subj.Kill()
-			time.Sleep(11 * time.Second) // wait to ensure no more executions after Kill is called
+			subj.Stop()
+			time.Sleep(11 * time.Second) // wait to ensure no more executions after stop is called
 			synctest.Wait()
 
 			// then
@@ -215,7 +215,7 @@ func TestKill(t *testing.T) {
 		})
 	})
 
-	t.Run("should be safe to call Kill multiple times", func(t *testing.T) {
+	t.Run("should be safe to call Stop multiple times", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			// given
 			ctx := t.Context()
@@ -237,10 +237,10 @@ func TestKill(t *testing.T) {
 
 			time.Sleep(11 * time.Second) // wait for the task to execute at least twice
 			synctest.Wait()
-			// call Kill multiple times
-			subj.Kill()
-			subj.Kill()
-			time.Sleep(11 * time.Second) // wait to ensure no more executions after Kill is called
+			// call Stop multiple times
+			subj.Stop()
+			subj.Stop()
+			time.Sleep(11 * time.Second) // wait to ensure no more executions after Stop is called
 			synctest.Wait()
 
 			// then


### PR DESCRIPTION
- Kill() renamed to Stop() -- uses mutex-guarded cancel function instead of sync.Once/channel close.
- Start() now derives a child context internally via a new canStart() helper, fixing a bug where the task received the parent context instead of a cancellable one.
- Duplicate Start calls are now detected via the cancel function (not atomic.Bool), and the scheduler can be re-started after being stopped.
