### PR TITLE
feat: implement AES-256-GCM encrypt/decrypt with secure memory

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/spec"
 	"github.com/openkcm/krypton/pkg/model"
 )
@@ -33,11 +34,11 @@ func validRootConfig() *RootConfig {
 			Name: "h",
 			KeySpecs: []spec.KeySpec{
 				{
-					Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256,
+					Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 				{
-					Kind: "K1", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256,
+					Kind: "K1", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{
 						Requirements: map[string]spec.LabelRequirement{
 							"env": {
@@ -158,9 +159,9 @@ func TestValidateRootConfig(t *testing.T) {
 				c.Hierarchy = spec.KeyHierarchy{
 					Name: "h",
 					KeySpecs: []spec.KeySpec{
-						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
 					},
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K1", EndKind: "K2"}
@@ -178,9 +179,9 @@ func TestValidateRootConfig(t *testing.T) {
 				c.Hierarchy = spec.KeyHierarchy{
 					Name: "h",
 					KeySpecs: []spec.KeySpec{
-						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K1", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K1", Role: spec.KeyRoleTek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
 					},
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
@@ -198,9 +199,9 @@ func TestValidateRootConfig(t *testing.T) {
 				c.Hierarchy = spec.KeyHierarchy{
 					Name: "h",
 					KeySpecs: []spec.KeySpec{
-						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K2", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
 					},
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
@@ -228,10 +229,10 @@ func TestValidateRootConfig(t *testing.T) {
 				c.Hierarchy = spec.KeyHierarchy{
 					Name: "h",
 					KeySpecs: []spec.KeySpec{
-						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
-						{Kind: "K3", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
+						{Kind: "K3", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256, LabelsSpec: validLabelsSpec()},
 					},
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}

--- a/internal/cryptor/aes256gcm.go
+++ b/internal/cryptor/aes256gcm.go
@@ -1,0 +1,189 @@
+package cryptor
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+const (
+	plainTextKey  = "plainText"
+	cipherTextKey = "cipherText"
+)
+
+type AES256GCM struct {
+	info Info
+}
+
+var _ Cryptor = &AES256GCM{}
+
+var ErrAllocatedDataNotFound = errors.New("allocated data not found in vault")
+
+func NewAES256GCM(name string) *AES256GCM {
+	return &AES256GCM{
+		info: Info{
+			Name:                     name,
+			DecryptionSecretRequired: true,
+		},
+	}
+}
+
+// Info returns metadata about the AES256GCM cryptor.
+func (a *AES256GCM) Info() Info {
+	return a.info
+}
+
+// Encrypt encrypts the plaintext using AES-256 in GCM mode with the provided key and AAD.
+func (a *AES256GCM) Encrypt(ctx context.Context, req EncryptRequest) (*EncryptResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	if req.Secret == nil {
+		return nil, fmt.Errorf("missing encryption secret: %w", ErrRequest)
+	}
+
+	secretSize := len(req.Secret.SecureBytes())
+	if secretSize != 32 {
+		return nil, fmt.Errorf("invalid key size: expected 32 bytes, got %d: %w", secretSize, ErrRequest)
+	}
+
+	resp, err := securemem.Run(ctx, func(ctx context.Context, hr *securemem.HandlerRequest) error {
+		// 1. Initialize AES-256 block cipher from the 32-byte key.
+		block, err := aes.NewCipher(req.Secret.SecureBytes())
+		if err != nil {
+			return fmt.Errorf("failed to create AES cipher: %w", err)
+		}
+
+		// 2. Wrap the block cipher in GCM mode for authenticated encryption.
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return fmt.Errorf("failed to create GCM: %w", err)
+		}
+
+		// 3. Compute total output size: nonce + ciphertext + auth tag.
+		nonceSize := gcm.NonceSize()
+		totalSealDataSize := nonceSize + len(req.Plaintext.SecureBytes()) + gcm.Overhead()
+
+		// 4. Reserve secure (mlock'd) memory in the persistent vault for the output.
+		cipherBytes, err := hr.PersistentVault().Reserve(cipherTextKey, totalSealDataSize)
+		if err != nil {
+			return fmt.Errorf("failed to allocate secure memory for ciphertext: %w", err)
+		}
+
+		// 5. Generate a random nonce and write it to the front of the output buffer.
+		nonce := cipherBytes[:nonceSize]
+		if _, err := rand.Read(nonce); err != nil {
+			return fmt.Errorf("failed to generate nonce: %w", err)
+		}
+
+		// 6. Seal plaintext into the buffer after the nonce.
+		//    Output layout: [nonce || ciphertext || tag]
+		gcm.Seal(cipherBytes[nonceSize:nonceSize], nonce, req.Plaintext.SecureBytes(), req.AAD)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// 7. Retrieve the sealed ciphertext from the (now read-only) vault.
+	cipherText, ok := resp.MemVault().Get(cipherTextKey)
+	if !ok {
+		// This should never happen since we just reserved this memory, but if it does, destroy all vault data to be safe.
+		err = resp.MemVault().DestroyAll()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("allocated ciphertext not found in vault after encryption: %w", ErrAllocatedDataNotFound)
+	}
+
+	return &EncryptResponse{
+		Ciphertext: cipherText,
+	}, nil
+}
+
+// Decrypt decrypts the ciphertext using AES-256 in GCM mode with the provided key and AAD.
+func (a *AES256GCM) Decrypt(ctx context.Context, req DecryptRequest) (*DecryptResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	if req.Secret == nil {
+		return nil, fmt.Errorf("missing decryption secret: %w", ErrRequest)
+	}
+
+	secretSize := len(req.Secret.SecureBytes())
+	if secretSize != 32 {
+		return nil, fmt.Errorf("invalid key size: expected 32 bytes, got %d: %w", secretSize, ErrRequest)
+	}
+
+	resp, err := securemem.Run(ctx, func(ctx context.Context, hr *securemem.HandlerRequest) error {
+		// 1. Initialize AES-256 block cipher from the 32-byte key.
+		block, err := aes.NewCipher(req.Secret.SecureBytes())
+		if err != nil {
+			return fmt.Errorf("failed to create AES cipher: %w", err)
+		}
+
+		// 2. Wrap the block cipher in GCM mode for authenticated decryption.
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return fmt.Errorf("failed to create GCM: %w", err)
+		}
+
+		nonceSize := gcm.NonceSize()
+		cipherTextSize := len(req.Ciphertext.SecureBytes())
+
+		// 3. Verify the ciphertext is at least nonce + tag bytes long.
+		if cipherTextSize < nonceSize+gcm.Overhead() {
+			return fmt.Errorf("ciphertext too short: %w", ErrRequest)
+		}
+
+		// 4. Compute plaintext size: total - nonce - tag.
+		plainTextSize := cipherTextSize - nonceSize - gcm.Overhead()
+
+		// 5. Reserve secure (mlock'd) memory in the persistent vault for the plaintext.
+		plainBytes, err := hr.PersistentVault().Reserve(plainTextKey, plainTextSize)
+		if err != nil {
+			return fmt.Errorf("failed to allocate secure memory for plaintext: %w", err)
+		}
+
+		// 6. Decrypt and authenticate. Open appends the plaintext into plainBytes'
+		//    backing array (passed as [:0] so it writes from the start).
+		//    Input layout: [nonce || ciphertext || tag]
+		_, err = gcm.Open(
+			plainBytes[:0],
+			req.Ciphertext.SecureBytes()[:nonceSize],
+			req.Ciphertext.SecureBytes()[nonceSize:],
+			req.AAD,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// 7. Retrieve the decrypted plaintext from the (now read-only) vault.
+	plainText, ok := resp.MemVault().Get(plainTextKey)
+	if !ok {
+		// This should never happen since we just reserved this memory, but if it does, destroy all vault data to be safe.
+		err = resp.MemVault().DestroyAll()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("allocated plaintext not found in vault after decryption: %w", ErrAllocatedDataNotFound)
+	}
+
+	return &DecryptResponse{
+		Plaintext: plainText,
+	}, nil
+}

--- a/internal/cryptor/aes256gcm.go
+++ b/internal/cryptor/aes256gcm.go
@@ -156,10 +156,13 @@ func (a *AES256GCM) Decrypt(ctx context.Context, req DecryptRequest) (*DecryptRe
 		// 6. Decrypt and authenticate. Open appends the plaintext into plainBytes'
 		//    backing array (passed as [:0] so it writes from the start).
 		//    Input layout: [nonce || ciphertext || tag]
+		nonce := req.Ciphertext.SecureBytes()[:nonceSize]
+		ciphertext := req.Ciphertext.SecureBytes()[nonceSize:]
+
 		_, err = gcm.Open(
 			plainBytes[:0],
-			req.Ciphertext.SecureBytes()[:nonceSize],
-			req.Ciphertext.SecureBytes()[nonceSize:],
+			nonce,
+			ciphertext,
 			req.AAD,
 		)
 		if err != nil {

--- a/internal/cryptor/aes256gcm.go
+++ b/internal/cryptor/aes256gcm.go
@@ -24,10 +24,10 @@ var _ Cryptor = &AES256GCM{}
 
 var ErrAllocatedDataNotFound = errors.New("allocated data not found in vault")
 
-func NewAES256GCM(name string) *AES256GCM {
+func NewAES256GCM() *AES256GCM {
 	return &AES256GCM{
 		info: Info{
-			Name:                     name,
+			Name:                     InfoNameAES256GCM,
 			DecryptionSecretRequired: true,
 		},
 	}

--- a/internal/cryptor/aes256gcm_test.go
+++ b/internal/cryptor/aes256gcm_test.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/securemem"
-	"github.com/openkcm/krypton/internal/spec"
 )
 
 func TestAES256GCM_Encrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj := cryptor.NewAES256GCM("aes256-gcm")
+	subj := cryptor.NewAES256GCM()
 
 	t.Run("should fail if encrypt request validation fails", func(t *testing.T) {
 		// given
@@ -23,7 +22,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Plaintext:  nil, // missing plaintext
 		}
 
@@ -45,7 +44,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Plaintext:  plainText,
 			Secret:     nil, // missing secret
 		}
@@ -75,7 +74,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Plaintext:  plainText,
 			Secret:     secret,
 		}
@@ -106,7 +105,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Plaintext:  plainText,
 			Secret:     secret, // invalid key size
 		}
@@ -136,7 +135,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Plaintext:  plainText,
 			Secret:     secret,
 		}
@@ -171,7 +170,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Plaintext:  plainText,
 			Secret:     secret,
 		}
@@ -190,7 +189,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 func TestAES256GCM_Decrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj := cryptor.NewAES256GCM("aes256-gcm")
+	subj := cryptor.NewAES256GCM()
 
 	t.Run("should fail if decrypt request validation fails", func(t *testing.T) {
 		// given
@@ -198,7 +197,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Ciphertext: nil, // missing ciphertext
 		}
 
@@ -220,7 +219,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Ciphertext: cipherText,
 			Secret:     nil, // missing secret
 		}
@@ -248,7 +247,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Ciphertext: cipherText,
 			Secret:     secret, // invalid key size
 		}
@@ -278,7 +277,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Ciphertext: cipherText,
 			Secret:     secret,
 		}
@@ -298,7 +297,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj := cryptor.NewAES256GCM("aes256-gcm")
+	subj := cryptor.NewAES256GCM()
 
 	// given
 	// allocate a 32-byte AES key in secure memory
@@ -342,7 +341,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Plaintext:  plainText,
 		})
@@ -360,7 +359,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Ciphertext: encResp.Ciphertext,
 		})
@@ -386,7 +385,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Plaintext:  plainText,
 			AAD:        aad,
@@ -402,7 +401,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Ciphertext: encResp.Ciphertext,
 			AAD:        aad,
@@ -425,7 +424,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secretKey,
 			Plaintext:  plainText,
 			AAD:        []byte("correct-aad"),
@@ -441,7 +440,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secretKey,
 			Ciphertext: encResp.Ciphertext,
 			AAD:        []byte("wrong-aad"),
@@ -463,7 +462,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret1,
 			Plaintext:  plainText,
 		})
@@ -478,7 +477,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret2,
 			Ciphertext: encResp.Ciphertext,
 		})
@@ -498,7 +497,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Plaintext:  plaintText,
 		})
@@ -522,7 +521,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Ciphertext: tampered,
 		})
@@ -542,7 +541,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Plaintext:  plainText,
 		})
@@ -564,7 +563,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Ciphertext: truncated,
 		})
