### PR TITLE
add securebytes struct for more safety

### DIFF
--- a/internal/securemem/data.go
+++ b/internal/securemem/data.go
@@ -11,6 +11,11 @@ import (
 
 const Redacted = "<<REDACTED>>"
 
+// SecureBytes is a byte slice that implements various stringer and marshaler interfaces to prevent
+// accidental logging or printing of sensitive data. It always returns a redacted string representation,
+// regardless of the actual contents of the byte slice.
+type SecureBytes []byte
+
 // Data is a named, secure memory region backed by mmap'd anonymous memory
 // that is locked to physical RAM to prevent swapping. It supports toggling the
 // underlying memory between read-write and read-only modes via mprotect, and
@@ -18,7 +23,7 @@ const Redacted = "<<REDACTED>>"
 // the memory.
 type Data struct {
 	name       string
-	data       []byte
+	data       SecureBytes
 	isReadOnly bool
 	mux        sync.RWMutex
 }
@@ -27,14 +32,19 @@ var (
 	// This is to ensure that data secret is not accidentally logged or printed in any way.
 	// Ensure covers %s, %v, %+v
 	_ fmt.Stringer = (*Data)(nil)
+	_ fmt.Stringer = (SecureBytes)(nil)
 	// covers %#v
 	_ fmt.GoStringer = (*Data)(nil)
+	_ fmt.GoStringer = (SecureBytes)(nil)
 	// covers slog
 	_ slog.LogValuer = (*Data)(nil)
+	_ slog.LogValuer = (SecureBytes)(nil)
 	// covers structured loggers
 	_ encoding.TextMarshaler = (*Data)(nil)
+	_ encoding.TextMarshaler = (SecureBytes)(nil)
 	// covers JSON serialization
 	_ json.Marshaler = (*Data)(nil)
+	_ json.Marshaler = (SecureBytes)(nil)
 )
 
 // ErrInvalidSize is returned by NewData when the requested allocation
@@ -61,10 +71,10 @@ func NewData(name string, size int) (*Data, error) {
 	}, nil
 }
 
-// Bytes returns the underlying byte slice of the secure memory region. If the
+// SecureBytes returns the underlying byte slice of the secure memory region. If the
 // vault has been destroyed, it returns nil. The returned slice points directly
 // to the locked memory; callers must not hold references after Destroy is called.
-func (m *Data) Bytes() []byte {
+func (m *Data) SecureBytes() SecureBytes {
 	m.mux.RLock()
 	defer m.mux.RUnlock()
 
@@ -140,7 +150,7 @@ func (m *Data) IsReadOnly() bool {
 
 // String implements [fmt.Stringer].
 func (m *Data) String() string {
-	return fmt.Sprintf(`{"Name":"%s", "Value":"%s"}`, m.name, Redacted)
+	return fmt.Sprintf(`{"Name":"%s", "Value":"%s"}`, m.name, m.data.String())
 }
 
 // GoString implements [fmt.GoStringer].
@@ -161,4 +171,29 @@ func (m *Data) MarshalJSON() ([]byte, error) {
 // MarshalText implements [encoding.TextMarshaler].
 func (m *Data) MarshalText() (text []byte, err error) {
 	return []byte(m.String()), nil
+}
+
+// String implements [fmt.Stringer].
+func (s SecureBytes) String() string {
+	return Redacted
+}
+
+// GoString implements [fmt.GoStringer].
+func (s SecureBytes) GoString() string {
+	return Redacted
+}
+
+// LogValue implements [slog.LogValuer].
+func (s SecureBytes) LogValue() slog.Value {
+	return slog.StringValue(Redacted)
+}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (s SecureBytes) MarshalText() (text []byte, err error) {
+	return []byte(Redacted), nil
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (s SecureBytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(Redacted)
 }

--- a/internal/securemem/data_test.go
+++ b/internal/securemem/data_test.go
@@ -26,7 +26,7 @@ func TestNewWithSize(t *testing.T) {
 		})
 
 		// then
-		data := subj.Bytes()
+		data := subj.SecureBytes()
 		assert.Len(t, data, 64)
 
 		// mmap'd anonymous memory should be zeroed
@@ -68,10 +68,10 @@ func TestNewWithSize(t *testing.T) {
 		})
 
 		// when
-		copy(subj.Bytes(), secret)
+		copy(subj.SecureBytes(), secret)
 
 		// then
-		assert.Equal(t, secret, subj.Bytes())
+		assert.Equal(t, securemem.SecureBytes(secret), subj.SecureBytes())
 	})
 
 	t.Run("should allocate larger sizes", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestNewWithSize(t *testing.T) {
 		})
 
 		// then
-		data := subj.Bytes()
+		data := subj.SecureBytes()
 		assert.Len(t, data, expectedSize)
 
 		for _, b := range data {
@@ -97,7 +97,93 @@ func TestNewWithSize(t *testing.T) {
 	})
 }
 
