### PR TITLE
feat: add typed vault config parsing with polymorphic YAML unmarshalling

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -297,7 +297,7 @@ key_bindings:
   K0:
     vault:
       name: "root-hsm-vault"
-      type: "aws-kms"
+      type: "open-bao"
   K1:
     vault:
       name: "root-vault"
@@ -329,13 +329,13 @@ topology:
         K2:
           vault:
             name: "aws-vault"
-            type: "aws-kms"
+            type: "open-bao"
           parent_key_provider:
             agent_name: "root"
         K3:
           vault:
             name: "aws-dek-vault"
-            type: "aws-kms"
+            type: "in-memory"
       labels:
         cloud: "aws"
 `
@@ -385,7 +385,7 @@ key_bindings:
   K0:
     vault:
       name: "vault"
-      type: "aws-kms"
+      type: "open-bao"
 hierarchy:
   name: "h"
   key_specs:

--- a/internal/spec/topology.go
+++ b/internal/spec/topology.go
@@ -3,6 +3,8 @@ package spec
 import (
 	"errors"
 	"fmt"
+
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -19,6 +21,14 @@ var (
 // Labels is a key-value map for metadata
 type Labels map[string]string
 
+// VaultType defines the type of vault (e.g., "open-bao", "aws-kms", "gcp-kms")
+type VaultType string
+
+const (
+	VaultTypeInMemory VaultType = "in-memory"
+	VaultTypeOpenBAO  VaultType = "open-bao"
+)
+
 // HierarchySegment represents a contiguous range of key kinds in the hierarchy
 type HierarchySegment struct {
 	StartKind string `yaml:"start_kind"` // First key kind in segment (e.g., "K2")
@@ -30,11 +40,16 @@ type ParentKeyProviderRef struct {
 	AgentName string `yaml:"agent_name"` // Agent name that provides parent keys
 }
 
+var (
+	_ yaml.Unmarshaler = (*VaultSpec)(nil)
+	_ yaml.Marshaler   = VaultSpec{}
+)
+
 // VaultSpec holds storage backend configuration
 type VaultSpec struct {
-	Name   string         `yaml:"name"`             // Vault identifier
-	Type   string         `yaml:"type"`             // Vault type (e.g., "open-bao", "aws-kms", "gcp-kms")
-	Params map[string]any `yaml:"params,omitempty"` // Type-specific configuration
+	Name   string      `yaml:"name"` // Vault identifier
+	Type   VaultType   `yaml:"type"` // Vault type (e.g., "open-bao", "aws-kms", "gcp-kms")
+	Config VaultConfig `yaml:"-"`    // Decoded vault config (not from YAML)
 }
 
 // KeyBinding encapsulates all dependencies needed to implement a key kind
@@ -108,5 +123,50 @@ func (t *Topology) Validate() error {
 			return fmt.Errorf("segment at index %d: %w", i, err)
 		}
 	}
+	return nil
+}
+
+// MarshalYAML implements [yaml.Marshaler].
+// Required because Config is tagged yaml:"-" to prevent interface decode issues.
+func (v VaultSpec) MarshalYAML() (any, error) {
+	type alias VaultSpec
+	return struct {
+		alias `yaml:",inline"`
+
+		Config VaultConfig `yaml:"config"`
+	}{
+		alias:  alias(v),
+		Config: v.Config,
+	}, nil
+}
+
+// UnmarshalYAML implements [yaml.Unmarshaler].
+func (v *VaultSpec) UnmarshalYAML(node *yaml.Node) error {
+	type alias VaultSpec
+	var raw struct {
+		alias `yaml:",inline"`
+
+		Config yaml.Node `yaml:"config"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return fmt.Errorf("failed to decode vault spec: %w", err)
+	}
+
+	var config VaultConfig
+	switch raw.Type {
+	case VaultTypeOpenBAO:
+		config = &OpenBAOConfig{}
+	case VaultTypeInMemory:
+		config = &InMemoryConfig{}
+	default:
+		return fmt.Errorf("unsupported vault type '%s': %w", raw.Type, ErrVaultConfigInvalid)
+	}
+
+	if err := raw.Config.Decode(config); err != nil {
+		return fmt.Errorf("failed to decode vault config: %w", err)
+	}
+
+	*v = VaultSpec(raw.alias)
+	v.Config = config
 	return nil
 }