@@ -584,7 +583,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Plaintext:  plainText,
 		})
@@ -595,7 +594,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
 			KeyVersion: 1,
-			Algorithm:  spec.KeyAlgorithmAES256,
+			Algorithm:  cryptor.KeyAlgorithmAES256,
 			Secret:     secret,
 			Ciphertext: encResp.Ciphertext,
 		})
@@ -610,12 +609,12 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 func TestAES256GCM_Info(t *testing.T) {
 	// given
-	subj := cryptor.NewAES256GCM("aes256-gcm")
+	subj := cryptor.NewAES256GCM()
 
 	// when
 	info := subj.Info()
 
 	// then
-	assert.Equal(t, "aes256-gcm", info.Name)
+	assert.Equal(t, cryptor.InfoNameAES256GCM, info.Name)
 	assert.True(t, info.DecryptionSecretRequired)
 }

--- a/internal/cryptor/aes256gcm_test.go
+++ b/internal/cryptor/aes256gcm_test.go
@@ -606,49 +606,6 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		assert.NotNil(t, secret.SecureBytes())
 		assert.NotNil(t, encResp.Ciphertext.SecureBytes())
 	})
-
-	// t.Run("should encrypt and decrypt for empty plaintext successfully", func(t *testing.T) {
-	// 	// given
-	// 	key := newKey(t)
-	// 	plaintext := []byte("")
-	// 	pt := newPlaintext(t, plaintext)
-	//
-	// 	// when
-	// 	// encrypt
-	// 	encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-	// 		TenantID:   "tenant-1",
-	// 		KeyID:      "key-1",
-	// 		KeyVersion: 1,
-	// 		Algorithm:  spec.KeyAlgorithmAES256,
-	// 		Secret:     key,
-	// 		Plaintext:  pt,
-	// 	})
-	//
-	// 	// then
-	// 	require.NoError(t, err)
-	// 	t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
-	//
-	// 	// ciphertext must differ from plaintext
-	// 	assert.NotEqual(t, plaintext, []byte(encResp.Ciphertext.SecureBytes()))
-	//
-	// 	// when
-	// 	// decrypt
-	// 	decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-	// 		TenantID:   "tenant-1",
-	// 		KeyID:      "key-1",
-	// 		KeyVersion: 1,
-	// 		Algorithm:  spec.KeyAlgorithmAES256,
-	// 		Secret:     key,
-	// 		Ciphertext: encResp.Ciphertext,
-	// 	})
-	//
-	// 	// then
-	// 	require.NoError(t, err)
-	// 	t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
-	//
-	// 	// recovered plaintext must match original
-	// 	assert.Equal(t, plaintext, []byte(decResp.Plaintext.SecureBytes()))
-	// })
 }
 
 func TestAES256GCM_Info(t *testing.T) {

--- a/internal/cryptor/aes256gcm_test.go
+++ b/internal/cryptor/aes256gcm_test.go
@@ -1,0 +1,664 @@
+package cryptor_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/securemem"
+	"github.com/openkcm/krypton/internal/spec"
+)
+
+func TestAES256GCM_Encrypt(t *testing.T) {
+	// given
+	ctx := t.Context()
+	subj := cryptor.NewAES256GCM("aes256-gcm")
+
+	t.Run("should fail if encrypt request validation fails", func(t *testing.T) {
+		// given
+		req := cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Plaintext:  nil, // missing plaintext
+		}
+
+		// when
+		resp, err := subj.Encrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should fail if encryption secret is missing", func(t *testing.T) {
+		// given
+		plainText, err := securemem.NewData("plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = plainText.Destroy() })
+
+		req := cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Plaintext:  plainText,
+			Secret:     nil, // missing secret
+		}
+
+		// when
+		resp, err := subj.Encrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should fail to encrypt if plaintext data is destroyed", func(t *testing.T) {
+		// given
+		plainText, err := securemem.NewData("plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = plainText.Destroy() })
+
+		secret, err := securemem.NewData("key", 32)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = secret.Destroy() })
+
+		_, err = rand.Read(secret.SecureBytes())
+		require.NoError(t, err)
+
+		req := cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Plaintext:  plainText,
+			Secret:     secret,
+		}
+
+		// destroy plaintext before encryption
+		require.NoError(t, plainText.Destroy())
+
+		// when
+		resp, err := subj.Encrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should fail if secret key size is invalid", func(t *testing.T) {
+		// given
+		plainText, err := securemem.NewData("plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = plainText.Destroy() })
+
+		// invalid secret size (should be 32 bytes for AES-256)
+		secret, err := securemem.NewData("key", 16)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = secret.Destroy() })
+
+		req := cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Plaintext:  plainText,
+			Secret:     secret, // invalid key size
+		}
+
+		// when
+		resp, err := subj.Encrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should generate different ciphertext for same plaintext and key", func(t *testing.T) {
+		// given
+		plainText, err := securemem.NewData("same-plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = plainText.Destroy() })
+
+		secret, err := securemem.NewData("same-key", 32)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = secret.Destroy() })
+
+		_, err = rand.Read(secret.SecureBytes())
+		require.NoError(t, err)
+
+		req := cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Plaintext:  plainText,
+			Secret:     secret,
+		}
+
+		// when
+		resp1, err := subj.Encrypt(ctx, req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp1.Ciphertext.Destroy() })
+
+		resp2, err := subj.Encrypt(ctx, req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp2.Ciphertext.Destroy() })
+
+		// then
+		assert.NotEqual(t, resp1.Ciphertext.SecureBytes(), resp2.Ciphertext.SecureBytes())
+	})
+
+	t.Run("should not destroy secret and plaintext after encryption", func(t *testing.T) {
+		// given
+		plainText, err := securemem.NewData("plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = plainText.Destroy() })
+
+		secret, err := securemem.NewData("key", 32)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = secret.Destroy() })
+
+		_, err = rand.Read(secret.SecureBytes())
+		require.NoError(t, err)
+
+		req := cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Plaintext:  plainText,
+			Secret:     secret,
+		}
+
+		// when
+		resp, err := subj.Encrypt(ctx, req)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = resp.Ciphertext.Destroy() })
+
+		// then
+		assert.NotNil(t, plainText.SecureBytes())
+		assert.NotNil(t, secret.SecureBytes())
+	})
+}
+
+func TestAES256GCM_Decrypt(t *testing.T) {
+	// given
+	ctx := t.Context()
+	subj := cryptor.NewAES256GCM("aes256-gcm")
+
+	t.Run("should fail if decrypt request validation fails", func(t *testing.T) {
+		// given
+		req := cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Ciphertext: nil, // missing ciphertext
+		}
+
+		// when
+		resp, err := subj.Decrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should fail if encryption secret is missing", func(t *testing.T) {
+		// given
+		cipherText, err := securemem.NewData("plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = cipherText.Destroy() })
+
+		req := cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Ciphertext: cipherText,
+			Secret:     nil, // missing secret
+		}
+
+		// when
+		resp, err := subj.Decrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should fail if secret key size is invalid", func(t *testing.T) {
+		// given
+		cipherText, err := securemem.NewData("plaintext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = cipherText.Destroy() })
+
+		// invalid secret size (should be 32 bytes for AES-256)
+		secret, err := securemem.NewData("key", 16)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = secret.Destroy() })
+
+		req := cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Ciphertext: cipherText,
+			Secret:     secret, // invalid key size
+		}
+
+		// when
+		resp, err := subj.Decrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should fail to decrypt if ciphertext data is destroyed", func(t *testing.T) {
+		// given
+		cipherText, err := securemem.NewData("ciphertext", 1)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = cipherText.Destroy() })
+
+		secret, err := securemem.NewData("key", 32)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = secret.Destroy() })
+
+		_, err = rand.Read(secret.SecureBytes())
+		require.NoError(t, err)
+
+		req := cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Ciphertext: cipherText,
+			Secret:     secret,
+		}
+
+		// destroy ciphertext before decryption
+		require.NoError(t, cipherText.Destroy())
+
+		// when
+		resp, err := subj.Decrypt(ctx, req)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestAES256GCM_EncryptDecrypt(t *testing.T) {
+	// given
+	ctx := t.Context()
+	subj := cryptor.NewAES256GCM("aes256-gcm")
+
+	// given
+	// allocate a 32-byte AES key in secure memory
+	newSecretKey := func(t *testing.T) *securemem.Data {
+		t.Helper()
+
+		key, err := securemem.NewData("test-key", 32)
+		require.NoError(t, err)
+
+		_, err = rand.Read(key.SecureBytes())
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = key.Destroy() })
+
+		return key
+	}
+
+	// allocate plaintext in secure memory
+	newPlaintext := func(t *testing.T, content []byte) *securemem.Data {
+		t.Helper()
+
+		pt, err := securemem.NewData("test-plaintext", len(content))
+		require.NoError(t, err)
+
+		copy(pt.SecureBytes(), content)
+
+		t.Cleanup(func() { _ = pt.Destroy() })
+
+		return pt
+	}
+
+	t.Run("should encrypt and decrypt plaintext successfully", func(t *testing.T) {
+		// given
+		secret := newSecretKey(t)
+		text := []byte("hello, secure world!")
+		plainText := newPlaintext(t, text)
+
+		// when
+		// encrypt
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Plaintext:  plainText,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		// ciphertext must differ from plaintext
+		assert.NotEqual(t, text, []byte(encResp.Ciphertext.SecureBytes()))
+
+		// when
+		// decrypt
+		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Ciphertext: encResp.Ciphertext,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+
+		// recovered plaintext must match original
+		assert.Equal(t, text, []byte(decResp.Plaintext.SecureBytes()))
+	})
+
+	t.Run("should encrypt and decrypt with AAD successfully", func(t *testing.T) {
+		// given
+		secret := newSecretKey(t)
+		text := []byte("authenticated payload")
+		plainText := newPlaintext(t, text)
+		aad := []byte("context-binding-data")
+
+		// when
+		// encrypt with AAD
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Plaintext:  plainText,
+			AAD:        aad,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		// when
+		// decrypt with same AAD succeeds
+		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Ciphertext: encResp.Ciphertext,
+			AAD:        aad,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+
+		assert.Equal(t, text, []byte(decResp.Plaintext.SecureBytes()))
+	})
+
+	t.Run("should fail to decrypt with wrong AAD", func(t *testing.T) {
+		// given
+		secretKey := newSecretKey(t)
+		plainText := newPlaintext(t, []byte("secret"))
+
+		// when
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secretKey,
+			Plaintext:  plainText,
+			AAD:        []byte("correct-aad"),
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		// when
+		// decrypt with wrong AAD must fail
+		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secretKey,
+			Ciphertext: encResp.Ciphertext,
+			AAD:        []byte("wrong-aad"),
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, decResp)
+	})
+
+	t.Run("should fail to decrypt with wrong key", func(t *testing.T) {
+		// given
+		secret1 := newSecretKey(t)
+		secret2 := newSecretKey(t)
+		plainText := newPlaintext(t, []byte("secret"))
+
+		// when
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret1,
+			Plaintext:  plainText,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		// when
+		// decrypt with different key must fail
+		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret2,
+			Ciphertext: encResp.Ciphertext,
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, decResp)
+	})
+
+	t.Run("should fail to decrypt tampered ciphertext", func(t *testing.T) {
+		// given
+		secret := newSecretKey(t)
+		plaintText := newPlaintext(t, []byte("do not tamper"))
+
+		// when
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Plaintext:  plaintText,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		// copy ciphertext into writable secure memory and flip a byte
+		ct := encResp.Ciphertext.SecureBytes()
+		tampered, err := securemem.NewData("tampered", len(ct))
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = tampered.Destroy() })
+
+		copy(tampered.SecureBytes(), ct)
+		tampered.SecureBytes()[len(ct)-1] ^= 0xFF
+
+		// when
+		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Ciphertext: tampered,
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, decResp)
+	})
+
+	t.Run("should fail to decrypt if cipher is too short to contain nonce and tag", func(t *testing.T) {
+		// given
+		secret := newSecretKey(t)
+		plainText := newPlaintext(t, []byte("short cipher"))
+
+		// when
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Plaintext:  plainText,
+		})
+
+		// then
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		// create a truncated ciphertext that is too short to contain nonce and tag
+		ct := encResp.Ciphertext.SecureBytes()
+		truncated, err := securemem.NewData("truncated", 8) // too short for nonce+tag
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = truncated.Destroy() })
+		copy(truncated.SecureBytes(), ct[:8])
+
+		// when
+		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Ciphertext: truncated,
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, decResp)
+	})
+
+	t.Run("should not destroy secret and ciphertext after decryption attempt", func(t *testing.T) {
+		// given
+		secret := newSecretKey(t)
+		plainText := newPlaintext(t, []byte("plaintext"))
+
+		// when
+		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Plaintext:  plainText,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+
+		decResp, _ := subj.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: 1,
+			Algorithm:  spec.KeyAlgorithmAES256,
+			Secret:     secret,
+			Ciphertext: encResp.Ciphertext,
+		})
+
+		t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+
+		// then
+		assert.NotNil(t, secret.SecureBytes())
+		assert.NotNil(t, encResp.Ciphertext.SecureBytes())
+	})
+
+	// t.Run("should encrypt and decrypt for empty plaintext successfully", func(t *testing.T) {
+	// 	// given
+	// 	key := newKey(t)
+	// 	plaintext := []byte("")
+	// 	pt := newPlaintext(t, plaintext)
+	//
+	// 	// when
+	// 	// encrypt
+	// 	encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
+	// 		TenantID:   "tenant-1",
+	// 		KeyID:      "key-1",
+	// 		KeyVersion: 1,
+	// 		Algorithm:  spec.KeyAlgorithmAES256,
+	// 		Secret:     key,
+	// 		Plaintext:  pt,
+	// 	})
+	//
+	// 	// then
+	// 	require.NoError(t, err)
+	// 	t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+	//
+	// 	// ciphertext must differ from plaintext
+	// 	assert.NotEqual(t, plaintext, []byte(encResp.Ciphertext.SecureBytes()))
+	//
+	// 	// when
+	// 	// decrypt
+	// 	decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
+	// 		TenantID:   "tenant-1",
+	// 		KeyID:      "key-1",
+	// 		KeyVersion: 1,
+	// 		Algorithm:  spec.KeyAlgorithmAES256,
+	// 		Secret:     key,
+	// 		Ciphertext: encResp.Ciphertext,
+	// 	})
+	//
+	// 	// then
+	// 	require.NoError(t, err)
+	// 	t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+	//
+	// 	// recovered plaintext must match original
+	// 	assert.Equal(t, plaintext, []byte(decResp.Plaintext.SecureBytes()))
+	// })
+}
+
+func TestAES256GCM_Info(t *testing.T) {
+	// given
+	subj := cryptor.NewAES256GCM("aes256-gcm")
+
+	// when
+	info := subj.Info()
+
+	// then
+	assert.Equal(t, "aes256-gcm", info.Name)
+	assert.True(t, info.DecryptionSecretRequired)
+}

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -100,7 +100,7 @@ func (req EncryptRequest) Validate() error {
 	if req.KeyVersion == 0 {
 		return fmt.Errorf("invalid key version: %w", ErrRequest)
 	}
-	if req.Plaintext == nil {
+	if req.Plaintext == nil || req.Plaintext.SecureBytes() == nil {
 		return fmt.Errorf("invalid plaintext: %w", ErrRequest)
 	}
 	return nil
@@ -116,7 +116,7 @@ func (req DecryptRequest) Validate() error {
 	if req.KeyVersion == 0 {
 		return fmt.Errorf("invalid key version: %w", ErrRequest)
 	}
-	if req.Ciphertext == nil {
+	if req.Ciphertext == nil || req.Ciphertext.SecureBytes() == nil {
 		return fmt.Errorf("invalid ciphertext: %w", ErrRequest)
 	}
 	return nil

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -8,8 +8,19 @@ import (
 	"fmt"
 
 	"github.com/openkcm/krypton/internal/securemem"
-	"github.com/openkcm/krypton/internal/spec"
 )
+
+// KeyAlgorithm identifies the encryption algorithm used by a key.
+type KeyAlgorithm string
+
+// KeyAlgorithmAES256 represents the AES-256 encryption algorithm.
+const KeyAlgorithmAES256 KeyAlgorithm = "AES256"
+
+// InfoName identifies the type of information returned by the Info() method of a Cryptor.
+type InfoName string
+
+// InfoNameAES256GCM indicates that the Cryptor supports AES-256 in Galois/Counter Mode (GCM).
+const InfoNameAES256GCM InfoName = "AES256-GCM"
 
 // EncryptRequest contains parameters for an encryption operation.
 type EncryptRequest struct {
@@ -20,7 +31,7 @@ type EncryptRequest struct {
 	// KeyVersion specifies which version of the key to use.
 	KeyVersion int
 	// Algorithm is the encryption algorithm to apply.
-	Algorithm spec.KeyAlgorithm
+	Algorithm KeyAlgorithm
 	// Secret is the key material used for encryption.
 	// The Secret is nil if Cryptor manages its own secrets (e.g., HSM).
 	Secret *securemem.Data
@@ -46,7 +57,7 @@ type DecryptRequest struct {
 	// KeyVersion specifies which version of the key to use.
 	KeyVersion int
 	// Algorithm is the encryption algorithm that was used.
-	Algorithm spec.KeyAlgorithm
+	Algorithm KeyAlgorithm
 	// Secret is the key material used for decryption.
 	// The Secret is nil if Cryptor manages its own secrets (e.g., HSM).
 	Secret *securemem.Data
@@ -66,7 +77,7 @@ type DecryptResponse struct {
 // Info describes a Cryptor implementation's capabilities.
 type Info struct {
 	// Name is a human-readable identifier for the implementation.
-	Name string
+	Name InfoName
 	// DecryptionSecretRequired is false if cryptor manages its own secret (e.g., HSM).
 	DecryptionSecretRequired bool
 }

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -100,7 +100,7 @@ func (req EncryptRequest) Validate() error {
 	if req.KeyVersion == 0 {
 		return fmt.Errorf("invalid key version: %w", ErrRequest)
 	}
-	if req.Plaintext == nil || req.Plaintext.SecureBytes() == nil {
+	if req.Plaintext == nil || len(req.Plaintext.SecureBytes()) == 0 {
 		return fmt.Errorf("invalid plaintext: %w", ErrRequest)
 	}
 	return nil
@@ -116,7 +116,7 @@ func (req DecryptRequest) Validate() error {
 	if req.KeyVersion == 0 {
 		return fmt.Errorf("invalid key version: %w", ErrRequest)
 	}
-	if req.Ciphertext == nil || req.Ciphertext.SecureBytes() == nil {
+	if req.Ciphertext == nil || len(req.Ciphertext.SecureBytes()) == 0 {
 		return fmt.Errorf("invalid ciphertext: %w", ErrRequest)
 	}
 	return nil

--- a/internal/cryptor/cryptor_test.go
+++ b/internal/cryptor/cryptor_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/securemem"
@@ -11,6 +12,19 @@ import (
 
 func TestDecryptRequestValidate(t *testing.T) {
 	// given
+	validData, err := securemem.NewData("valid", 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = validData.Destroy()
+	})
+
+	destroyedData, err := securemem.NewData("destroyed", 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = destroyedData.Destroy()
+	})
+	_ = destroyedData.Destroy()
+
 	tts := []struct {
 		name    string
 		req     cryptor.DecryptRequest
@@ -22,7 +36,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 				TenantID:   "tenant1",
 				KeyID:      "key1",
 				KeyVersion: 1,
-				Ciphertext: &securemem.Data{},
+				Ciphertext: validData,
 			},
 			wantErr: nil,
 		},
@@ -32,7 +46,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 				TenantID:   "tenant1",
 				KeyID:      "key1",
 				KeyVersion: -1,
-				Ciphertext: &securemem.Data{},
+				Ciphertext: validData,
 			},
 			wantErr: nil,
 		},
@@ -73,6 +87,16 @@ func TestDecryptRequestValidate(t *testing.T) {
 			},
 			wantErr: cryptor.ErrRequest,
 		},
+		{
+			name: "destroyed ciphertext",
+			req: cryptor.DecryptRequest{
+				TenantID:   "tenant1",
+				KeyID:      "key1",
+				KeyVersion: 1,
+				Ciphertext: destroyedData,
+			},
+			wantErr: cryptor.ErrRequest,
+		},
 	}
 
 	for _, tt := range tts {
@@ -88,6 +112,19 @@ func TestDecryptRequestValidate(t *testing.T) {
 
 func TestEncryptRequestValidate(t *testing.T) {
 	// given
+	validData, err := securemem.NewData("valid", 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = validData.Destroy()
+	})
+
+	destroyedData, err := securemem.NewData("destroyed", 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = destroyedData.Destroy()
+	})
+	_ = destroyedData.Destroy()
+
 	tts := []struct {
 		name    string
 		req     cryptor.EncryptRequest
@@ -99,7 +136,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 				TenantID:   "tenant1",
 				KeyID:      "key1",
 				KeyVersion: 1,
-				Plaintext:  &securemem.Data{},
+				Plaintext:  validData,
 			},
 			wantErr: nil,
 		},
@@ -109,7 +146,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 				TenantID:   "tenant1",
 				KeyID:      "key1",
 				KeyVersion: -1,
-				Plaintext:  &securemem.Data{},
+				Plaintext:  validData,
 			},
 			wantErr: nil,
 		},
@@ -147,6 +184,16 @@ func TestEncryptRequestValidate(t *testing.T) {
 				TenantID:   "tenant1",
 				KeyID:      "key1",
 				KeyVersion: 1,
+			},
+			wantErr: cryptor.ErrRequest,
+		},
+		{
+			name: "destroyed plaintext",
+			req: cryptor.EncryptRequest{
+				TenantID:   "tenant1",
+				KeyID:      "key1",
+				KeyVersion: 1,
+				Plaintext:  destroyedData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},

--- a/internal/cryptor/cryptor_test.go
+++ b/internal/cryptor/cryptor_test.go
@@ -97,6 +97,16 @@ func TestDecryptRequestValidate(t *testing.T) {
 			},
 			wantErr: cryptor.ErrRequest,
 		},
+		{
+			name: "empty securememe data",
+			req: cryptor.DecryptRequest{
+				TenantID:   "tenant1",
+				KeyID:      "key1",
+				KeyVersion: 1,
+				Ciphertext: &securemem.Data{},
+			},
+			wantErr: cryptor.ErrRequest,
+		},
 	}
 
 	for _, tt := range tts {
@@ -194,6 +204,16 @@ func TestEncryptRequestValidate(t *testing.T) {
 				KeyID:      "key1",
 				KeyVersion: 1,
 				Plaintext:  destroyedData,
+			},
+			wantErr: cryptor.ErrRequest,
+		},
+		{
+			name: "empty securemem data",
+			req: cryptor.EncryptRequest{
+				TenantID:   "tenant1",
+				KeyID:      "key1",
+				KeyVersion: 1,
+				Plaintext:  &securemem.Data{},
 			},
 			wantErr: cryptor.ErrRequest,
 		},

--- a/internal/securemem/data_test.go
+++ b/internal/securemem/data_test.go
@@ -466,21 +466,23 @@ func TestSubSlicingRetainstheUnderlyingdatastructure(t *testing.T) {
 			dataByteB[i] = byte(i)
 		}
 
-		// sameUnderlying reports whether slices a and b overlap in memory (by capacity).
-		//	Case 1: Overlap → true        Case 2: No overlap → false
+		// sameUnderlying reports whether slice a is fully contained within
+		// the memory region of slice b (by capacity).
 		//
-		//	aStart           aEnd          aStart   aEnd
-		//	├────── cap(a) ──┤             ├─cap(a)─┤
-		//	┌──┬──┬──┬──┬──┬──┐           ┌──┬──┬──┐
-		//	│  │  │  │  │  │  │           │  │  │  │
-		//	└──┴──┴──┴──┴──┴──┘           └──┴──┴──┘
-		//	      ┌──┬──┬──┬──┬──┬──┐                  ┌──┬──┬──┐
-		//	      │  │  │  │  │  │  │                  │  │  │  │
-		//	      └──┴──┴──┴──┴──┴──┘                  └──┴──┴──┘
-		//	      ├────── cap(b) ──┤                   ├─cap(b)─┤
-		//	      bStart           bEnd                bStart   bEnd
+		//	Case 1: Contained → true       Case 2: Not contained → false
 		//
-		//	aStart<=bEnd ✓ && bStart<=aEnd ✓    bStart<=aEnd ✗ → false
+		//	bStart                 bEnd     aStart         aEnd
+		//	├────── cap(b) ────────┤        ├── cap(a) ────┤
+		//	┌──┬──┬──┬──┬──┬──┬──┬──┐      ┌──┬──┬──┬──┬──┐
+		//	│  │  │  │  │  │  │  │  │      │  │  │  │  │  │
+		//	└──┴──┴──┴──┴──┴──┴──┴──┘      └──┴──┴──┴──┴──┘
+		//	      ┌──┬──┬──┐                            ┌──┬──┬──┐
+		//	      │  │  │  │                            │  │  │  │
+		//	      └──┴──┴──┘                            └──┴──┴──┘
+		//	      ├─cap(a)─┤                            ├─cap(b)─┤
+		//	      aStart   aEnd                         bStart   bEnd
+		//
+		//	bStart<=aStart ✓ && aEnd<=bEnd ✓    bStart<=aStart ✗ → false
 		sameUnderLying := func(a, b []byte) bool {
 			if len(a) == 0 || len(b) == 0 {
 				return false
@@ -490,8 +492,8 @@ func TestSubSlicingRetainstheUnderlyingdatastructure(t *testing.T) {
 			bStart := unsafe.SliceData(b)
 			bEnd := unsafe.Add(unsafe.Pointer(bStart), uintptr(cap(b)-1)*unsafe.Sizeof(b[0]))
 
-			return uintptr(unsafe.Pointer(aStart)) <= uintptr(bEnd) &&
-				uintptr(unsafe.Pointer(bStart)) <= uintptr(aEnd)
+			return uintptr(unsafe.Pointer(bStart)) <= uintptr(unsafe.Pointer(aStart)) &&
+				uintptr(aEnd) <= uintptr(bEnd)
 		}
 
 		// when

--- a/internal/securemem/data_test.go
+++ b/internal/securemem/data_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -423,5 +424,83 @@ func TestName(t *testing.T) {
 
 		// then
 		assert.Equal(t, name, got)
+	})
+}
+
+// TestSubSlicingRetainsUnderlyingMemory verifies that sub-slicing a
+// securemem.Data slice produces slices that still reference the same
+// underlying memory region, ensuring no hidden copies are made.
+//
+// This matters because securemem.Data is backed by protected memory
+// (e.g., mlock'd pages). If sub-slicing triggered a copy, the derived
+// slice would escape to unprotected heap memory, defeating the purpose.
+//
+// The test uses an interval-overlap check on raw pointers to confirm
+// that any sub-slice's backing array intersects the original:
+//
+//	Original securemem allocation (cap=10)
+//	┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+//	│ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │  ← dataByteA
+//	└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+//	        ├───────────┤
+//	        dataByteA[2:5]  → still points into the same region ✓
+//
+//	Separate heap allocation (cap=10)
+//	┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
+//	│ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │  ← dataByteB
+//	└───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
+//	        → different memory, no overlap ✗
+func TestSubSlicingRetainstheUnderlyingdatastructure(t *testing.T) {
+	t.Run("sub slice shares underlying array", func(t *testing.T) {
+		// given
+		data, err := securemem.NewData("test-data", 10)
+		require.NoError(t, err)
+
+		dataByteA := data.SecureBytes()
+		for i := range dataByteA {
+			dataByteA[i] = byte(i)
+		}
+
+		dataByteB := make([]byte, 10)
+		for i := range dataByteB {
+			dataByteB[i] = byte(i)
+		}
+
+		// sameUnderlying reports whether slices a and b overlap in memory (by capacity).
+		//	Case 1: Overlap → true        Case 2: No overlap → false
+		//
+		//	aStart           aEnd          aStart   aEnd
+		//	├────── cap(a) ──┤             ├─cap(a)─┤
+		//	┌──┬──┬──┬──┬──┬──┐           ┌──┬──┬──┐
+		//	│  │  │  │  │  │  │           │  │  │  │
+		//	└──┴──┴──┴──┴──┴──┘           └──┴──┴──┘
+		//	      ┌──┬──┬──┬──┬──┬──┐                  ┌──┬──┬──┐
+		//	      │  │  │  │  │  │  │                  │  │  │  │
+		//	      └──┴──┴──┴──┴──┴──┘                  └──┴──┴──┘
+		//	      ├────── cap(b) ──┤                   ├─cap(b)─┤
+		//	      bStart           bEnd                bStart   bEnd
+		//
+		//	aStart<=bEnd ✓ && bStart<=aEnd ✓    bStart<=aEnd ✗ → false
+		sameUnderLying := func(a, b []byte) bool {
+			if len(a) == 0 || len(b) == 0 {
+				return false
+			}
+			aStart := unsafe.SliceData(a)
+			aEnd := unsafe.Add(unsafe.Pointer(aStart), uintptr(cap(a)-1)*unsafe.Sizeof(a[0]))
+			bStart := unsafe.SliceData(b)
+			bEnd := unsafe.Add(unsafe.Pointer(bStart), uintptr(cap(b)-1)*unsafe.Sizeof(b[0]))
+
+			return uintptr(unsafe.Pointer(aStart)) <= uintptr(bEnd) &&
+				uintptr(unsafe.Pointer(bStart)) <= uintptr(aEnd)
+		}
+
+		// when
+		assert.False(t, sameUnderLying(dataByteA, dataByteB))
+		assert.True(t, sameUnderLying(dataByteA[:1], dataByteA))
+		assert.True(t, sameUnderLying(dataByteA[:5][:2], dataByteA))
+		assert.True(t, sameUnderLying(dataByteA[2:], dataByteA))
+		assert.True(t, sameUnderLying(dataByteA[2:][:3], dataByteA))
+		assert.True(t, sameUnderLying(dataByteA[2:5], dataByteA))
+		assert.True(t, sameUnderLying(dataByteA[2:5][:1], dataByteA))
 	})
 }

--- a/internal/securemem/handler.go
+++ b/internal/securemem/handler.go
@@ -80,6 +80,11 @@ func Run(ctx context.Context, handler Handler) (*HandlerResponse, error) {
 			}
 		}
 
+		// Sever references to the vaults so the GC below can finalize any
+		// unreachable vault data; prevents the request from holding them alive.
+		req.persistentVault = nil
+		req.temporaryVault = nil
+
 		// calling GC here to ensure that any vault data that is no longer referenced is
 		// collected and finalized before we mark the persistent vault as read-only.
 		// This is important because if there are any vault data that are still referenced,

--- a/internal/securemem/handler_test.go
+++ b/internal/securemem/handler_test.go
@@ -108,9 +108,9 @@ func TestHandlerRequestRun(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 
-			actBytes, ok := resp.MemVault().Get("foo")
+			actData, ok := resp.MemVault().Get("foo")
 			assert.True(t, ok)
-			assert.Equal(t, "bar", string(actBytes))
+			assert.Equal(t, "bar", string(actData.SecureBytes()))
 		})
 
 		t.Run("should not persist values in tmp vault", func(t *testing.T) {
@@ -139,9 +139,9 @@ func TestHandlerRequestRun(t *testing.T) {
 				}
 				copy(b, []byte("bar"))
 
-				actBytes, ok := req.TemporaryVault().Get("foo")
+				actData, ok := req.TemporaryVault().Get("foo")
 				assert.True(t, ok)
-				assert.Equal(t, "bar", string(actBytes))
+				assert.Equal(t, "bar", string(actData.SecureBytes()))
 				return nil
 			})
 
@@ -159,9 +159,9 @@ func TestHandlerRequestRun(t *testing.T) {
 				}
 				copy(b, []byte("bar"))
 
-				actBytes, ok := req.PersistentVault().Get("foo")
+				actData, ok := req.PersistentVault().Get("foo")
 				assert.True(t, ok)
-				assert.Equal(t, "bar", string(actBytes))
+				assert.Equal(t, "bar", string(actData.SecureBytes()))
 				return nil
 			})
 