-func TestAvoidLogPrints(t *testing.T) {
+func TestAvoidLogSecureBytesPrints(t *testing.T) {
+	// given
+	secret := []byte("super-secret-key")
+	data, err := securemem.NewData("test-key", len(secret))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := data.Destroy()
+		assert.NoError(t, err)
+	})
+
+	copy(data.SecureBytes(), secret)
+
+	subj := data.SecureBytes()
+
+	t.Run("should not leak data when printing with fmt.Printf", func(t *testing.T) {
+		tts := []struct {
+			format string
+		}{
+			{format: "%s"},
+			{format: "%v"},
+			{format: "%+v"},
+			{format: "%#v"},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.format, func(t *testing.T) {
+				var buf bytes.Buffer
+
+				// when
+				fmt.Fprintf(&buf, tt.format, subj)
+
+				got, err := io.ReadAll(&buf)
+
+				// then
+				require.NoError(t, err)
+				actString := string(got)
+				assert.Contains(t, actString, securemem.Redacted)
+				assert.NotContains(t, actString, string(secret))
+			})
+		}
+	})
+
+	t.Run("should not leak data in slog output", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+		// when
+		logger.Info("vault", "data", subj)
+
+		got, err := io.ReadAll(&buf)
+
+		// then
+		require.NoError(t, err)
+		actString := string(got)
+		assert.Contains(t, actString, securemem.Redacted)
+		assert.NotContains(t, actString, string(secret))
+	})
+
+	t.Run("should not leak data in MarshalJSON()", func(t *testing.T) {
+		// when
+		got, err := json.Marshal(subj)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, json.Valid(got))
+
+		var decoded string
+		err = json.Unmarshal(got, &decoded)
+		require.NoError(t, err)
+		assert.Contains(t, decoded, securemem.Redacted)
+		assert.NotContains(t, decoded, string(secret))
+	})
+
+	t.Run("should not leak data in MarshalText()", func(t *testing.T) {
+		// when
+		got, err := subj.MarshalText()
+
+		// then
+		require.NoError(t, err)
+		actString := string(got)
+		assert.Contains(t, actString, securemem.Redacted)
+		assert.NotContains(t, actString, string(secret))
+	})
+}
+
+func TestAvoidLogDataPrints(t *testing.T) {
 	// given
 	secret := []byte("super-secret-key")
 	subj, err := securemem.NewData("test-key", len(secret))
@@ -108,7 +194,7 @@ func TestAvoidLogPrints(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	copy(subj.Bytes(), secret)
+	copy(subj.SecureBytes(), secret)
 
 	t.Run("should not leak data when printing with fmt.Printf", func(t *testing.T) {
 		tts := []struct {
@@ -196,7 +282,7 @@ func TestDestroy(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Nil(t, subj.Bytes())
+		assert.Nil(t, subj.SecureBytes())
 	})
 
 	t.Run("should be idempotent", func(t *testing.T) {
@@ -215,7 +301,7 @@ func TestDestroy(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Nil(t, subj.Bytes())
+		assert.Nil(t, subj.SecureBytes())
 	})
 }
 
@@ -295,7 +381,7 @@ func TestReadonly(t *testing.T) {
 		require.NoError(t, err)
 
 		// then
-		assert.Nil(t, subj.Bytes())
+		assert.Nil(t, subj.SecureBytes())
 	})
 
 	t.Run("should preserve data after marking read-only", func(t *testing.T) {
@@ -309,14 +395,14 @@ func TestReadonly(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		copy(subj.Bytes(), secret)
+		copy(subj.SecureBytes(), secret)
 
 		// when
 		err = subj.MarkReadOnly()
 		assert.NoError(t, err)
 
 		// then
-		assert.Equal(t, secret, subj.Bytes())
+		assert.Equal(t, securemem.SecureBytes(secret), subj.SecureBytes())
 	})
 }
 

--- a/internal/securemem/memvault.go
+++ b/internal/securemem/memvault.go
@@ -23,8 +23,8 @@ func NewMemVault() *MemVault {
 	}
 }
 
-// Reserve creates a new Data instance with the given name and size, and stores it in the vault.
-func (v *MemVault) Reserve(name string, size int) ([]byte, error) {
+// Reserve creates a new Data instance with the given name and size, stores it in the vault, and returns its SecureBytes.
+func (v *MemVault) Reserve(name string, size int) (SecureBytes, error) {
 	v.mux.Lock()
 	defer v.mux.Unlock()
 
@@ -41,11 +41,12 @@ func (v *MemVault) Reserve(name string, size int) ([]byte, error) {
 	}
 
 	v.store[name] = data
-	return data.Bytes(), nil
+	return data.SecureBytes(), nil
 }
 
-// Get retrieves the byte slice associated with the given name from the vault.
-func (v *MemVault) Get(name string) ([]byte, bool) {
+// Get retrieves the SecureBytes associated with the given name from the vault.
+// It returns the SecureBytes and a boolean indicating whether the data was found.
+func (v *MemVault) Get(name string) (SecureBytes, bool) {
 	v.mux.RLock()
 	defer v.mux.RUnlock()
 
@@ -55,7 +56,7 @@ func (v *MemVault) Get(name string) ([]byte, bool) {
 		return nil, false
 	}
 
-	return data.Bytes(), true
+	return data.SecureBytes(), true
 }
 
 // Destroy securely destroys the Data instance associated with the given name and removes it from the vault.

--- a/internal/securemem/memvault_test.go
+++ b/internal/securemem/memvault_test.go
@@ -38,7 +38,7 @@ func TestGet(t *testing.T) {
 
 		// then
 		assert.True(t, ok)
-		assert.Equal(t, data, actResult)
+		assert.Equal(t, securemem.SecureBytes(data), actResult)
 	})
 
 	t.Run("should return false when data does not exist in vault", func(t *testing.T) {
@@ -165,13 +165,13 @@ func TestReserve(t *testing.T) {
 
 		actResult, ok := subj.Get(name)
 		assert.True(t, ok)
-		assert.Equal(t, data, actResult)
+		assert.Equal(t, securemem.SecureBytes(data), actResult)
 
 		data[0] = 'S'
 
 		actResult, ok = subj.Get(name)
 		assert.True(t, ok)
-		assert.Equal(t, []byte("secret"), actResult)
+		assert.Equal(t, securemem.SecureBytes([]byte("secret")), actResult)
 	})
 }
 
@@ -218,7 +218,7 @@ func TestVaultDestroy(t *testing.T) {
 
 			actBytes, ok = subj.Get(name2)
 			assert.True(t, ok)
-			assert.Equal(t, data2, actBytes)
+			assert.Equal(t, securemem.SecureBytes(data2), actBytes)
 
 			actBytes, ok = subj.Get(name3)
 			assert.False(t, ok)
@@ -299,7 +299,7 @@ func TestVaultDestroy(t *testing.T) {
 			// then
 			actBytes, ok := subj.Get(name)
 			assert.True(t, ok)
-			assert.Equal(t, data2, actBytes)
+			assert.Equal(t, securemem.SecureBytes(data2), actBytes)
 		})
 	})
 
@@ -419,11 +419,11 @@ func TestVaultDestroy(t *testing.T) {
 			// then
 			actBytes, ok := subj.Get(name1)
 			assert.True(t, ok)
-			assert.Equal(t, data1, actBytes)
+			assert.Equal(t, securemem.SecureBytes(data1), actBytes)
 
 			actBytes, ok = subj.Get(name2)
 			assert.True(t, ok)
-			assert.Equal(t, data2, actBytes)
+			assert.Equal(t, securemem.SecureBytes(data2), actBytes)
 		})
 	})
 }