--- a/internal/spec/topology_test.go
+++ b/internal/spec/topology_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestValidateHierarchySegment(t *testing.T) {
@@ -76,9 +77,8 @@ func TestValidateKeyBinding(t *testing.T) {
 			name: "valid binding with all fields",
 			binding: KeyBinding{
 				Vault: VaultSpec{
-					Name:   "my-vault",
-					Type:   "aws-kms",
-					Params: map[string]any{"region": "us-east-1"},
+					Name: "my-vault",
+					Type: "aws-kms",
 				},
 				ParentKeyProvider: &ParentKeyProviderRef{
 					AgentName: "root",
@@ -93,16 +93,6 @@ func TestValidateKeyBinding(t *testing.T) {
 				Vault: VaultSpec{
 					Name: "my-vault",
 					Type: "open-bao",
-				},
-			},
-			wantErr: nil,
-		},
-		{
-			name: "valid binding with nil params",
-			binding: KeyBinding{
-				Vault: VaultSpec{
-					Name: "my-vault",
-					Type: "gcp-kms",
 				},
 			},
 			wantErr: nil,
@@ -394,4 +384,175 @@ func TestValidateTopology(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVaultSpecUnMarshalYaml(t *testing.T) {
+	t.Run("unmarshal in-memory vault config", func(t *testing.T) {
+		// given
+		a := VaultSpec{
+			Name: "my-vault",
+			Type: VaultTypeInMemory,
+			Config: &InMemoryConfig{
+				Prefix: "my-prefix",
+			},
+		}
+
+		b, _ := yaml.Marshal(a)
+
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal(b, &vaultSpec)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "my-vault", vaultSpec.Name)
+		assert.Equal(t, VaultTypeInMemory, vaultSpec.Type)
+
+		inMemConfig, ok := vaultSpec.Config.(*InMemoryConfig)
+		assert.True(t, ok)
+		assert.Equal(t, "my-prefix", inMemConfig.Prefix)
+	})
+
+	t.Run("unmarshal open-bao vault config", func(t *testing.T) {
+		// given
+		a := VaultSpec{
+			Name: "my-vault",
+			Type: VaultTypeOpenBAO,
+			Config: &OpenBAOConfig{
+				ClusterAddress: "https://bao.example.com",
+			},
+		}
+
+		b, _ := yaml.Marshal(a)
+
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal(b, &vaultSpec)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "my-vault", vaultSpec.Name)
+		assert.Equal(t, VaultTypeOpenBAO, vaultSpec.Type)
+
+		openBaoConfig, ok := vaultSpec.Config.(*OpenBAOConfig)
+		assert.True(t, ok)
+		assert.Equal(t, "https://bao.example.com", openBaoConfig.ClusterAddress)
+	})
+
+	t.Run("unmarshal with missing config", func(t *testing.T) {
+		// given
+		a := VaultSpec{
+			Name: "my-vault",
+			Type: VaultTypeOpenBAO,
+		}
+
+		b, _ := yaml.Marshal(a)
+
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal(b, &vaultSpec)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "my-vault", vaultSpec.Name)
+		assert.Equal(t, VaultTypeOpenBAO, vaultSpec.Type)
+		assert.Equal(t, &OpenBAOConfig{}, vaultSpec.Config)
+	})
+
+	t.Run("unmarshal with unknown vault type", func(t *testing.T) {
+		// given
+		a := VaultSpec{
+			Name: "my-vault",
+			Type: "unknown-type",
+		}
+
+		b, _ := yaml.Marshal(a)
+
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal(b, &vaultSpec)
+
+		// then
+		assert.Error(t, err)
+	})
+
+	t.Run("unmarshal with invalid config type", func(t *testing.T) {
+		// given
+		a := VaultSpec{
+			Name: "my-vault",
+			Type: VaultTypeOpenBAO,
+			Config: &InMemoryConfig{
+				Prefix: "my-prefix",
+			},
+		}
+
+		b, _ := yaml.Marshal(a)
+
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal(b, &vaultSpec)
+
+		// then
+		assert.NoError(t, err)
+	})
+
+	t.Run("unmarshal with invalid config structure", func(t *testing.T) {
+		// given
+		yamlData := `
+name: my-vault
+type: open-bao
+config:
+	unexpected_field: value
+`
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal([]byte(yamlData), &vaultSpec)
+
+		// then
+		assert.Error(t, err)
+	})
+
+	t.Run("unmarshal with missing config field for open-bao", func(t *testing.T) {
+		// given
+		yamlData := `
+name: my-vault
+type: open-bao
+config:
+`
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal([]byte(yamlData), &vaultSpec)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "my-vault", vaultSpec.Name)
+		assert.Equal(t, VaultTypeOpenBAO, vaultSpec.Type)
+
+		openBaoConfig, ok := vaultSpec.Config.(*OpenBAOConfig)
+		assert.True(t, ok)
+		assert.Empty(t, openBaoConfig.ClusterAddress)
+	})
+
+	t.Run("should return error if the vault type is unknown", func(t *testing.T) {
+		// given
+		yamlData := `
+name: my-vault
+type: unknown-type
+config:
+`
+		var vaultSpec VaultSpec
+
+		// when
+		err := yaml.Unmarshal([]byte(yamlData), &vaultSpec)
+
+		// then
+		assert.Error(t, err)
+	})
 }

--- a/internal/spec/vaultconfig.go
+++ b/internal/spec/vaultconfig.go
@@ -1,0 +1,45 @@
+package spec
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrVaultConfigInvalid is returned when a vault configuration is invalid.
+var ErrVaultConfigInvalid = errors.New("invalid vault config")
+
+// VaultConfig is an interface that all vault configuration types must implement.
+type VaultConfig interface {
+	IsValidVaultConfig() error
+}
+
+// InMemoryConfig is a vault configuration for an in-memory vault.
+type InMemoryConfig struct {
+	Prefix string
+}
+
+// OpenBAOConfig is a vault configuration for an OpenBAO vault.
+type OpenBAOConfig struct {
+	ClusterAddress string
+}
+
+var (
+	_ VaultConfig = (*InMemoryConfig)(nil)
+	_ VaultConfig = (*OpenBAOConfig)(nil)
+)
+
+// IsValidVaultConfig checks if the InMemoryConfig is valid.
+func (i *InMemoryConfig) IsValidVaultConfig() error {
+	if i.Prefix == "" {
+		return fmt.Errorf("prefix cannot be empty: %w", ErrVaultConfigInvalid)
+	}
+	return nil
+}
+
+// IsValidVaultConfig checks if the OpenBAOConfig is valid.
+func (o *OpenBAOConfig) IsValidVaultConfig() error {
+	if o.ClusterAddress == "" {
+		return fmt.Errorf("cluster address cannot be empty: %w", ErrVaultConfigInvalid)
+	}
+	return nil
+}

--- a/internal/spec/vaultconfig_test.go
+++ b/internal/spec/vaultconfig_test.go
@@ -3,8 +3,9 @@ package spec_test
 import (
 	"testing"
 
-	"github.com/openkcm/krypton/internal/spec"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/internal/spec"
 )
 
 func TestOpenBaoVaultConfig(t *testing.T) {

--- a/internal/spec/vaultconfig_test.go
+++ b/internal/spec/vaultconfig_test.go
@@ -1,0 +1,72 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/openkcm/krypton/internal/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenBaoVaultConfig(t *testing.T) {
+	tts := []struct {
+		name   string
+		cfg    *spec.OpenBAOConfig
+		expErr error
+	}{
+		{
+			name: "empty cluster address",
+			cfg: &spec.OpenBAOConfig{
+				ClusterAddress: "",
+			},
+			expErr: spec.ErrVaultConfigInvalid,
+		},
+		{
+			name: "valid config",
+			cfg: &spec.OpenBAOConfig{
+				ClusterAddress: "test-cluster-address",
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.cfg.IsValidVaultConfig()
+
+			// then
+			assert.ErrorIs(t, err, tt.expErr)
+		})
+	}
+}
+
+func TestInMemoryConfig(t *testing.T) {
+	tts := []struct {
+		name   string
+		cfg    *spec.InMemoryConfig
+		expErr error
+	}{
+		{
+			name: "empty prefix",
+			cfg: &spec.InMemoryConfig{
+				Prefix: "",
+			},
+			expErr: spec.ErrVaultConfigInvalid,
+		},
+		{
+			name: "valid config",
+			cfg: &spec.InMemoryConfig{
+				Prefix: "test-prefix",
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.cfg.IsValidVaultConfig()
+
+			// then
+			assert.ErrorIs(t, err, tt.expErr)
+		})
+	}
+}


### PR DESCRIPTION
Introduce VaultConfig interface with InMemoryConfig and OpenBAOConfig implementations, and custom YAML marshal/unmarshal on VaultSpec to decode the config field based on vault type discriminator.