--- a/internal/securemem/memvault.go
+++ b/internal/securemem/memvault.go
@@ -44,9 +44,9 @@ func (v *MemVault) Reserve(name string, size int) (SecureBytes, error) {
 	return data.SecureBytes(), nil
 }
 
-// Get retrieves the SecureBytes associated with the given name from the vault.
-// It returns the SecureBytes and a boolean indicating whether the data was found.
-func (v *MemVault) Get(name string) (SecureBytes, bool) {
+// Get retrieves the Data instance associated with the given name from the vault.
+// It returns the Data instance and a boolean indicating whether the data was found in the vault.
+func (v *MemVault) Get(name string) (*Data, bool) {
 	v.mux.RLock()
 	defer v.mux.RUnlock()
 
@@ -56,7 +56,7 @@ func (v *MemVault) Get(name string) (SecureBytes, bool) {
 		return nil, false
 	}
 
-	return data.SecureBytes(), true
+	return data, true
 }
 
 // Destroy securely destroys the Data instance associated with the given name and removes it from the vault.

--- a/internal/securemem/memvault_test.go
+++ b/internal/securemem/memvault_test.go
@@ -38,7 +38,7 @@ func TestGet(t *testing.T) {
 
 		// then
 		assert.True(t, ok)
-		assert.Equal(t, securemem.SecureBytes(data), actResult)
+		assert.Equal(t, securemem.SecureBytes(data), actResult.SecureBytes())
 	})
 
 	t.Run("should return false when data does not exist in vault", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestReserve(t *testing.T) {
 			// then
 			actResult, ok := subj.Get(name)
 			assert.True(t, ok)
-			assert.Equal(t, name, string(actResult))
+			assert.Equal(t, name, string(actResult.SecureBytes()))
 		}
 	})
 
