### PR TITLE
feat: agent registration and list and delete endpoint

### DIFF
--- a/internal/securemem/test/dump/main.go
+++ b/internal/securemem/test/dump/main.go
@@ -34,7 +34,7 @@ func main() {
 	// Run the secret runner and the exposed secret in parallel to simulate a real-world scenario
 	handlerResponse := securememRunner()
 
-	// Simulate an un unsecured secret read that is not protected by securemem
+	// Simulate an unsecured secret read that is not protected by securemem
 	unSecuredSecretReader()
 
 	// Create a trigger file to keep the container running for analysis

--- a/pkg/api/agents/deregister_test.go
+++ b/pkg/api/agents/deregister_test.go
@@ -183,7 +183,7 @@ func TestDeregister(t *testing.T) {
 			assert.NoError(t, err)
 
 			// directly update the status to unhealthy to simulate the scenario where the agent becomes unhealthy before sending the deregister request
-			err = agentStore.UpdateRegistrationStatus(t.Context(), store.UpdateRegistrationStatusQuery{
+			err = agentStore.UpdateStatus(t.Context(), store.UpdateAgentStatusQuery{
 				Name:       expAgentName,
 				InstanceID: expAgentID,
 				FromStatus: []core.AgentRegistrationStatus{core.AgentRegistrationStatusRegistered},
@@ -239,7 +239,7 @@ func TestDeregister(t *testing.T) {
 				InstanceID: expAgentID,
 			})
 
-			assert.ErrorIs(t, err, store.ErrAgentRegistrationNotFound)
+			assert.ErrorIs(t, err, store.ErrAgentNotFound)
 		})
 
 		t.Run("server should return error if X-Agent-Name header is missing", func(t *testing.T) {

--- a/pkg/api/agents/handler.go
+++ b/pkg/api/agents/handler.go
@@ -125,7 +125,7 @@ func (a *agent) deregister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = a.store.UpdateRegistrationStatus(r.Context(), store.UpdateRegistrationStatusQuery{
+	err = a.store.UpdateStatus(r.Context(), store.UpdateAgentStatusQuery{
 		Name:       ah.agentName,
 		InstanceID: ah.agentID,
 		FromStatus: []core.AgentRegistrationStatus{
@@ -137,7 +137,7 @@ func (a *agent) deregister(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Printf("failed to update agent status to deregistered : %v", err)
-		http.Error(w, "failed to update agent status to deregistered ", http.StatusInternalServerError)
+		http.Error(w, "failed to update agent status to deregistered", http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/api/agents/heartbeat_test.go
+++ b/pkg/api/agents/heartbeat_test.go
@@ -178,7 +178,7 @@ func TestSendHeartbeat(t *testing.T) {
 				InstanceID: expAgentID,
 			})
 
-			assert.ErrorIs(t, err, store.ErrAgentRegistrationNotFound)
+			assert.ErrorIs(t, err, store.ErrAgentNotFound)
 		})
 
 		t.Run("server should return error if X-Agent-Name header is missing", func(t *testing.T) {

--- a/pkg/api/agents/register_test.go
+++ b/pkg/api/agents/register_test.go
@@ -124,7 +124,7 @@ func TestAgentRegister(t *testing.T) {
 		srv := httptest.NewServer(handler)
 		t.Cleanup(srv.Close)
 
-		t.Run("agent client should sent a successful request to the server", func(t *testing.T) {
+		t.Run("agent client should send a successful request to the server", func(t *testing.T) {
 			// given
 			subj, err := agents.NewClient(srv.URL, expAgentName, expAgentID)
 			assert.NoError(t, err)
@@ -147,7 +147,7 @@ func TestAgentRegister(t *testing.T) {
 			}, resp)
 		})
 
-		t.Run("agent client should sent a successful request and the server should register the client in the registry store", func(t *testing.T) {
+		t.Run("agent client should send a successful request and the server should register the client in the registry store", func(t *testing.T) {
 			// given
 			subj, err := agents.NewClient(srv.URL, expAgentName, expAgentID)
 			assert.NoError(t, err)

--- a/pkg/store/agent.go
+++ b/pkg/store/agent.go
@@ -8,12 +8,17 @@ import (
 	"github.com/openkcm/krypton/internal/core"
 )
 
-var ErrAgentRegistrationNotFound = errors.New("agent registration not found")
+var (
+	ErrAgentNotFound     = errors.New("agent registration not found")
+	ErrAgentQueryInvalid = errors.New("agent registration query invalid required field")
+)
 
 type Agent interface {
-	Register(ctx context.Context, query RegisterAgentQuery) (RegisterAgentResult, error)
-	Get(ctx context.Context, query GetAgentQuery) (GetAgentResult, error)
-	UpdateRegistrationStatus(ctx context.Context, query UpdateRegistrationStatusQuery) error
+	Register(ctx context.Context, q RegisterAgentQuery) (RegisterAgentResult, error)
+	Get(ctx context.Context, q GetAgentQuery) (GetAgentResult, error)
+	UpdateStatus(ctx context.Context, q UpdateAgentStatusQuery) error
+	Delete(ctx context.Context, q DeleteAgentQuery) error
+	List(ctx context.Context, q ListAgentQuery) (ListAgentResult, error)
 }
 
 type (
@@ -34,11 +39,24 @@ type (
 		Registration core.AgentRegistration
 	}
 
-	UpdateRegistrationStatusQuery struct {
+	UpdateAgentStatusQuery struct {
 		Name               string
 		InstanceID         string
 		FromStatus         []core.AgentRegistrationStatus
 		ToStatus           core.AgentRegistrationStatus
 		HeartbeatThreshold time.Duration
+	}
+
+	DeleteAgentQuery struct {
+		Status             core.AgentRegistrationStatus
+		HeartbeatThreshold time.Duration
+	}
+
+	ListAgentQuery struct {
+		Name string
+	}
+
+	ListAgentResult struct {
+		Registrations []core.AgentRegistration
 	}
 )

--- a/pkg/store/sql/agent.go
+++ b/pkg/store/sql/agent.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 
 	"github.com/openkcm/krypton/internal/clock"
@@ -101,7 +102,7 @@ func (s *AgentStore) Get(ctx context.Context, q store.GetAgentQuery) (store.GetA
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return store.GetAgentResult{}, store.ErrAgentRegistrationNotFound
+			return store.GetAgentResult{}, store.ErrAgentNotFound
 		}
 		return store.GetAgentResult{}, err
 	}
@@ -111,29 +112,106 @@ func (s *AgentStore) Get(ctx context.Context, q store.GetAgentQuery) (store.GetA
 	}, nil
 }
 
-// UpdateRegistrationStatus implements [store.Agent].
-func (s *AgentStore) UpdateRegistrationStatus(ctx context.Context, query store.UpdateRegistrationStatusQuery) error {
-	var sb strings.Builder
-	now := clock.Now()
-	sb.WriteString(`UPDATE agent_registrations
-	SET status = $1, updated_at = $2
-	WHERE name = $3 AND instance_id = $4
-	AND status = ANY($5)`)
-	args := []any{
-		query.ToStatus,
-		now,
-		query.Name,
-		query.InstanceID,
-		query.FromStatus,
+func (s *AgentStore) UpdateStatus(ctx context.Context, q store.UpdateAgentStatusQuery) error {
+	if len(q.FromStatus) == 0 {
+		return fmt.Errorf("missing from status: %w", store.ErrAgentQueryInvalid)
 	}
-	if query.HeartbeatThreshold != 0 {
-		sb.WriteString(` AND ($6 - last_heartbeat) > $7`)
-		args = append(args, now)
-		args = append(args, query.HeartbeatThreshold.Nanoseconds())
+	if q.ToStatus == "" {
+		return fmt.Errorf("missing to status: %w", store.ErrAgentQueryInvalid)
 	}
 
-	_, err := s.db.ExecContext(ctx, sb.String(),
-		args...,
-	)
+	var sb strings.Builder
+	now := clock.Now()
+
+	sb.WriteString(`UPDATE agent_registrations
+    SET status = $1, updated_at = $2
+    WHERE status = ANY($3)`)
+	args := []any{
+		q.ToStatus,
+		now,
+		q.FromStatus,
+	}
+
+	if q.Name != "" {
+		argIdx := len(args) + 1
+		fmt.Fprintf(&sb, ` AND name = $%d`, argIdx)
+		args = append(args, q.Name)
+	}
+
+	if q.InstanceID != "" {
+		argIdx := len(args) + 1
+		fmt.Fprintf(&sb, ` AND instance_id = $%d`, argIdx)
+		args = append(args, q.InstanceID)
+	}
+
+	if q.HeartbeatThreshold > 0 {
+		argIdx := len(args) + 1
+		fmt.Fprintf(&sb, ` AND ($%d - last_heartbeat) > $%d`, argIdx, argIdx+1)
+		args = append(args, now, q.HeartbeatThreshold.Nanoseconds())
+	}
+	_, err := s.db.ExecContext(ctx, sb.String(), args...)
 	return err
+}
+
+func (s *AgentStore) Delete(ctx context.Context, q store.DeleteAgentQuery) error {
+	if q.Status == "" {
+		return fmt.Errorf("missing status: %w", store.ErrAgentQueryInvalid)
+	}
+	if q.HeartbeatThreshold <= 0 {
+		return fmt.Errorf("invalid heartbeat threshold: %w", store.ErrAgentQueryInvalid)
+	}
+
+	now := clock.Now()
+	stmt := `
+	DELETE FROM agent_registrations
+	WHERE status = $1 AND ($2 - last_heartbeat) > $3
+	`
+	_, err := s.db.ExecContext(ctx, stmt, q.Status, now, q.HeartbeatThreshold.Nanoseconds())
+	return err
+}
+
+func (s *AgentStore) List(ctx context.Context, q store.ListAgentQuery) (store.ListAgentResult, error) {
+	var sb strings.Builder
+	sb.WriteString(`
+	SELECT name, instance_id, status, last_heartbeat, created_at, updated_at
+	FROM agent_registrations
+	WHERE 1=1 `)
+
+	var args []any
+	if q.Name != "" {
+		sb.WriteString(` AND name = $1`)
+		args = append(args, q.Name)
+	}
+
+	rows, err := s.db.QueryContext(ctx, sb.String(), args...)
+	if err != nil {
+		return store.ListAgentResult{}, err
+	}
+	defer rows.Close()
+
+	var registrations []core.AgentRegistration
+
+	for rows.Next() {
+		var reg core.AgentRegistration
+		err := rows.Scan(
+			&reg.Name,
+			&reg.InstanceID,
+			&reg.Status,
+			&reg.LastHeartbeat,
+			&reg.CreatedAt,
+			&reg.UpdatedAt,
+		)
+		if err != nil {
+			return store.ListAgentResult{}, err
+		}
+		registrations = append(registrations, reg)
+	}
+
+	if err := rows.Err(); err != nil {
+		return store.ListAgentResult{}, err
+	}
+
+	return store.ListAgentResult{
+		Registrations: registrations,
+	}, nil
 }

--- a/pkg/store/sql/agent_test.go
+++ b/pkg/store/sql/agent_test.go
@@ -50,7 +50,7 @@ func TestRegister(t *testing.T) {
 	t.Run("should insert new agent registration", func(t *testing.T) {
 		// given
 		registration := core.AgentRegistration{
-			Name:       "test-agent",
+			Name:       agentName(),
 			InstanceID: uuid.New().String(),
 			Status:     core.AgentRegistrationStatusHealthy,
 		}
@@ -74,7 +74,7 @@ func TestRegister(t *testing.T) {
 	t.Run("should update existing agent registration", func(t *testing.T) {
 		// given
 		registration := core.AgentRegistration{
-			Name:       "test-agent",
+			Name:       agentName(),
 			InstanceID: uuid.New().String(),
 			Status:     core.AgentRegistrationStatusHealthy,
 		}
@@ -123,7 +123,7 @@ func TestGet(t *testing.T) {
 		require.NoError(t, err)
 
 		registration := core.AgentRegistration{
-			Name:       "test-agent",
+			Name:       agentName(),
 			InstanceID: uuid.New().String(),
 			Status:     core.AgentRegistrationStatusHealthy,
 		}
@@ -190,7 +190,7 @@ func TestUpdateStatus(t *testing.T) {
 			{
 				name: "missing to status",
 				updateQuery: store.UpdateAgentStatusQuery{
-					Name:       "test-agent",
+					Name:       agentName(),
 					InstanceID: uuid.New().String(),
 					FromStatus: []core.AgentRegistrationStatus{
 						core.AgentRegistrationStatusHealthy,
@@ -200,7 +200,7 @@ func TestUpdateStatus(t *testing.T) {
 			{
 				name: "missing from status",
 				updateQuery: store.UpdateAgentStatusQuery{
-					Name:       "test-agent",
+					Name:       agentName(),
 					InstanceID: uuid.New().String(),
 					ToStatus:   core.AgentRegistrationStatusDeregistered,
 				},
@@ -257,13 +257,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with matching name",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent-1",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent-2",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -284,13 +284,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should not update status of any registration for an unknown name",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent-1",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -310,13 +310,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with a matching instanceID",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -336,13 +336,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should not update status of any registration for an unknown instanceID",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -361,13 +361,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with matching instanceID and name",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -388,13 +388,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with heartbeat threshold exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.UnixNano(time.Now().Add(-1 * time.Minute).UnixNano()),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -414,13 +414,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should not update status of any registration when heartbeat threshold not exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -439,13 +439,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of both registration when heartbeat threshold exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -466,13 +466,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with heartbeat threshold exceeded and matching name",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent-1",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent-2",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -493,13 +493,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with heartbeat threshold exceeded and matching instanceID",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent-1",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent-2",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -520,13 +520,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of only registration with heartbeat threshold exceeded, matching instanceID and name",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent-1",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent-2",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -548,13 +548,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update status of both registration for the same from status",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -574,13 +574,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should not update the status of any registration when the from status does not match",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -598,13 +598,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update the status of one registration when the from status match",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusRegistered,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -623,13 +623,13 @@ func TestUpdateStatus(t *testing.T) {
 				name: "should update the status of all registration when the from status match",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusRegistered,
 						LastHeartbeat: clock.Now(),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
@@ -766,13 +766,13 @@ func TestDelete(t *testing.T) {
 				name: "should delete both registration for the same status and heartbeat threshold exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusDeregistered,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusDeregistered,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -789,13 +789,13 @@ func TestDelete(t *testing.T) {
 				name: "should not delete any registration when status matches and the heartbeat threshold not exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusDeregistered,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusDeregistered,
 						LastHeartbeat: clock.Now(),
@@ -812,13 +812,13 @@ func TestDelete(t *testing.T) {
 				name: "should not delete any registration when the status does not match even if the heartbeat threshold exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusDeregistered,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -835,13 +835,13 @@ func TestDelete(t *testing.T) {
 				name: "should delete only registration with matching status and heartbeat threshold exceeded",
 				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
 					reg1 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusDeregistered,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
 					}
 					reg2 := core.AgentRegistration{
-						Name:          "test-agent",
+						Name:          agentName(),
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
@@ -961,6 +961,10 @@ func TestList(t *testing.T) {
 			assert.Equal(t, name1, reg.Name)
 		}
 	})
+}
+
+func agentName() string {
+	return "test-agent-" + uuid.New().String()
 }
 
 func setupPostgres() (func(), error) {

--- a/pkg/store/sql/agent_test.go
+++ b/pkg/store/sql/agent_test.go
@@ -108,17 +108,17 @@ func TestRegister(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	// given
 	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
 
 	t.Run("should get existing agent registration", func(t *testing.T) {
 		// given
-		db, err := sql.Open("postgres", pgConnStr)
-		require.NoError(t, err)
-
-		t.Cleanup(func() {
-			db.Close()
-		})
-
 		subj, err := storesql.NewAgentStore(ctx, db)
 		require.NoError(t, err)
 
@@ -152,13 +152,6 @@ func TestGet(t *testing.T) {
 
 	t.Run("should return error if agent registration not found", func(t *testing.T) {
 		// given
-		db, err := sql.Open("postgres", pgConnStr)
-		require.NoError(t, err)
-
-		t.Cleanup(func() {
-			db.Close()
-		})
-
 		subj, err := storesql.NewAgentStore(ctx, db)
 		require.NoError(t, err)
 
@@ -169,12 +162,12 @@ func TestGet(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorIs(t, err, store.ErrAgentRegistrationNotFound)
+		assert.ErrorIs(t, err, store.ErrAgentNotFound)
 		assert.Zero(t, getResult.Registration)
 	})
 }
 
-func TestUpdateRegistrationStatus(t *testing.T) {
+func TestUpdateStatus(t *testing.T) {
 	// given
 	ctx := t.Context()
 
@@ -188,237 +181,784 @@ func TestUpdateRegistrationStatus(t *testing.T) {
 	subj, err := storesql.NewAgentStore(ctx, db)
 	require.NoError(t, err)
 
-	t.Run("UpdateRegistrationStatus", func(t *testing.T) {
+	t.Run("should return error if the query does not have required fields", func(t *testing.T) {
+		// given
 		tests := []struct {
-			name                string
-			sleepDuration       time.Duration
-			expectStatusChanged bool
+			name        string
+			updateQuery store.UpdateAgentStatusQuery
 		}{
 			{
-				name:                "should update status when heartbeat threshold exceeded",
-				sleepDuration:       21 * time.Second, // threshold + 1s
-				expectStatusChanged: true,
+				name: "missing to status",
+				updateQuery: store.UpdateAgentStatusQuery{
+					Name:       "test-agent",
+					InstanceID: uuid.New().String(),
+					FromStatus: []core.AgentRegistrationStatus{
+						core.AgentRegistrationStatusHealthy,
+					},
+				},
 			},
 			{
-				name:          "should not update status when heartbeat threshold not exceeded",
-				sleepDuration: 10 * time.Second, // threshold - 10s
-
-				expectStatusChanged: false,
+				name: "missing from status",
+				updateQuery: store.UpdateAgentStatusQuery{
+					Name:       "test-agent",
+					InstanceID: uuid.New().String(),
+					ToStatus:   core.AgentRegistrationStatusDeregistered,
+				},
 			},
 		}
-		heartbeatThreshold := 15 * time.Second
-
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				synctest.Test(t, func(t *testing.T) {
-					// given
-					registration := core.AgentRegistration{
+				// when
+				err := subj.UpdateStatus(ctx, tt.updateQuery)
+
+				// then
+				assert.ErrorIs(t, err, store.ErrAgentQueryInvalid)
+			})
+		}
+	})
+
+	t.Run("UpdateStatus", func(t *testing.T) {
+		// given
+		tests := []struct {
+			name          string
+			inputs        func() (reg1 core.AgentRegistration, reg2 core.AgentRegistration, query store.UpdateAgentStatusQuery)
+			isReg1Changed bool
+			isReg2Changed bool
+		}{
+			{
+				name: "should update status of both registration for the same name",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
 						Name:          "test-agent",
 						InstanceID:    uuid.New().String(),
 						Status:        core.AgentRegistrationStatusHealthy,
 						LastHeartbeat: clock.Now(),
 					}
 
-					prevResult, err := subj.Register(ctx, store.RegisterAgentQuery{
-						Registration: registration,
-					})
-
-					require.NoError(t, err)
-
-					time.Sleep(tt.sleepDuration)
-					synctest.Wait()
-
-					updateQuery := store.UpdateRegistrationStatusQuery{
-						Name:       registration.Name,
-						InstanceID: registration.InstanceID,
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						Name: "test-agent",
 						FromStatus: []core.AgentRegistrationStatus{
 							core.AgentRegistrationStatusHealthy,
 						},
-						ToStatus:           core.AgentRegistrationStatusUnhealthy,
-						HeartbeatThreshold: heartbeatThreshold,
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg1Changed: true,
+				isReg2Changed: true,
+			},
+
+			{
+				name: "should update status of only registration with matching name",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent-1",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent-2",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
 					}
 
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						Name: reg2.Name,
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg2Changed: true,
+			},
+
+			{
+				name: "should not update status of any registration for an unknown name",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent-1",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						Name: "unknown-agent",
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+			},
+
+			{
+				name: "should update status of only registration with a matching instanceID",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						InstanceID: reg2.InstanceID,
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg2Changed: true,
+			},
+			{
+				name: "should not update status of any registration for an unknown instanceID",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						InstanceID: uuid.New().String(),
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+			},
+			{
+				name: "should update status of only registration with matching instanceID and name",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						InstanceID: reg1.InstanceID,
+						Name:       reg1.Name,
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg1Changed: true,
+			},
+			{
+				name: "should update status of only registration with heartbeat threshold exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.UnixNano(time.Now().Add(-1 * time.Minute).UnixNano()),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus:           core.AgentRegistrationStatusDeregistered,
+						HeartbeatThreshold: 30 * time.Second,
+					}
+				},
+				isReg1Changed: true,
+			},
+			{
+				name: "should not update status of any registration when heartbeat threshold not exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus:           core.AgentRegistrationStatusDeregistered,
+						HeartbeatThreshold: 30 * time.Minute,
+					}
+				},
+			},
+			{
+				name: "should update status of both registration when heartbeat threshold exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus:           core.AgentRegistrationStatusDeregistered,
+						HeartbeatThreshold: 30 * time.Second,
+					}
+				},
+				isReg1Changed: true,
+				isReg2Changed: true,
+			},
+			{
+				name: "should update status of only registration with heartbeat threshold exceeded and matching name",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent-1",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent-2",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus:           core.AgentRegistrationStatusDeregistered,
+						Name:               reg2.Name,
+						HeartbeatThreshold: 30 * time.Second,
+					}
+				},
+				isReg2Changed: true,
+			},
+			{
+				name: "should update status of only registration with heartbeat threshold exceeded and matching instanceID",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent-1",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent-2",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus:           core.AgentRegistrationStatusDeregistered,
+						InstanceID:         reg1.InstanceID,
+						HeartbeatThreshold: 30 * time.Second,
+					}
+				},
+				isReg1Changed: true,
+			},
+			{
+				name: "should update status of only registration with heartbeat threshold exceeded, matching instanceID and name",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent-1",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent-2",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus:           core.AgentRegistrationStatusDeregistered,
+						InstanceID:         reg2.InstanceID,
+						Name:               reg2.Name,
+						HeartbeatThreshold: 30 * time.Second,
+					}
+				},
+				isReg2Changed: true,
+			},
+			{
+				name: "should update status of both registration for the same from status",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg1Changed: true,
+				isReg2Changed: true,
+			},
+			{
+				name: "should not update the status of any registration when the from status does not match",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusRegistered,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+			},
+			{
+				name: "should update the status of one registration when the from status match",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusRegistered,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg2Changed: true,
+			},
+			{
+				name: "should update the status of all registration when the from status match",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.UpdateAgentStatusQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusRegistered,
+						LastHeartbeat: clock.Now(),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now(),
+					}
+
+					return reg1, reg2, store.UpdateAgentStatusQuery{
+						FromStatus: []core.AgentRegistrationStatus{
+							core.AgentRegistrationStatusHealthy,
+							core.AgentRegistrationStatusRegistered,
+						},
+						ToStatus: core.AgentRegistrationStatusDeregistered,
+					}
+				},
+				isReg1Changed: true,
+				isReg2Changed: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					// given
+					reg1, reg2, query := tt.inputs()
+
+					reg1Before, err := subj.Register(ctx, store.RegisterAgentQuery{
+						Registration: reg1,
+					})
+					require.NoError(t, err)
+
+					reg2Before, err := subj.Register(ctx, store.RegisterAgentQuery{
+						Registration: reg2,
+					})
+					require.NoError(t, err)
+
 					// when
-					err = subj.UpdateRegistrationStatus(ctx, updateQuery)
+					time.Sleep(1 * time.Second) // ensure the updatedAt timestamp will be different after update
+					synctest.Wait()
+					err = subj.UpdateStatus(ctx, query)
 
 					// then
 					assert.NoError(t, err)
 
-					getResult, err := subj.Get(ctx, store.GetAgentQuery{
-						Name:       registration.Name,
-						InstanceID: registration.InstanceID,
+					reg1After, err := subj.Get(ctx, store.GetAgentQuery{
+						Name:       reg1.Name,
+						InstanceID: reg1.InstanceID,
 					})
 					require.NoError(t, err)
 
-					assert.Equal(t, prevResult.Registration.Name, getResult.Registration.Name)
-					assert.Equal(t, prevResult.Registration.InstanceID, getResult.Registration.InstanceID)
-					assert.Equal(t, prevResult.Registration.LastHeartbeat, getResult.Registration.LastHeartbeat)
-					assert.Equal(t, prevResult.Registration.CreatedAt, getResult.Registration.CreatedAt)
-					if tt.expectStatusChanged {
-						assert.Equal(t, updateQuery.ToStatus, getResult.Registration.Status)
-						assert.NotEqual(t, prevResult.Registration.UpdatedAt, getResult.Registration.UpdatedAt)
-						assert.Greater(t, getResult.Registration.UpdatedAt, prevResult.Registration.UpdatedAt)
+					reg2After, err := subj.Get(ctx, store.GetAgentQuery{
+						Name:       reg2.Name,
+						InstanceID: reg2.InstanceID,
+					})
+					require.NoError(t, err)
+
+					if tt.isReg1Changed {
+						assert.Equal(t, query.ToStatus, reg1After.Registration.Status)
+						assert.Greater(t, reg1After.Registration.UpdatedAt, reg1Before.Registration.UpdatedAt)
 					} else {
-						assert.Equal(t, prevResult.Registration.Status, getResult.Registration.Status)
-						assert.Equal(t, prevResult.Registration.UpdatedAt, getResult.Registration.UpdatedAt)
+						assert.Equal(t, reg1Before.Registration, reg1After.Registration)
+					}
+
+					if tt.isReg2Changed {
+						assert.Equal(t, query.ToStatus, reg2After.Registration.Status)
+						assert.Greater(t, reg2After.Registration.UpdatedAt, reg2Before.Registration.UpdatedAt)
+					} else {
+						assert.Equal(t, reg2Before.Registration, reg2After.Registration)
 					}
 				})
 			})
 		}
 	})
+}
 
-	t.Run("should deregister without a LastHeartbeat threshold", func(t *testing.T) {
-		tests := []struct {
-			name       string
-			fromStatus core.AgentRegistrationStatus
+func TestDelete(t *testing.T) {
+	// given
+	ctx := t.Context()
+
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+	subj, err := storesql.NewAgentStore(ctx, db)
+	require.NoError(t, err)
+
+	t.Run("should return error if the query does not have required fields", func(t *testing.T) {
+		// given
+		tts := []struct {
+			name        string
+			deleteQuery store.DeleteAgentQuery
 		}{
 			{
-				name:       "from healthy",
-				fromStatus: core.AgentRegistrationStatusHealthy,
+				name: "missing status",
+				deleteQuery: store.DeleteAgentQuery{
+					HeartbeatThreshold: 30 * time.Second,
+				},
 			},
 			{
-				name:       "from unhealthy",
-				fromStatus: core.AgentRegistrationStatusUnhealthy,
+				name: "missing heartbeat threshold",
+				deleteQuery: store.DeleteAgentQuery{
+					Status: core.AgentRegistrationStatusDeregistered,
+				},
 			},
 			{
-				name:       "from registered",
-				fromStatus: core.AgentRegistrationStatusRegistered,
+				name: "negative heartbeat threshold",
+				deleteQuery: store.DeleteAgentQuery{
+					Status:             core.AgentRegistrationStatusDeregistered,
+					HeartbeatThreshold: -1 * time.Second,
+				},
 			},
 		}
-		for _, tt := range tests {
+
+		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
-				// given
-				registration := core.AgentRegistration{
-					Name:          "test-agent",
-					InstanceID:    uuid.New().String(),
-					Status:        tt.fromStatus,
-					LastHeartbeat: clock.Now(),
-				}
-
-				prevResult, err := subj.Register(ctx, store.RegisterAgentQuery{
-					Registration: registration,
-				})
-				require.NoError(t, err)
-
-				updateQuery := store.UpdateRegistrationStatusQuery{
-					Name:       registration.Name,
-					InstanceID: registration.InstanceID,
-					FromStatus: []core.AgentRegistrationStatus{
-						tt.fromStatus,
-					},
-					ToStatus: core.AgentRegistrationStatusDeregistered,
-				}
-
 				// when
-				err = subj.UpdateRegistrationStatus(ctx, updateQuery)
+				err = subj.Delete(ctx, tt.deleteQuery)
 
 				// then
-				assert.NoError(t, err)
-
-				getResult, err := subj.Get(ctx, store.GetAgentQuery{
-					Name:       registration.Name,
-					InstanceID: registration.InstanceID,
-				})
-				require.NoError(t, err)
-
-				assert.Equal(t, updateQuery.ToStatus, getResult.Registration.Status)
-				assert.Greater(t, getResult.Registration.UpdatedAt, prevResult.Registration.UpdatedAt)
-
-				assert.Equal(t, prevResult.Registration.Name, getResult.Registration.Name)
-				assert.Equal(t, prevResult.Registration.InstanceID, getResult.Registration.InstanceID)
-				assert.Equal(t, prevResult.Registration.LastHeartbeat, getResult.Registration.LastHeartbeat)
-				assert.Equal(t, prevResult.Registration.CreatedAt, getResult.Registration.CreatedAt)
+				assert.ErrorIs(t, err, store.ErrAgentQueryInvalid)
 			})
 		}
 	})
 
-	t.Run("should not update status if query does not match registration", func(t *testing.T) {
+	t.Run("Delete", func(t *testing.T) {
 		// given
-		registration := core.AgentRegistration{
-			Name:          "test-agent",
-			InstanceID:    uuid.New().String(),
-			Status:        core.AgentRegistrationStatusHealthy,
-			LastHeartbeat: clock.Now(),
-		}
-
-		prevResult, err := subj.Register(ctx, store.RegisterAgentQuery{
-			Registration: registration,
-		})
-
-		require.NoError(t, err)
-
 		tts := []struct {
-			name        string
-			updateQuery store.UpdateRegistrationStatusQuery
+			name          string
+			inputs        func() (reg1 core.AgentRegistration, reg2 core.AgentRegistration, query store.DeleteAgentQuery)
+			isReg1Deleted bool
+			isReg2Deleted bool
 		}{
 			{
-				name: "non-existent name",
-				updateQuery: store.UpdateRegistrationStatusQuery{
-					Name:       "non-existent-agent",
-					InstanceID: registration.InstanceID,
-					FromStatus: []core.AgentRegistrationStatus{
-						registration.Status,
-					},
-					ToStatus: core.AgentRegistrationStatusDeregistered,
+				name: "should delete both registration for the same status and heartbeat threshold exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusDeregistered,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusDeregistered,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					return reg1, reg2, store.DeleteAgentQuery{
+						Status:             core.AgentRegistrationStatusDeregistered,
+						HeartbeatThreshold: 30 * time.Second,
+					}
 				},
+				isReg1Deleted: true,
+				isReg2Deleted: true,
 			},
 			{
-				name: "non-existent instance ID",
-				updateQuery: store.UpdateRegistrationStatusQuery{
-					Name:       registration.Name,
-					InstanceID: uuid.New().String(),
-					FromStatus: []core.AgentRegistrationStatus{
-						registration.Status,
-					},
-					ToStatus: core.AgentRegistrationStatusDeregistered,
+				name: "should not delete any registration when status matches and the heartbeat threshold not exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusDeregistered,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusDeregistered,
+						LastHeartbeat: clock.Now(),
+					}
+					return reg1, reg2, store.DeleteAgentQuery{
+						Status:             core.AgentRegistrationStatusDeregistered,
+						HeartbeatThreshold: 30 * time.Minute,
+					}
 				},
+				isReg1Deleted: false,
+				isReg2Deleted: false,
 			},
 			{
-				name: "from status does not match",
-				updateQuery: store.UpdateRegistrationStatusQuery{
-					Name:       registration.Name,
-					InstanceID: registration.InstanceID,
-					FromStatus: []core.AgentRegistrationStatus{
-						core.AgentRegistrationStatusUnhealthy,
-					},
-					ToStatus: core.AgentRegistrationStatusDeregistered,
+				name: "should not delete any registration when the status does not match even if the heartbeat threshold exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusDeregistered,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					return reg1, reg2, store.DeleteAgentQuery{
+						Status:             core.AgentRegistrationStatusRegistered,
+						HeartbeatThreshold: 30 * time.Second,
+					}
 				},
+				isReg1Deleted: false,
+				isReg2Deleted: false,
 			},
 			{
-				name: "heartbeat threshold not exceeded",
-				updateQuery: store.UpdateRegistrationStatusQuery{
-					Name:       registration.Name,
-					InstanceID: registration.InstanceID,
-					FromStatus: []core.AgentRegistrationStatus{
-						registration.Status,
-					},
-					ToStatus:           core.AgentRegistrationStatusDeregistered,
-					HeartbeatThreshold: 100 * time.Second,
+				name: "should delete only registration with matching status and heartbeat threshold exceeded",
+				inputs: func() (core.AgentRegistration, core.AgentRegistration, store.DeleteAgentQuery) {
+					reg1 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusDeregistered,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					reg2 := core.AgentRegistration{
+						Name:          "test-agent",
+						InstanceID:    uuid.New().String(),
+						Status:        core.AgentRegistrationStatusHealthy,
+						LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+					}
+					return reg1, reg2, store.DeleteAgentQuery{
+						Status:             core.AgentRegistrationStatusDeregistered,
+						HeartbeatThreshold: 30 * time.Second,
+					}
 				},
+				isReg1Deleted: true,
+				isReg2Deleted: false,
 			},
 		}
 		for _, tt := range tts {
 			t.Run(tt.name, func(t *testing.T) {
+				// given
+				reg1, reg2, query := tt.inputs()
+
+				_, err = subj.Register(ctx, store.RegisterAgentQuery{
+					Registration: reg1,
+				})
+				require.NoError(t, err)
+
+				_, err = subj.Register(ctx, store.RegisterAgentQuery{
+					Registration: reg2,
+				})
+				require.NoError(t, err)
+
 				// when
-				err = subj.UpdateRegistrationStatus(ctx, tt.updateQuery)
+				err = subj.Delete(ctx, query)
 
 				// then
 				assert.NoError(t, err)
 
-				getResult, err := subj.Get(ctx, store.GetAgentQuery{
-					Name:       registration.Name,
-					InstanceID: registration.InstanceID,
+				_, err = subj.Get(ctx, store.GetAgentQuery{
+					Name:       reg1.Name,
+					InstanceID: reg1.InstanceID,
 				})
 
-				require.NoError(t, err)
+				if tt.isReg1Deleted {
+					assert.ErrorIs(t, err, store.ErrAgentNotFound)
+				} else {
+					assert.NoError(t, err)
+				}
 
-				assert.Equal(t, registration.Status, getResult.Registration.Status)
-				assert.Equal(t, prevResult.Registration.Name, getResult.Registration.Name)
-				assert.Equal(t, prevResult.Registration.InstanceID, getResult.Registration.InstanceID)
-				assert.Equal(t, prevResult.Registration.LastHeartbeat, getResult.Registration.LastHeartbeat)
-				assert.Equal(t, prevResult.Registration.CreatedAt, getResult.Registration.CreatedAt)
-				assert.Equal(t, prevResult.Registration.UpdatedAt, getResult.Registration.UpdatedAt)
+				_, err = subj.Get(ctx, store.GetAgentQuery{
+					Name:       reg2.Name,
+					InstanceID: reg2.InstanceID,
+				})
+				if tt.isReg2Deleted {
+					assert.ErrorIs(t, err, store.ErrAgentNotFound)
+				} else {
+					assert.NoError(t, err)
+				}
 			})
+		}
+	})
+}
+
+func TestList(t *testing.T) {
+	// given
+	ctx := t.Context()
+
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+	subj, err := storesql.NewAgentStore(ctx, db)
+	require.NoError(t, err)
+
+	name1 := uuid.New().String()
+	name2 := uuid.New().String()
+
+	_, err = subj.Register(ctx, store.RegisterAgentQuery{
+		Registration: core.AgentRegistration{
+			Name:          name1,
+			InstanceID:    uuid.New().String(),
+			Status:        core.AgentRegistrationStatusDeregistered,
+			LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = subj.Register(ctx, store.RegisterAgentQuery{
+		Registration: core.AgentRegistration{
+			Name:          name2,
+			InstanceID:    uuid.New().String(),
+			Status:        core.AgentRegistrationStatusDeregistered,
+			LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+		},
+	})
+	assert.NoError(t, err)
+
+	_, err = subj.Register(ctx, store.RegisterAgentQuery{
+		Registration: core.AgentRegistration{
+			Name:          name1,
+			InstanceID:    uuid.New().String(),
+			Status:        core.AgentRegistrationStatusDeregistered,
+			LastHeartbeat: clock.Now() - clock.UnixNano(time.Minute),
+		},
+	})
+	assert.NoError(t, err)
+
+	t.Run("should filter agent registrations by name", func(t *testing.T) {
+		// when
+		listResult, err := subj.List(ctx, store.ListAgentQuery{
+			Name: name1,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, listResult.Registrations, 2)
+
+		for _, reg := range listResult.Registrations {
+			assert.Equal(t, name1, reg.Name)
 		}
 	})
 }


### PR DESCRIPTION

1. Renamed and generalized UpdateStatus - Name and InstanceID are now optional filters instead of required, allowing bulk status updates across multiple registrations. Dynamic SQL parameter building replaces hardcoded placeholders. Input validation added.
2. New Delete method - Deletes registrations matching a given status whose heartbeat has exceeded a threshold (for cleaning up stale entries).
3. New List method - Queries registrations with an optional name filter.
4. Consistent error naming - ErrAgentRegistrationNotFound -> ErrAgentNotFound, added ErrAgentQueryInvalid.
5. Tests massively expanded - UpdateStatus tests grew from 2 cases to 16, covering all filter combinations. New test suites for Delete and List.
6. Minor fixes - Two typos corrected in test names and a comment.