### PR TITLE
feat: add GetKeyChain and GetKeyDescendants store operations

### DIFF
--- a/pkg/model/key.go
+++ b/pkg/model/key.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"iter"
+	"slices"
+
 	"github.com/google/uuid"
 
 	"github.com/openkcm/krypton/internal/clock"
@@ -32,6 +35,22 @@ type Key struct {
 	UpdatedAt clock.UnixNano `json:"updated_at"`
 }
 
+// KeyTree represents a hierarchical structure of keys, where each inner
+// slice represents a layer of keys in the hierarchy.
+type KeyTree [][]Key
+
+// KeyTreeTraverser defines methods for traversing a KeyTree in different orders.
+type KeyTreeTraverser interface {
+	// IterKeysByLayerAsc iterates the keys layer by layer in ascending order (from root to leaf).
+	IterKeysByLayerAsc() iter.Seq[[]Key]
+	// IterKeysByLayerDsc iterates the keys layer by layer in descending order (from leaf to root).
+	IterKeysByLayerDsc() iter.Seq[[]Key]
+	// IterLayerAsc iterates the key kinds layer by layer in ascending order (from root to leaf).
+	IterLayerAsc() iter.Seq[KeyKind]
+	// IterLayerDsc iterates the key kinds layer by layer in descending order (from leaf to root).
+	IterLayerDsc() iter.Seq[KeyKind]
+}
+
 func NewKey(tenantID, name string, kind string, parentID *string, managedBy string, labels Labels) Key {
 	now := clock.Now()
 	return Key{
@@ -45,5 +64,57 @@ func NewKey(tenantID, name string, kind string, parentID *string, managedBy stri
 		State:     KeyStatePreActivation,
 		CreatedAt: now,
 		UpdatedAt: now,
+	}
+}
+
+var _ KeyTreeTraverser = KeyTree{}
+
+// IterKeysByLayerAsc iterates the keys layer by layer in ascending order (from root to leaf).
+func (kt KeyTree) IterKeysByLayerAsc() iter.Seq[[]Key] {
+	return func(yield func([]Key) bool) {
+		for _, layer := range kt {
+			if !yield(layer) {
+				return
+			}
+		}
+	}
+}
+
+// IterKeysByLayerDsc iterates the keys layer by layer in descending order (from leaf to root).
+func (kt KeyTree) IterKeysByLayerDsc() iter.Seq[[]Key] {
+	return func(yield func([]Key) bool) {
+		for _, layer := range slices.Backward(kt) {
+			if !yield(layer) {
+				return
+			}
+		}
+	}
+}
+
+// IterLayerAsc iterates the key kinds layer by layer in ascending order (from root to leaf).
+func (kt KeyTree) IterLayerAsc() iter.Seq[KeyKind] {
+	return func(yield func(KeyKind) bool) {
+		for _, layer := range kt {
+			if len(layer) == 0 {
+				continue
+			}
+			if !yield(layer[0].Kind) {
+				return
+			}
+		}
+	}
+}
+
+// IterLayerDsc iterates the key kinds layer by layer in descending order (from leaf to root).
+func (kt KeyTree) IterLayerDsc() iter.Seq[KeyKind] {
+	return func(yield func(KeyKind) bool) {
+		for _, layer := range slices.Backward(kt) {
+			if len(layer) == 0 {
+				continue
+			}
+			if !yield(layer[0].Kind) {
+				return
+			}
+		}
 	}
 }

--- a/pkg/model/key_test.go
+++ b/pkg/model/key_test.go
@@ -1,4 +1,4 @@
-package store_test
+package model_test
 
 import (
 	"testing"
@@ -6,12 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openkcm/krypton/pkg/model"
-	"github.com/openkcm/krypton/pkg/store"
 )
 
 func TestKeyTreeTraversal(t *testing.T) {
 	// given
-	subj := store.KeyTree{
+	subj := model.KeyTree{
 		{
 			{ID: "A", Name: "A", Kind: "K0"},
 		},

--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"errors"
+	"iter"
+	"slices"
 
 	"github.com/openkcm/krypton/pkg/model"
 )
@@ -13,8 +15,11 @@ type Key interface {
 	CreateKey(ctx context.Context, key model.Key) error
 	GetKeyByID(ctx context.Context, id, tenantID string) (*model.Key, error)
 	GetKeyChain(ctx context.Context, query GetKeyChainQuery) (GetKeyChainResult, error)
-	GetKeyDescendants(ctx context.Context, query GetKeyDescendantsQuery) (GetKeyDescendantsResult, error)
+	GetKeyTree(ctx context.Context, query GetKeyTreeQuery) (GetKeyTreeResult, error)
 }
+
+// KeyTree represents a hierarchical structure of keys, where each inner slice represents a layer of keys in the hierarchy.
+type KeyTree [][]model.Key
 
 type GetKeyChainQuery struct {
 	KeyID    string
@@ -25,11 +30,75 @@ type GetKeyChainResult struct {
 	Keys []model.Key
 }
 
-type GetKeyDescendantsQuery struct {
+type GetKeyTreeQuery struct {
 	KeyID    string
 	TenantID string
 }
 
-type GetKeyDescendantsResult struct {
-	Keys [][]model.Key
+type GetKeyTreeResult struct {
+	KeyTree KeyTree
+}
+
+// KeyTreeTraverser defines methods for traversing a KeyTree in different orders.
+type KeyTreeTraverser interface {
+	// IterKeysByLayerAsc iterates the keys layer by layer in ascending order (from root to leaf).
+	IterKeysByLayerAsc() iter.Seq[[]model.Key]
+	// IterKeysByLayerDsc iterates the keys layer by layer in descending order (from leaf to root).
+	IterKeysByLayerDsc() iter.Seq[[]model.Key]
+	// IterLayerAsc iterates the key kinds layer by layer in ascending order (from root to leaf).
+	IterLayerAsc() iter.Seq[model.KeyKind]
+	// IterLayerDsc iterates the key kinds layer by layer in descending order (from leaf to root).
+	IterLayerDsc() iter.Seq[model.KeyKind]
+}
+
+var _ KeyTreeTraverser = KeyTree{}
+
+// IterKeysByLayerAsc iterates the keys layer by layer in ascending order (from root to leaf).
+func (kt KeyTree) IterKeysByLayerAsc() iter.Seq[[]model.Key] {
+	return func(yield func([]model.Key) bool) {
+		for _, layer := range kt {
+			if !yield(layer) {
+				return
+			}
+		}
+	}
+}
+
+// IterKeysByLayerDsc iterates the keys layer by layer in descending order (from leaf to root).
+func (kt KeyTree) IterKeysByLayerDsc() iter.Seq[[]model.Key] {
+	return func(yield func([]model.Key) bool) {
+		for _, layer := range slices.Backward(kt) {
+			if !yield(layer) {
+				return
+			}
+		}
+	}
+}
+
+// IterLayerAsc iterates the key kinds layer by layer in ascending order (from root to leaf).
+func (kt KeyTree) IterLayerAsc() iter.Seq[model.KeyKind] {
+	return func(yield func(model.KeyKind) bool) {
+		for _, layer := range kt {
+			if len(layer) == 0 {
+				continue
+			}
+			if !yield(layer[0].Kind) {
+				return
+			}
+		}
+	}
+}
+
+// IterLayerDsc iterates the key kinds layer by layer in descending order (from leaf to root).
+func (kt KeyTree) IterLayerDsc() iter.Seq[model.KeyKind] {
+	return func(yield func(model.KeyKind) bool) {
+		for _, layer := range slices.Backward(kt) {
+			if len(layer) == 0 {
+				continue
+			}
+			if !yield(layer[0].Kind) {
+				return
+			}
+		}
+	}
 }

--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -12,4 +12,24 @@ var ErrKeyNotFound = errors.New("key not found")
 type Key interface {
 	CreateKey(ctx context.Context, key model.Key) error
 	GetKeyByID(ctx context.Context, id, tenantID string) (*model.Key, error)
+	GetKeyChain(ctx context.Context, query GetKeyChainQuery) (GetKeyChainResult, error)
+	GetKeyDescendants(ctx context.Context, query GetKeyDescendantsQuery) (GetKeyDescendantsResult, error)
+}
+
+type GetKeyChainQuery struct {
+	KeyID    string
+	TenantID string
+}
+
+type GetKeyChainResult struct {
+	Keys []model.Key
+}
+
+type GetKeyDescendantsQuery struct {
+	KeyID    string
+	TenantID string
+}
+
+type GetKeyDescendantsResult struct {
+	Keys [][]model.Key
 }

--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -3,8 +3,6 @@ package store
 import (
 	"context"
 	"errors"
-	"iter"
-	"slices"
 
 	"github.com/openkcm/krypton/pkg/model"
 )
@@ -17,9 +15,6 @@ type Key interface {
 	GetKeyChain(ctx context.Context, query GetKeyChainQuery) (GetKeyChainResult, error)
 	GetKeyTree(ctx context.Context, query GetKeyTreeQuery) (GetKeyTreeResult, error)
 }
-
-// KeyTree represents a hierarchical structure of keys, where each inner slice represents a layer of keys in the hierarchy.
-type KeyTree [][]model.Key
 
 type GetKeyChainQuery struct {
 	KeyID    string
@@ -36,69 +31,5 @@ type GetKeyTreeQuery struct {
 }
 
 type GetKeyTreeResult struct {
-	KeyTree KeyTree
-}
-
-// KeyTreeTraverser defines methods for traversing a KeyTree in different orders.
-type KeyTreeTraverser interface {
-	// IterKeysByLayerAsc iterates the keys layer by layer in ascending order (from root to leaf).
-	IterKeysByLayerAsc() iter.Seq[[]model.Key]
-	// IterKeysByLayerDsc iterates the keys layer by layer in descending order (from leaf to root).
-	IterKeysByLayerDsc() iter.Seq[[]model.Key]
-	// IterLayerAsc iterates the key kinds layer by layer in ascending order (from root to leaf).
-	IterLayerAsc() iter.Seq[model.KeyKind]
-	// IterLayerDsc iterates the key kinds layer by layer in descending order (from leaf to root).
-	IterLayerDsc() iter.Seq[model.KeyKind]
-}
-
-var _ KeyTreeTraverser = KeyTree{}
-
-// IterKeysByLayerAsc iterates the keys layer by layer in ascending order (from root to leaf).
-func (kt KeyTree) IterKeysByLayerAsc() iter.Seq[[]model.Key] {
-	return func(yield func([]model.Key) bool) {
-		for _, layer := range kt {
-			if !yield(layer) {
-				return
-			}
-		}
-	}
-}
-
-// IterKeysByLayerDsc iterates the keys layer by layer in descending order (from leaf to root).
-func (kt KeyTree) IterKeysByLayerDsc() iter.Seq[[]model.Key] {
-	return func(yield func([]model.Key) bool) {
-		for _, layer := range slices.Backward(kt) {
-			if !yield(layer) {
-				return
-			}
-		}
-	}
-}
-
-// IterLayerAsc iterates the key kinds layer by layer in ascending order (from root to leaf).
-func (kt KeyTree) IterLayerAsc() iter.Seq[model.KeyKind] {
-	return func(yield func(model.KeyKind) bool) {
-		for _, layer := range kt {
-			if len(layer) == 0 {
-				continue
-			}
-			if !yield(layer[0].Kind) {
-				return
-			}
-		}
-	}
-}
-
-// IterLayerDsc iterates the key kinds layer by layer in descending order (from leaf to root).
-func (kt KeyTree) IterLayerDsc() iter.Seq[model.KeyKind] {
-	return func(yield func(model.KeyKind) bool) {
-		for _, layer := range slices.Backward(kt) {
-			if len(layer) == 0 {
-				continue
-			}
-			if !yield(layer[0].Kind) {
-				return
-			}
-		}
-	}
+	KeyTree model.KeyTreeTraverser
 }

--- a/pkg/store/key_test.go
+++ b/pkg/store/key_test.go
@@ -1,0 +1,122 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+)
+
+func TestKeyTreeTraversal(t *testing.T) {
+	// given
+	subj := store.KeyTree{
+		{
+			{ID: "A", Name: "A", Kind: "K0"},
+		},
+		{
+			{ID: "B", Name: "B", Kind: "K1"},
+			{ID: "C", Name: "C", Kind: "K1"},
+		},
+		{
+			{ID: "D", Name: "D", Kind: "K2"},
+			{ID: "E", Name: "E", Kind: "K2"},
+			{ID: "F", Name: "F", Kind: "K2"},
+			{ID: "G", Name: "G", Kind: "K2"},
+		},
+		{
+			{ID: "H", Name: "H", Kind: "K3"},
+		},
+	}
+
+	t.Run("IterKeysByLayerAsc should iterate layers in ascending order", func(t *testing.T) {
+		// given
+		expectedLayers := [][]model.Key{
+			{
+				{ID: "A", Name: "A", Kind: "K0"},
+			},
+			{
+				{ID: "B", Name: "B", Kind: "K1"},
+				{ID: "C", Name: "C", Kind: "K1"},
+			},
+			{
+				{ID: "D", Name: "D", Kind: "K2"},
+				{ID: "E", Name: "E", Kind: "K2"},
+				{ID: "F", Name: "F", Kind: "K2"},
+				{ID: "G", Name: "G", Kind: "K2"},
+			},
+			{
+				{ID: "H", Name: "H", Kind: "K3"},
+			},
+		}
+
+		i := 0
+		// when
+		for layer := range subj.IterKeysByLayerAsc() {
+			// then
+			assert.Equal(t, expectedLayers[i], layer)
+			i++
+		}
+		assert.Equal(t, len(expectedLayers), i)
+	})
+
+	t.Run("IterKeysByLayerDsc should iterate layers in descending order", func(t *testing.T) {
+		// given
+		expectedLayers := [][]model.Key{
+			{
+				{ID: "H", Name: "H", Kind: "K3"},
+			},
+			{
+				{ID: "D", Name: "D", Kind: "K2"},
+				{ID: "E", Name: "E", Kind: "K2"},
+				{ID: "F", Name: "F", Kind: "K2"},
+				{ID: "G", Name: "G", Kind: "K2"},
+			},
+			{
+				{ID: "B", Name: "B", Kind: "K1"},
+				{ID: "C", Name: "C", Kind: "K1"},
+			},
+			{
+				{ID: "A", Name: "A", Kind: "K0"},
+			},
+		}
+
+		i := 0
+		// when
+		for layer := range subj.IterKeysByLayerDsc() {
+			// then
+			assert.Equal(t, expectedLayers[i], layer)
+			i++
+		}
+		assert.Equal(t, len(expectedLayers), i)
+	})
+
+	t.Run("IterLayerAsc should iterate key kinds in ascending order", func(t *testing.T) {
+		// given
+		expectedKinds := []model.KeyKind{"K0", "K1", "K2", "K3"}
+
+		i := 0
+		// when
+		for kind := range subj.IterLayerAsc() {
+			//  then
+			assert.Equal(t, expectedKinds[i], kind)
+			i++
+		}
+		assert.Equal(t, len(expectedKinds), i)
+	})
+
+	t.Run("IterLayerDsc should iterate key kinds in descending order", func(t *testing.T) {
+		// given
+		expectedKinds := []model.KeyKind{"K3", "K2", "K1", "K0"}
+
+		i := 0
+		// when
+		for kind := range subj.IterLayerDsc() {
+			// then
+			assert.Equal(t, expectedKinds[i], kind)
+			i++
+		}
+		assert.Equal(t, len(expectedKinds), i)
+	})
+}

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -31,7 +31,8 @@ func (ks *KeyStore) CreateKey(ctx context.Context, key model.Key) error {
 		return err
 	}
 
-	_, err = ks.db.ExecContext(ctx, stmt,
+	_, err = ks.db.ExecContext(
+		ctx, stmt,
 		key.ID,
 		key.TenantID,
 		key.Kind,
@@ -55,6 +56,129 @@ func (ks *KeyStore) GetKeyByID(ctx context.Context, id, tenantID string) (*model
 	row := ks.db.QueryRowContext(ctx, stmt, id, tenantID)
 
 	return scanKey(row)
+}
+
+// GetKeyChain returns all ancestors of the given key (including itself) by traversing parent_id up to the root.
+func (ks *KeyStore) GetKeyChain(ctx context.Context, query store.GetKeyChainQuery) (store.GetKeyChainResult, error) {
+	stmt := `
+		WITH RECURSIVE key_chain AS (
+			SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at, 0 AS depth
+			FROM keys
+			WHERE id = $1 AND tenant_id = $2
+
+			UNION ALL
+
+			SELECT k.id, k.tenant_id, k.kind, k.name, k.parent_id, k.managed_by, k.labels, k.state, k.created_at, k.updated_at, kc.depth + 1
+			FROM keys k
+			INNER JOIN key_chain kc ON k.id = kc.parent_id AND k.tenant_id = kc.tenant_id
+		)
+		SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at
+		FROM key_chain
+		ORDER BY depth DESC
+	`
+
+	rows, err := ks.db.QueryContext(ctx, stmt, query.KeyID, query.TenantID)
+	if err != nil {
+		return store.GetKeyChainResult{}, err
+	}
+	defer rows.Close()
+
+	var keys []model.Key
+	for rows.Next() {
+		key, err := scanKey(rows)
+		if err != nil {
+			return store.GetKeyChainResult{}, err
+		}
+		keys = append(keys, *key)
+	}
+
+	if err := rows.Err(); err != nil {
+		return store.GetKeyChainResult{}, err
+	}
+
+	if len(keys) == 0 {
+		return store.GetKeyChainResult{}, store.ErrKeyNotFound
+	}
+
+	return store.GetKeyChainResult{Keys: keys}, nil
+}
+
+// GetKeyDescendants returns all descendants of the given key (including itself)
+// by traversing parent_id down to the leaves.
+// The result is grouped by depth level.
+func (ks *KeyStore) GetKeyDescendants(ctx context.Context, query store.GetKeyDescendantsQuery) (store.GetKeyDescendantsResult, error) {
+	stmt := `
+		WITH RECURSIVE key_tree AS (
+			SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at, 0 AS depth
+			FROM keys
+			WHERE id = $1 AND tenant_id = $2
+
+			UNION ALL
+
+			SELECT k.id, k.tenant_id, k.kind, k.name, k.parent_id, k.managed_by, k.labels, k.state, k.created_at, k.updated_at, kt.depth + 1
+			FROM keys k
+			INNER JOIN key_tree kt ON k.parent_id = kt.id AND k.tenant_id = kt.tenant_id
+		)
+		SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at, depth
+		FROM key_tree
+		ORDER BY depth ASC, created_at ASC
+	`
+
+	rows, err := ks.db.QueryContext(ctx, stmt, query.KeyID, query.TenantID)
+	if err != nil {
+		return store.GetKeyDescendantsResult{}, err
+	}
+	defer rows.Close()
+
+	var levels [][]model.Key
+	var found bool
+	for rows.Next() {
+		var key model.Key
+		var labelsData []byte
+		var depth int
+
+		err := rows.Scan(
+			&key.ID,
+			&key.TenantID,
+			&key.Kind,
+			&key.Name,
+			&key.ParentID,
+			&key.ManagedBy,
+			&labelsData,
+			&key.State,
+			&key.CreatedAt,
+			&key.UpdatedAt,
+			&depth,
+		)
+		if err != nil {
+			return store.GetKeyDescendantsResult{}, err
+		}
+
+		if len(labelsData) > 0 {
+			if err := json.Unmarshal(labelsData, &key.Labels); err != nil {
+				return store.GetKeyDescendantsResult{}, err
+			}
+		}
+
+		if depth == 0 {
+			found = true
+		}
+
+		for len(levels) <= depth {
+			levels = append(levels, nil)
+		}
+		levels[depth] = append(levels[depth], key)
+	}
+
+	if err := rows.Err(); err != nil {
+		return store.GetKeyDescendantsResult{}, err
+	}
+
+	if !found {
+		return store.GetKeyDescendantsResult{}, store.ErrKeyNotFound
+	}
+
+	return store.GetKeyDescendantsResult{Keys: levels}, nil
 }
 
 func scanKey(row interface{ Scan(...any) error }) (*model.Key, error) {

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -130,7 +130,7 @@ func (ks *KeyStore) GetKeyTree(ctx context.Context, query store.GetKeyTreeQuery)
 	}
 	defer rows.Close()
 
-	var layers [][]model.Key
+	var layers model.KeyTree
 	var found bool
 	for rows.Next() {
 		var key model.Key

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -103,10 +103,10 @@ func (ks *KeyStore) GetKeyChain(ctx context.Context, query store.GetKeyChainQuer
 	return store.GetKeyChainResult{Keys: keys}, nil
 }
 
-// GetKeyDescendants returns all descendants of the given key (including itself)
+// GetKeyTree returns all descendants of the given key (including itself)
 // by traversing parent_id down to the leaves.
 // The result is grouped by depth level.
-func (ks *KeyStore) GetKeyDescendants(ctx context.Context, query store.GetKeyDescendantsQuery) (store.GetKeyDescendantsResult, error) {
+func (ks *KeyStore) GetKeyTree(ctx context.Context, query store.GetKeyTreeQuery) (store.GetKeyTreeResult, error) {
 	stmt := `
 		WITH RECURSIVE key_tree AS (
 			SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at, 0 AS depth
@@ -126,11 +126,11 @@ func (ks *KeyStore) GetKeyDescendants(ctx context.Context, query store.GetKeyDes
 
 	rows, err := ks.db.QueryContext(ctx, stmt, query.KeyID, query.TenantID)
 	if err != nil {
-		return store.GetKeyDescendantsResult{}, err
+		return store.GetKeyTreeResult{}, err
 	}
 	defer rows.Close()
 
-	var levels [][]model.Key
+	var layers [][]model.Key
 	var found bool
 	for rows.Next() {
 		var key model.Key
@@ -151,12 +151,12 @@ func (ks *KeyStore) GetKeyDescendants(ctx context.Context, query store.GetKeyDes
 			&depth,
 		)
 		if err != nil {
-			return store.GetKeyDescendantsResult{}, err
+			return store.GetKeyTreeResult{}, err
 		}
 
 		if len(labelsData) > 0 {
 			if err := json.Unmarshal(labelsData, &key.Labels); err != nil {
-				return store.GetKeyDescendantsResult{}, err
+				return store.GetKeyTreeResult{}, err
 			}
 		}
 
@@ -164,21 +164,21 @@ func (ks *KeyStore) GetKeyDescendants(ctx context.Context, query store.GetKeyDes
 			found = true
 		}
 
-		for len(levels) <= depth {
-			levels = append(levels, nil)
+		for len(layers) <= depth {
+			layers = append(layers, nil)
 		}
-		levels[depth] = append(levels[depth], key)
+		layers[depth] = append(layers[depth], key)
 	}
 
 	if err := rows.Err(); err != nil {
-		return store.GetKeyDescendantsResult{}, err
+		return store.GetKeyTreeResult{}, err
 	}
 
 	if !found {
-		return store.GetKeyDescendantsResult{}, store.ErrKeyNotFound
+		return store.GetKeyTreeResult{}, store.ErrKeyNotFound
 	}
 
-	return store.GetKeyDescendantsResult{Keys: levels}, nil
+	return store.GetKeyTreeResult{KeyTree: layers}, nil
 }
 
 func scanKey(row interface{ Scan(...any) error }) (*model.Key, error) {

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -172,6 +172,7 @@ func TestGetKey(t *testing.T) {
 }
 
 func TestGetKeyChain(t *testing.T) {
+	// given
 	ctx := t.Context()
 	db, err := sql.Open("postgres", pgConnStr)
 	require.NoError(t, err)
@@ -184,8 +185,13 @@ func TestGetKeyChain(t *testing.T) {
 	h := createKeyHierarchy(t, keyStore, tenantStore)
 
 	t.Run("should get full key chain for leaf node", func(t *testing.T) {
+		// given
 		query := store.GetKeyChainQuery{KeyID: h.h.ID, TenantID: h.tenant.ID}
+
+		// when
 		result, err := keyStore.GetKeyChain(ctx, query)
+
+		// then
 		require.NoError(t, err)
 		require.Len(t, result.Keys, 4)
 		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
@@ -195,8 +201,13 @@ func TestGetKeyChain(t *testing.T) {
 	})
 
 	t.Run("should get key chain for intermediate node", func(t *testing.T) {
+		// given
 		query := store.GetKeyChainQuery{KeyID: h.c.ID, TenantID: h.tenant.ID}
+
+		// when
 		result, err := keyStore.GetKeyChain(ctx, query)
+
+		// then
 		require.NoError(t, err)
 		require.Len(t, result.Keys, 2)
 		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
@@ -204,8 +215,13 @@ func TestGetKeyChain(t *testing.T) {
 	})
 
 	t.Run("should get key chain for second intermediate node", func(t *testing.T) {
+		// given
 		query := store.GetKeyChainQuery{KeyID: h.e.ID, TenantID: h.tenant.ID}
+
+		// when
 		result, err := keyStore.GetKeyChain(ctx, query)
+
+		// then
 		require.NoError(t, err)
 		require.Len(t, result.Keys, 3)
 		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
@@ -214,27 +230,42 @@ func TestGetKeyChain(t *testing.T) {
 	})
 
 	t.Run("should get key chain for root node", func(t *testing.T) {
+		// given
 		query := store.GetKeyChainQuery{KeyID: h.root.ID, TenantID: h.tenant.ID}
+
+		// when
 		result, err := keyStore.GetKeyChain(ctx, query)
+
+		// then
 		require.NoError(t, err)
 		require.Len(t, result.Keys, 1)
 		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
 	})
 
 	t.Run("should return not found for nonexistent key", func(t *testing.T) {
+		// given
 		query := store.GetKeyChainQuery{KeyID: uuid.NewString(), TenantID: h.tenant.ID}
+
+		// when
 		_, err := keyStore.GetKeyChain(ctx, query)
+
+		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 
 	t.Run("should return not found for wrong tenant", func(t *testing.T) {
+		// given
 		query := store.GetKeyChainQuery{KeyID: h.h.ID, TenantID: uuid.NewString()}
+
+		// when
 		_, err := keyStore.GetKeyChain(ctx, query)
+
+		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 }
 
-func TestGetKeyDescendants(t *testing.T) {
+func TestGetKeyTree(t *testing.T) {
 	ctx := t.Context()
 	db, err := sql.Open("postgres", pgConnStr)
 	require.NoError(t, err)
@@ -246,57 +277,108 @@ func TestGetKeyDescendants(t *testing.T) {
 
 	k := createKeyHierarchy(t, keyStore, tenantStore)
 
-	t.Run("should get all descendants for root node", func(t *testing.T) {
-		query := store.GetKeyDescendantsQuery{KeyID: k.root.ID, TenantID: k.tenant.ID}
-		result, err := keyStore.GetKeyDescendants(ctx, query)
+	t.Run("should get all key tree for root node", func(t *testing.T) {
+		// given
+		query := store.GetKeyTreeQuery{KeyID: k.root.ID, TenantID: k.tenant.ID}
+
+		// when
+		result, err := keyStore.GetKeyTree(ctx, query)
+
+		// then
 		require.NoError(t, err)
-		require.Len(t, result.Keys, 4)                   // 4 levels total (depth 0-3)
-		require.Len(t, result.Keys[0], 1)                // depth 0: A
-		require.Len(t, result.Keys[1], 2)                // depth 1: B, C
-		require.Len(t, result.Keys[2], 4)                // depth 2: D, E, F, G
-		require.Len(t, result.Keys[3], 1)                // depth 3: H
-		assert.Equal(t, k.root.ID, result.Keys[0][0].ID) // A
-		assert.Equal(t, k.b.ID, result.Keys[1][0].ID)    // B
-		assert.Equal(t, k.c.ID, result.Keys[1][1].ID)    // C
-		assert.Equal(t, k.d.ID, result.Keys[2][0].ID)    // D
-		assert.Equal(t, k.e.ID, result.Keys[2][1].ID)    // E
-		assert.Equal(t, k.f.ID, result.Keys[2][2].ID)    // F
-		assert.Equal(t, k.g.ID, result.Keys[2][3].ID)    // G
-		assert.Equal(t, k.h.ID, result.Keys[3][0].ID)    // H
+		depth := 0
+		for layer := range result.KeyTree.IterKeysByLayerAsc() {
+			switch depth {
+			case 0:
+				require.Len(t, layer, 1)                // depth 0: A
+				assert.Equal(t, k.root.ID, layer[0].ID) // A
+			case 1:
+				require.Len(t, layer, 2)             // depth 1: B, C
+				assert.Equal(t, k.b.ID, layer[0].ID) // B
+				assert.Equal(t, k.c.ID, layer[1].ID) // C
+			case 2:
+				require.Len(t, layer, 4)             // depth 2: D, E, F, G
+				assert.Equal(t, k.d.ID, layer[0].ID) // D
+				assert.Equal(t, k.e.ID, layer[1].ID) // E
+				assert.Equal(t, k.f.ID, layer[2].ID) // F
+				assert.Equal(t, k.g.ID, layer[3].ID) // G
+			case 3:
+				require.Len(t, layer, 1)             // depth 3: H
+				assert.Equal(t, k.h.ID, layer[0].ID) // H
+			}
+			depth++
+		}
+		assert.Equal(t, 4, depth) // 4 levels total (depth 0-3)
 	})
 
-	t.Run("should get descendants for intermediate node", func(t *testing.T) {
-		query := store.GetKeyDescendantsQuery{KeyID: k.c.ID, TenantID: k.tenant.ID}
-		result, err := keyStore.GetKeyDescendants(ctx, query)
+	t.Run("should get tree for intermediate node", func(t *testing.T) {
+		// given
+		query := store.GetKeyTreeQuery{KeyID: k.c.ID, TenantID: k.tenant.ID}
+
+		// when
+		result, err := keyStore.GetKeyTree(ctx, query)
+
+		// then
 		require.NoError(t, err)
-		require.Len(t, result.Keys, 3)                // 3 depth levels below C including itself
-		require.Len(t, result.Keys[0], 1)             // depth 0: C
-		require.Len(t, result.Keys[1], 2)             // depth 1: F, G
-		require.Len(t, result.Keys[2], 1)             // depth 2: H
-		assert.Equal(t, k.c.ID, result.Keys[0][0].ID) // C
-		assert.Equal(t, k.f.ID, result.Keys[1][0].ID) // F
-		assert.Equal(t, k.g.ID, result.Keys[1][1].ID) // G
-		assert.Equal(t, k.h.ID, result.Keys[2][0].ID) // H
+		depth := 0
+		for layer := range result.KeyTree.IterKeysByLayerAsc() {
+			switch depth {
+			case 0:
+				require.Len(t, layer, 1)             // depth 0: C
+				assert.Equal(t, k.c.ID, layer[0].ID) // C
+			case 1:
+				require.Len(t, layer, 2)             // depth 1: F, G
+				assert.Equal(t, k.f.ID, layer[0].ID) // F
+				assert.Equal(t, k.g.ID, layer[1].ID) // G
+			case 2:
+				require.Len(t, layer, 1)             // depth 2: H
+				assert.Equal(t, k.h.ID, layer[0].ID) // H
+			}
+			depth++
+		}
+		require.Equal(t, 3, depth) // 3 depth levels below C including itself
 	})
 
 	t.Run("should get only self for leaf node", func(t *testing.T) {
-		query := store.GetKeyDescendantsQuery{KeyID: k.h.ID, TenantID: k.tenant.ID}
-		result, err := keyStore.GetKeyDescendants(ctx, query)
+		// given
+		query := store.GetKeyTreeQuery{KeyID: k.h.ID, TenantID: k.tenant.ID}
+
+		// when
+		result, err := keyStore.GetKeyTree(ctx, query)
+
+		// then
 		require.NoError(t, err)
-		require.Len(t, result.Keys, 1)                // 1 depth level below H including itself
-		require.Len(t, result.Keys[0], 1)             // depth 0: H
-		assert.Equal(t, k.h.ID, result.Keys[0][0].ID) // H
+		depth := 0
+		for layer := range result.KeyTree.IterKeysByLayerAsc() {
+			switch depth {
+			case 0:
+				require.Len(t, layer, 1)             // depth 0: H
+				assert.Equal(t, k.h.ID, layer[0].ID) // H
+			}
+			depth++
+		}
+		require.Equal(t, 1, depth) // 1 depth level below H including itself
 	})
 
 	t.Run("should return not found for nonexistent key", func(t *testing.T) {
-		query := store.GetKeyDescendantsQuery{KeyID: uuid.NewString(), TenantID: k.tenant.ID}
-		_, err := keyStore.GetKeyDescendants(ctx, query)
+		// given
+		query := store.GetKeyTreeQuery{KeyID: uuid.NewString(), TenantID: k.tenant.ID}
+
+		// when
+		_, err := keyStore.GetKeyTree(ctx, query)
+
+		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 
 	t.Run("should return not found for wrong tenant", func(t *testing.T) {
-		query := store.GetKeyDescendantsQuery{KeyID: k.root.ID, TenantID: uuid.NewString()}
-		_, err := keyStore.GetKeyDescendants(ctx, query)
+		// given
+		query := store.GetKeyTreeQuery{KeyID: k.root.ID, TenantID: uuid.NewString()}
+
+		// when
+		_, err := keyStore.GetKeyTree(ctx, query)
+
+		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 }

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -15,6 +15,28 @@ import (
 	storesql "github.com/openkcm/krypton/pkg/store/sql"
 )
 
+// keyHierarchy holds a test key tree with the following structure:
+//
+//	A(K0)
+//	  B(K1)
+//	    D(K2)
+//	    E(K2)
+//	  C(K1)
+//	    F(K2)
+//	    G(K2)
+//	      H(K3)
+type keyHierarchy struct {
+	tenant model.Tenant
+	root   model.Key // A
+	b      model.Key
+	c      model.Key
+	d      model.Key
+	e      model.Key
+	f      model.Key
+	g      model.Key
+	h      model.Key
+}
+
 func TestCreateKey(t *testing.T) {
 	ctx := t.Context()
 	db, err := sql.Open("postgres", pgConnStr)
@@ -147,6 +169,191 @@ func TestGetKey(t *testing.T) {
 		_, err := keyStore.GetKeyByID(ctx, key.ID, uuid.NewString())
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
+}
+
+func TestGetKeyChain(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	tenantStore := storesql.NewTenantStore(db)
+	require.NoError(t, storesql.Migrate(ctx, db))
+	keyStore := storesql.NewKeyStore(db)
+
+	h := createKeyHierarchy(t, keyStore, tenantStore)
+
+	t.Run("should get full key chain for leaf node", func(t *testing.T) {
+		query := store.GetKeyChainQuery{KeyID: h.h.ID, TenantID: h.tenant.ID}
+		result, err := keyStore.GetKeyChain(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 4)
+		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
+		assert.Equal(t, h.c.ID, result.Keys[1].ID)    // C
+		assert.Equal(t, h.g.ID, result.Keys[2].ID)    // G
+		assert.Equal(t, h.h.ID, result.Keys[3].ID)    // H
+	})
+
+	t.Run("should get key chain for intermediate node", func(t *testing.T) {
+		query := store.GetKeyChainQuery{KeyID: h.c.ID, TenantID: h.tenant.ID}
+		result, err := keyStore.GetKeyChain(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 2)
+		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
+		assert.Equal(t, h.c.ID, result.Keys[1].ID)    // C
+	})
+
+	t.Run("should get key chain for second intermediate node", func(t *testing.T) {
+		query := store.GetKeyChainQuery{KeyID: h.e.ID, TenantID: h.tenant.ID}
+		result, err := keyStore.GetKeyChain(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 3)
+		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
+		assert.Equal(t, h.b.ID, result.Keys[1].ID)    // B
+		assert.Equal(t, h.e.ID, result.Keys[2].ID)    // E
+	})
+
+	t.Run("should get key chain for root node", func(t *testing.T) {
+		query := store.GetKeyChainQuery{KeyID: h.root.ID, TenantID: h.tenant.ID}
+		result, err := keyStore.GetKeyChain(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 1)
+		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
+	})
+
+	t.Run("should return not found for nonexistent key", func(t *testing.T) {
+		query := store.GetKeyChainQuery{KeyID: uuid.NewString(), TenantID: h.tenant.ID}
+		_, err := keyStore.GetKeyChain(ctx, query)
+		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+	})
+
+	t.Run("should return not found for wrong tenant", func(t *testing.T) {
+		query := store.GetKeyChainQuery{KeyID: h.h.ID, TenantID: uuid.NewString()}
+		_, err := keyStore.GetKeyChain(ctx, query)
+		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+	})
+}
+
+func TestGetKeyDescendants(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	tenantStore := storesql.NewTenantStore(db)
+	require.NoError(t, storesql.Migrate(ctx, db))
+	keyStore := storesql.NewKeyStore(db)
+
+	k := createKeyHierarchy(t, keyStore, tenantStore)
+
+	t.Run("should get all descendants for root node", func(t *testing.T) {
+		query := store.GetKeyDescendantsQuery{KeyID: k.root.ID, TenantID: k.tenant.ID}
+		result, err := keyStore.GetKeyDescendants(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 4)                   // 4 levels total (depth 0-3)
+		require.Len(t, result.Keys[0], 1)                // depth 0: A
+		require.Len(t, result.Keys[1], 2)                // depth 1: B, C
+		require.Len(t, result.Keys[2], 4)                // depth 2: D, E, F, G
+		require.Len(t, result.Keys[3], 1)                // depth 3: H
+		assert.Equal(t, k.root.ID, result.Keys[0][0].ID) // A
+		assert.Equal(t, k.b.ID, result.Keys[1][0].ID)    // B
+		assert.Equal(t, k.c.ID, result.Keys[1][1].ID)    // C
+		assert.Equal(t, k.d.ID, result.Keys[2][0].ID)    // D
+		assert.Equal(t, k.e.ID, result.Keys[2][1].ID)    // E
+		assert.Equal(t, k.f.ID, result.Keys[2][2].ID)    // F
+		assert.Equal(t, k.g.ID, result.Keys[2][3].ID)    // G
+		assert.Equal(t, k.h.ID, result.Keys[3][0].ID)    // H
+	})
+
+	t.Run("should get descendants for intermediate node", func(t *testing.T) {
+		query := store.GetKeyDescendantsQuery{KeyID: k.c.ID, TenantID: k.tenant.ID}
+		result, err := keyStore.GetKeyDescendants(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 3)                // 3 depth levels below C including itself
+		require.Len(t, result.Keys[0], 1)             // depth 0: C
+		require.Len(t, result.Keys[1], 2)             // depth 1: F, G
+		require.Len(t, result.Keys[2], 1)             // depth 2: H
+		assert.Equal(t, k.c.ID, result.Keys[0][0].ID) // C
+		assert.Equal(t, k.f.ID, result.Keys[1][0].ID) // F
+		assert.Equal(t, k.g.ID, result.Keys[1][1].ID) // G
+		assert.Equal(t, k.h.ID, result.Keys[2][0].ID) // H
+	})
+
+	t.Run("should get only self for leaf node", func(t *testing.T) {
+		query := store.GetKeyDescendantsQuery{KeyID: k.h.ID, TenantID: k.tenant.ID}
+		result, err := keyStore.GetKeyDescendants(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 1)                // 1 depth level below H including itself
+		require.Len(t, result.Keys[0], 1)             // depth 0: H
+		assert.Equal(t, k.h.ID, result.Keys[0][0].ID) // H
+	})
+
+	t.Run("should return not found for nonexistent key", func(t *testing.T) {
+		query := store.GetKeyDescendantsQuery{KeyID: uuid.NewString(), TenantID: k.tenant.ID}
+		_, err := keyStore.GetKeyDescendants(ctx, query)
+		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+	})
+
+	t.Run("should return not found for wrong tenant", func(t *testing.T) {
+		query := store.GetKeyDescendantsQuery{KeyID: k.root.ID, TenantID: uuid.NewString()}
+		_, err := keyStore.GetKeyDescendants(ctx, query)
+		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+	})
+}
+
+//createKeyHierarchy sets up a test key hierarchy with 8 keys across 4 levels and returns the created keys for reference in tests.
+//// keyHierarchy holds a test key tree with the following structure:
+//
+//	A(K0)
+//	  B(K1)
+//	    D(K2)
+//	    E(K2)
+//	  C(K1)
+//	    F(K2)
+//	    G(K2)
+//	      H(K3)
+
+func createKeyHierarchy(t *testing.T, keyStore *storesql.KeyStore, tenantStore *storesql.TenantStore) keyHierarchy {
+	t.Helper()
+	ctx := t.Context()
+
+	tenant := createTenant(t, tenantStore)
+
+	root := model.NewKey(tenant.ID, "A", "K0", nil, "root", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, root))
+
+	b := model.NewKey(tenant.ID, "B", "K1", &root.ID, "root", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, b))
+
+	c := model.NewKey(tenant.ID, "C", "K1", &root.ID, "root", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, c))
+
+	d := model.NewKey(tenant.ID, "D", "K2", &b.ID, "agent-aws", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, d))
+
+	e := model.NewKey(tenant.ID, "E", "K2", &b.ID, "agent-azure", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, e))
+
+	f := model.NewKey(tenant.ID, "F", "K2", &c.ID, "agent-gcp", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, f))
+
+	g := model.NewKey(tenant.ID, "G", "K2", &c.ID, "agent-onprem", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, g))
+
+	h := model.NewKey(tenant.ID, "H", "K3", &g.ID, "agent-onprem-2", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, h))
+
+	return keyHierarchy{
+		tenant: tenant,
+		root:   root,
+		b:      b,
+		c:      c,
+		d:      d,
+		e:      e,
+		f:      f,
+		g:      g,
+		h:      h,
+	}
 }
 
 func createTenant(t *testing.T, s *storesql.TenantStore) model.Tenant {


### PR DESCRIPTION
This adds recursive CTE queries to traverse the key hierarchy — GetKeyChain walks ancestors upward, GetKeyTree walks children downward grouped by depth level.