@@ -165,13 +165,13 @@ func TestReserve(t *testing.T) {
 
 		actResult, ok := subj.Get(name)
 		assert.True(t, ok)
-		assert.Equal(t, securemem.SecureBytes(data), actResult)
+		assert.Equal(t, securemem.SecureBytes(data), actResult.SecureBytes())
 
 		data[0] = 'S'
 
 		actResult, ok = subj.Get(name)
 		assert.True(t, ok)
-		assert.Equal(t, securemem.SecureBytes([]byte("secret")), actResult)
+		assert.Equal(t, securemem.SecureBytes([]byte("secret")), actResult.SecureBytes())
 	})
 }
 
@@ -212,17 +212,17 @@ func TestVaultDestroy(t *testing.T) {
 			assert.NoError(t, err)
 
 			// then
-			actBytes, ok := subj.Get(name1)
+			actData, ok := subj.Get(name1)
 			assert.False(t, ok)
-			assert.Nil(t, actBytes)
+			assert.Nil(t, actData)
 
-			actBytes, ok = subj.Get(name2)
+			actData, ok = subj.Get(name2)
 			assert.True(t, ok)
-			assert.Equal(t, securemem.SecureBytes(data2), actBytes)
+			assert.Equal(t, securemem.SecureBytes(data2), actData.SecureBytes())
 
-			actBytes, ok = subj.Get(name3)
+			actData, ok = subj.Get(name3)
 			assert.False(t, ok)
-			assert.Nil(t, actBytes)
+			assert.Nil(t, actData)
 		})
 
 		t.Run("should be idempotent when destroying data", func(t *testing.T) {
@@ -297,9 +297,9 @@ func TestVaultDestroy(t *testing.T) {
 			copy(b, data2)
 
 			// then
-			actBytes, ok := subj.Get(name)
+			actData, ok := subj.Get(name)
 			assert.True(t, ok)
-			assert.Equal(t, securemem.SecureBytes(data2), actBytes)
+			assert.Equal(t, securemem.SecureBytes(data2), actData.SecureBytes())
 		})
 	})
 