@@ -458,11 +458,11 @@ func TestVaultMarkReadOnly(t *testing.T) {
 		// then
 		actBytes, ok := subj.Get(name1)
 		assert.True(t, ok)
-		assert.Equal(t, data1, actBytes)
+		assert.Equal(t, securemem.SecureBytes(data1), actBytes)
 
 		actBytes, ok = subj.Get(name2)
 		assert.True(t, ok)
-		assert.Equal(t, data2, actBytes)
+		assert.Equal(t, securemem.SecureBytes(data2), actBytes)
 	})
 
 	t.Run("should be idempotent when marking all data as read-only", func(t *testing.T) {
@@ -491,7 +491,7 @@ func TestVaultMarkReadOnly(t *testing.T) {
 		// then
 		actBytes, ok := subj.Get(name)
 		assert.True(t, ok)
-		assert.Equal(t, data, actBytes)
+		assert.Equal(t, securemem.SecureBytes(data), actBytes)
 	})
 
 	t.Run("should not return an error when vault is empty", func(t *testing.T) {

--- a/internal/securemem/test/readonlydata/main.go
+++ b/internal/securemem/test/readonlydata/main.go
@@ -32,7 +32,7 @@ func main() {
 	}()
 
 	// copy the secret data into the secure memory region
-	copy(data.Bytes(), []byte(SecretData))
+	copy(data.SecureBytes(), []byte(SecretData))
 
 	// make the memory region read-only
 	err = data.MarkReadOnly()
@@ -41,8 +41,8 @@ func main() {
 	}
 
 	// print the secret data
-	slog.Info(string(data.Bytes()))
+	slog.Info(string(data.SecureBytes()))
 
 	// attempt to modify the read-only memory region, which should cause a panic due to the read-only protection
-	data.Bytes()[0] = 's' // panic: runtime error: invalid memory address or nil pointer dereference
+	data.SecureBytes()[0] = 's' // panic: runtime error: invalid memory address or nil pointer dereference
 }


### PR DESCRIPTION
Introduces a new type SecureBytes []byte named type that prevents accidental leaking of secret data through printing, logging, or serialization. (edited)