@@ -417,13 +417,13 @@ func TestVaultDestroy(t *testing.T) {
 			copy(b, data2)
 
 			// then
-			actBytes, ok := subj.Get(name1)
+			actData, ok := subj.Get(name1)
 			assert.True(t, ok)
-			assert.Equal(t, securemem.SecureBytes(data1), actBytes)
+			assert.Equal(t, securemem.SecureBytes(data1), actData.SecureBytes())
 
-			actBytes, ok = subj.Get(name2)
+			actData, ok = subj.Get(name2)
 			assert.True(t, ok)
-			assert.Equal(t, securemem.SecureBytes(data2), actBytes)
+			assert.Equal(t, securemem.SecureBytes(data2), actData.SecureBytes())
 		})
 	})
 }
@@ -456,13 +456,13 @@ func TestVaultMarkReadOnly(t *testing.T) {
 		assert.NoError(t, err)
 
 		// then
-		actBytes, ok := subj.Get(name1)
+		actData, ok := subj.Get(name1)
 		assert.True(t, ok)
-		assert.Equal(t, securemem.SecureBytes(data1), actBytes)
+		assert.Equal(t, securemem.SecureBytes(data1), actData.SecureBytes())
 
-		actBytes, ok = subj.Get(name2)
+		actData, ok = subj.Get(name2)
 		assert.True(t, ok)
-		assert.Equal(t, securemem.SecureBytes(data2), actBytes)
+		assert.Equal(t, securemem.SecureBytes(data2), actData.SecureBytes())
 	})
 
 	t.Run("should be idempotent when marking all data as read-only", func(t *testing.T) {
@@ -489,9 +489,9 @@ func TestVaultMarkReadOnly(t *testing.T) {
 		assert.NoError(t, err)
 
 		// then
-		actBytes, ok := subj.Get(name)
+		actData, ok := subj.Get(name)
 		assert.True(t, ok)
-		assert.Equal(t, securemem.SecureBytes(data), actBytes)
+		assert.Equal(t, securemem.SecureBytes(data), actData.SecureBytes())
 	})
 
 	t.Run("should not return an error when vault is empty", func(t *testing.T) {

--- a/internal/securemem/test/readonlyrun/main.go
+++ b/internal/securemem/test/readonlyrun/main.go
@@ -46,14 +46,14 @@ func main() {
 	}()
 
 	// Attempt to retrieve the secret data from the vault and print it.
-	b, ok := res.MemVault().Get("secret")
+	d, ok := res.MemVault().Get("secret")
 	if !ok {
 		panic(errors.New("secret not found in vault"))
 	}
 
 	// Print the secret data. This should work fine.
-	log.Println(string(b))
+	log.Println(string(d.SecureBytes()))
 
 	// Attempt to modify the secret data. This should cause a panic due to read-only memory.
-	b[0] = 'X' // This should cause a panic due to read-only memory
+	d.SecureBytes()[0] = 'X' // This should cause a panic due to read-only memory
 }

--- a/internal/spec/hierarchy_validation_test.go
+++ b/internal/spec/hierarchy_validation_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/spec"
 )
 
@@ -13,11 +14,11 @@ func testHierarchy() spec.KeyHierarchy {
 	return spec.KeyHierarchy{
 		Name: "test-hierarchy",
 		KeySpecs: []spec.KeySpec{
-			{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
-			{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
-			{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
-			{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
-			{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+			{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256},
+			{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+			{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: cryptor.KeyAlgorithmAES256},
+			{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+			{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256},
 		},
 	}
 }

--- a/internal/spec/keyhierarchy_test.go
+++ b/internal/spec/keyhierarchy_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/spec"
 	"github.com/openkcm/krypton/pkg/model"
 )
@@ -24,7 +25,7 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -55,7 +56,7 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -70,7 +71,7 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -85,7 +86,7 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleTek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -100,13 +101,13 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -136,7 +137,7 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: false},
 						},
 					},
@@ -151,25 +152,25 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K2",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K3",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -184,19 +185,19 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K2",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -211,31 +212,31 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K2",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K3",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K4",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -250,25 +251,25 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K2",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K3",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -283,13 +284,13 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -304,13 +305,13 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleTek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -325,13 +326,13 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -346,19 +347,19 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K2",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -373,31 +374,31 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K1",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K2",
 							Role:       spec.KeyRoleTek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K3",
 							Role:       spec.KeyRoleKek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 						{
 							Kind:       "K4",
 							Role:       spec.KeyRoleDek,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -412,7 +413,7 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:       "K0",
 							Role:       spec.KeyRoleRoot,
-							Algorithm:  spec.KeyAlgorithmAES256,
+							Algorithm:  cryptor.KeyAlgorithmAES256,
 							LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 						},
 					},
@@ -453,17 +454,17 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:      "K0",
 							Role:      spec.KeyRoleRoot,
-							Algorithm: spec.KeyAlgorithmAES256,
+							Algorithm: cryptor.KeyAlgorithmAES256,
 						},
 						{
 							Kind:      "K1",
 							Role:      spec.KeyRoleKek,
-							Algorithm: spec.KeyAlgorithmAES256,
+							Algorithm: cryptor.KeyAlgorithmAES256,
 						},
 						{
 							Kind:      "K2",
 							Role:      spec.KeyRoleDek,
-							Algorithm: spec.KeyAlgorithmAES256,
+							Algorithm: cryptor.KeyAlgorithmAES256,
 						},
 					},
 				},
@@ -472,7 +473,7 @@ func TestKeyHierarchy(t *testing.T) {
 				expKeySpec: spec.KeySpec{
 					Kind:      "K1",
 					Role:      spec.KeyRoleKek,
-					Algorithm: spec.KeyAlgorithmAES256,
+					Algorithm: cryptor.KeyAlgorithmAES256,
 				},
 			},
 			{
@@ -483,17 +484,17 @@ func TestKeyHierarchy(t *testing.T) {
 						{
 							Kind:      "K0",
 							Role:      spec.KeyRoleRoot,
-							Algorithm: spec.KeyAlgorithmAES256,
+							Algorithm: cryptor.KeyAlgorithmAES256,
 						},
 						{
 							Kind:      "K1",
 							Role:      spec.KeyRoleKek,
-							Algorithm: spec.KeyAlgorithmAES256,
+							Algorithm: cryptor.KeyAlgorithmAES256,
 						},
 						{
 							Kind:      "K2",
 							Role:      spec.KeyRoleDek,
-							Algorithm: spec.KeyAlgorithmAES256,
+							Algorithm: cryptor.KeyAlgorithmAES256,
 						},
 					},
 				},
@@ -519,11 +520,11 @@ func TestKeyHierarchy(t *testing.T) {
 		hierarchy := &spec.KeyHierarchy{
 			Name: "test-hierarchy",
 			KeySpecs: []spec.KeySpec{
-				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256},
 			},
 		}
 
@@ -550,11 +551,11 @@ func TestKeyHierarchy(t *testing.T) {
 		hierarchy := &spec.KeyHierarchy{
 			Name: "test-hierarchy",
 			KeySpecs: []spec.KeySpec{
-				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: spec.KeyAlgorithmAES256},
-				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: spec.KeyAlgorithmAES256},
+				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256},
 			},
 		}
 

--- a/internal/spec/keyspec.go
+++ b/internal/spec/keyspec.go
@@ -3,14 +3,13 @@ package spec
 import (
 	"errors"
 
+	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/pkg/model"
 )
 
 type (
 	// KeyRole identifies the role of a key within a hierarchy.
 	KeyRole string
-	// KeyAlgorithm identifies the encryption algorithm used by a key.
-	KeyAlgorithm string
 )
 
 const (
@@ -24,12 +23,9 @@ const (
 	KeyRoleTek KeyRole = "tek"
 )
 
-// KeyAlgorithmAES256 represents the AES-256 encryption algorithm.
-const KeyAlgorithmAES256 KeyAlgorithm = "AES256"
-
 // validKeyAlgorithms defines the set of supported KeyAlgorithm values.
-var validKeyAlgorithms = map[KeyAlgorithm]struct{}{
-	KeyAlgorithmAES256: {},
+var validKeyAlgorithms = map[cryptor.KeyAlgorithm]struct{}{
+	cryptor.KeyAlgorithmAES256: {},
 }
 
 var (
@@ -50,10 +46,10 @@ var (
 
 // KeySpec defines the properties of a key within a hierarchy, including its kind, role, and algorithm.
 type KeySpec struct {
-	Kind       model.KeyKind `yaml:"kind"`
-	Role       KeyRole       `yaml:"role"`
-	Algorithm  KeyAlgorithm  `yaml:"algorithm"`
-	LabelsSpec LabelsSpec    `yaml:"labels_spec"`
+	Kind       model.KeyKind        `yaml:"kind"`
+	Role       KeyRole              `yaml:"role"`
+	Algorithm  cryptor.KeyAlgorithm `yaml:"algorithm"`
+	LabelsSpec LabelsSpec           `yaml:"labels_spec"`
 }
 
 // Usage returns the KeyUsage associated with the KeySpec's role.
@@ -96,7 +92,7 @@ func (k KeySpec) Validate() error {
 }
 
 // IsSupportedAlgorithm checks if the provided KeyAlgorithm is supported by the system.
-func IsSupportedAlgorithm(alg KeyAlgorithm) bool {
+func IsSupportedAlgorithm(alg cryptor.KeyAlgorithm) bool {
 	_, ok := validKeyAlgorithms[alg]
 	return ok
 }

--- a/internal/spec/keyspec_test.go
+++ b/internal/spec/keyspec_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/spec"
 )
 
@@ -21,7 +22,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:      "K0",
 					Role:      spec.KeyRoleRoot,
-					Algorithm: spec.KeyAlgorithmAES256,
+					Algorithm: cryptor.KeyAlgorithmAES256,
 				},
 				expUsage: spec.KeyUsageWrap | spec.KeyUsageUnwrap,
 			},
@@ -30,7 +31,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:      "K0",
 					Role:      spec.KeyRoleKek,
-					Algorithm: spec.KeyAlgorithmAES256,
+					Algorithm: cryptor.KeyAlgorithmAES256,
 				},
 				expUsage: spec.KeyUsageWrap | spec.KeyUsageUnwrap,
 			},
@@ -39,7 +40,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:      "K0",
 					Role:      spec.KeyRoleTek,
-					Algorithm: spec.KeyAlgorithmAES256,
+					Algorithm: cryptor.KeyAlgorithmAES256,
 				},
 				expUsage: spec.KeyUsageWrap | spec.KeyUsageUnwrap,
 			},
@@ -48,7 +49,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:      "K0",
 					Role:      spec.KeyRoleDek,
-					Algorithm: spec.KeyAlgorithmAES256,
+					Algorithm: cryptor.KeyAlgorithmAES256,
 				},
 				expUsage: spec.KeyUsageEncrypt | spec.KeyUsageDecrypt,
 			},
@@ -57,7 +58,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:      "K0",
 					Role:      "invalid-role",
-					Algorithm: spec.KeyAlgorithmAES256,
+					Algorithm: cryptor.KeyAlgorithmAES256,
 				},
 				expUsage: spec.KeyUsageNone,
 			},
@@ -85,7 +86,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "",
 					Role:       spec.KeyRoleRoot,
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 				expErr: spec.ErrKeySpecKindEmpty,
@@ -95,7 +96,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "K0",
 					Role:       "invalid-role",
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 				expErr: spec.ErrKeySpecRoleInvalid,
@@ -125,7 +126,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "K0",
 					Role:       spec.KeyRoleRoot,
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 			},
@@ -134,7 +135,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "K0",
 					Role:       spec.KeyRoleKek,
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 			},
@@ -143,7 +144,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "K0",
 					Role:       spec.KeyRoleDek,
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 			},
@@ -152,7 +153,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "K0",
 					Role:       spec.KeyRoleTek,
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: true},
 				},
 			},
@@ -161,7 +162,7 @@ func TestKeySpec(t *testing.T) {
 				input: spec.KeySpec{
 					Kind:       "K0",
 					Role:       spec.KeyRoleTek,
-					Algorithm:  spec.KeyAlgorithmAES256,
+					Algorithm:  cryptor.KeyAlgorithmAES256,
 					LabelsSpec: spec.LabelsSpec{AllowUserLabels: false},
 				},
 				expErr: spec.ErrLabelsSpecRequirementEmpty,
@@ -187,12 +188,12 @@ func TestKeySpec(t *testing.T) {
 	t.Run("IsSupportedAlgorithm", func(t *testing.T) {
 		tts := []struct {
 			name  string
-			input spec.KeyAlgorithm
+			input cryptor.KeyAlgorithm
 			expOk bool
 		}{
 			{
 				name:  "should return true for 'AES256'",
-				input: spec.KeyAlgorithmAES256,
+				input: cryptor.KeyAlgorithmAES256,
 				expOk: true,
 			},
 			{


### PR DESCRIPTION
Add AES-256-GCM cryptor implementation that performs authenticated encryption and decryption using mlock'd memory for all sensitive data. Includes round-trip tests covering AAD, wrong key, and tampered ciphertext scenarios.
