### PR TITLE
feat: add grpc endpoint for getting a keys descendants

### DIFF
--- a/api-specs/v1/proto/admin/key.proto
+++ b/api-specs/v1/proto/admin/key.proto
@@ -9,6 +9,7 @@ service KeyService {
   rpc AnnounceKey(AnnounceKeyRequest) returns (AnnounceKeyResponse);
   rpc GetKey(GetKeyRequest) returns (GetKeyResponse);
   rpc GetParentKeys(GetParentKeysRequest) returns (GetParentKeysResponse);
+  rpc GetDescendantKeys(GetDescendantKeysRequest) returns (GetDescendantKeysResponse);
 }
 
 message Key {
@@ -53,5 +54,18 @@ message GetParentKeysRequest {
 
 message GetParentKeysResponse {
   repeated Key keys = 1;
+}
+
+message GetDescendantKeysRequest {
+  string id = 1;
+  string tenant_id = 2;
+}
+
+message KeyTree {
+  repeated Key keys = 1;
+}
+
+message GetDescendantKeysResponse {
+  repeated KeyTree key_tree = 1;
 }
 

--- a/api-specs/v1/proto/admin/key.proto
+++ b/api-specs/v1/proto/admin/key.proto
@@ -8,7 +8,7 @@ option go_package = "github.com/openkcm/krypton/pkg/api/v1/proto/admin";
 service KeyService {
   rpc AnnounceKey(AnnounceKeyRequest) returns (AnnounceKeyResponse);
   rpc GetKey(GetKeyRequest) returns (GetKeyResponse);
-  rpc GetKeyChain(GetKeyChainRequest) returns (GetKeyChainResponse);
+  rpc GetParentKeys(GetParentKeysRequest) returns (GetParentKeysResponse);
 }
 
 message Key {
@@ -46,12 +46,12 @@ message GetKeyResponse {
   Key key = 1;
 }
 
-message GetKeyChainRequest {
+message GetParentKeysRequest {
   string id = 1;
   string tenant_id = 2;
 }
 
-message GetKeyChainResponse {
+message GetParentKeysResponse {
   repeated Key keys = 1;
 }
 

--- a/pkg/api/v1/proto/admin/key.pb.go
+++ b/pkg/api/v1/proto/admin/key.pb.go
@@ -362,7 +362,7 @@ func (x *GetKeyResponse) GetKey() *Key {
 	return nil
 }
 
-type GetKeyChainRequest struct {
+type GetParentKeysRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
@@ -370,20 +370,20 @@ type GetKeyChainRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetKeyChainRequest) Reset() {
-	*x = GetKeyChainRequest{}
+func (x *GetParentKeysRequest) Reset() {
+	*x = GetParentKeysRequest{}
 	mi := &file_key_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetKeyChainRequest) String() string {
+func (x *GetParentKeysRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetKeyChainRequest) ProtoMessage() {}
+func (*GetParentKeysRequest) ProtoMessage() {}
 
-func (x *GetKeyChainRequest) ProtoReflect() protoreflect.Message {
+func (x *GetParentKeysRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_key_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -395,46 +395,46 @@ func (x *GetKeyChainRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetKeyChainRequest.ProtoReflect.Descriptor instead.
-func (*GetKeyChainRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetParentKeysRequest.ProtoReflect.Descriptor instead.
+func (*GetParentKeysRequest) Descriptor() ([]byte, []int) {
 	return file_key_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *GetKeyChainRequest) GetId() string {
+func (x *GetParentKeysRequest) GetId() string {
 	if x != nil {
 		return x.Id
 	}
 	return ""
 }
 
-func (x *GetKeyChainRequest) GetTenantId() string {
+func (x *GetParentKeysRequest) GetTenantId() string {
 	if x != nil {
 		return x.TenantId
 	}
 	return ""
 }
 
-type GetKeyChainResponse struct {
+type GetParentKeysResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Keys          []*Key                 `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetKeyChainResponse) Reset() {
-	*x = GetKeyChainResponse{}
+func (x *GetParentKeysResponse) Reset() {
+	*x = GetParentKeysResponse{}
 	mi := &file_key_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetKeyChainResponse) String() string {
+func (x *GetParentKeysResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetKeyChainResponse) ProtoMessage() {}
+func (*GetParentKeysResponse) ProtoMessage() {}
 
-func (x *GetKeyChainResponse) ProtoReflect() protoreflect.Message {
+func (x *GetParentKeysResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_key_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -446,12 +446,12 @@ func (x *GetKeyChainResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetKeyChainResponse.ProtoReflect.Descriptor instead.
-func (*GetKeyChainResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetParentKeysResponse.ProtoReflect.Descriptor instead.
+func (*GetParentKeysResponse) Descriptor() ([]byte, []int) {
 	return file_key_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *GetKeyChainResponse) GetKeys() []*Key {
+func (x *GetParentKeysResponse) GetKeys() []*Key {
 	if x != nil {
 		return x.Keys
 	}
@@ -498,17 +498,17 @@ const file_key_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"9\n" +
 	"\x0eGetKeyResponse\x12'\n" +
-	"\x03key\x18\x01 \x01(\v2\x15.krypton.v1.admin.KeyR\x03key\"A\n" +
-	"\x12GetKeyChainRequest\x12\x0e\n" +
+	"\x03key\x18\x01 \x01(\v2\x15.krypton.v1.admin.KeyR\x03key\"C\n" +
+	"\x14GetParentKeysRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
-	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"@\n" +
-	"\x13GetKeyChainResponse\x12)\n" +
-	"\x04keys\x18\x01 \x03(\v2\x15.krypton.v1.admin.KeyR\x04keys2\x91\x02\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"B\n" +
+	"\x15GetParentKeysResponse\x12)\n" +
+	"\x04keys\x18\x01 \x03(\v2\x15.krypton.v1.admin.KeyR\x04keys2\x97\x02\n" +
 	"\n" +
 	"KeyService\x12Z\n" +
 	"\vAnnounceKey\x12$.krypton.v1.admin.AnnounceKeyRequest\x1a%.krypton.v1.admin.AnnounceKeyResponse\x12K\n" +
-	"\x06GetKey\x12\x1f.krypton.v1.admin.GetKeyRequest\x1a .krypton.v1.admin.GetKeyResponse\x12Z\n" +
-	"\vGetKeyChain\x12$.krypton.v1.admin.GetKeyChainRequest\x1a%.krypton.v1.admin.GetKeyChainResponseB3Z1github.com/openkcm/krypton/pkg/api/v1/proto/adminb\x06proto3"
+	"\x06GetKey\x12\x1f.krypton.v1.admin.GetKeyRequest\x1a .krypton.v1.admin.GetKeyResponse\x12`\n" +
+	"\rGetParentKeys\x12&.krypton.v1.admin.GetParentKeysRequest\x1a'.krypton.v1.admin.GetParentKeysResponseB3Z1github.com/openkcm/krypton/pkg/api/v1/proto/adminb\x06proto3"
 
 var (
 	file_key_proto_rawDescOnce sync.Once
@@ -524,28 +524,28 @@ func file_key_proto_rawDescGZIP() []byte {
 
 var file_key_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_key_proto_goTypes = []any{
-	(*Key)(nil),                 // 0: krypton.v1.admin.Key
-	(*AnnounceKeyRequest)(nil),  // 1: krypton.v1.admin.AnnounceKeyRequest
-	(*AnnounceKeyResponse)(nil), // 2: krypton.v1.admin.AnnounceKeyResponse
-	(*GetKeyRequest)(nil),       // 3: krypton.v1.admin.GetKeyRequest
-	(*GetKeyResponse)(nil),      // 4: krypton.v1.admin.GetKeyResponse
-	(*GetKeyChainRequest)(nil),  // 5: krypton.v1.admin.GetKeyChainRequest
-	(*GetKeyChainResponse)(nil), // 6: krypton.v1.admin.GetKeyChainResponse
-	nil,                         // 7: krypton.v1.admin.Key.LabelsEntry
-	nil,                         // 8: krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
+	(*Key)(nil),                   // 0: krypton.v1.admin.Key
+	(*AnnounceKeyRequest)(nil),    // 1: krypton.v1.admin.AnnounceKeyRequest
+	(*AnnounceKeyResponse)(nil),   // 2: krypton.v1.admin.AnnounceKeyResponse
+	(*GetKeyRequest)(nil),         // 3: krypton.v1.admin.GetKeyRequest
+	(*GetKeyResponse)(nil),        // 4: krypton.v1.admin.GetKeyResponse
+	(*GetParentKeysRequest)(nil),  // 5: krypton.v1.admin.GetParentKeysRequest
+	(*GetParentKeysResponse)(nil), // 6: krypton.v1.admin.GetParentKeysResponse
+	nil,                           // 7: krypton.v1.admin.Key.LabelsEntry
+	nil,                           // 8: krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
 }
 var file_key_proto_depIdxs = []int32{
 	7, // 0: krypton.v1.admin.Key.labels:type_name -> krypton.v1.admin.Key.LabelsEntry
 	8, // 1: krypton.v1.admin.AnnounceKeyRequest.labels:type_name -> krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
 	0, // 2: krypton.v1.admin.AnnounceKeyResponse.key:type_name -> krypton.v1.admin.Key
 	0, // 3: krypton.v1.admin.GetKeyResponse.key:type_name -> krypton.v1.admin.Key
-	0, // 4: krypton.v1.admin.GetKeyChainResponse.keys:type_name -> krypton.v1.admin.Key
+	0, // 4: krypton.v1.admin.GetParentKeysResponse.keys:type_name -> krypton.v1.admin.Key
 	1, // 5: krypton.v1.admin.KeyService.AnnounceKey:input_type -> krypton.v1.admin.AnnounceKeyRequest
 	3, // 6: krypton.v1.admin.KeyService.GetKey:input_type -> krypton.v1.admin.GetKeyRequest
-	5, // 7: krypton.v1.admin.KeyService.GetKeyChain:input_type -> krypton.v1.admin.GetKeyChainRequest
+	5, // 7: krypton.v1.admin.KeyService.GetParentKeys:input_type -> krypton.v1.admin.GetParentKeysRequest
 	2, // 8: krypton.v1.admin.KeyService.AnnounceKey:output_type -> krypton.v1.admin.AnnounceKeyResponse
 	4, // 9: krypton.v1.admin.KeyService.GetKey:output_type -> krypton.v1.admin.GetKeyResponse
-	6, // 10: krypton.v1.admin.KeyService.GetKeyChain:output_type -> krypton.v1.admin.GetKeyChainResponse
+	6, // 10: krypton.v1.admin.KeyService.GetParentKeys:output_type -> krypton.v1.admin.GetParentKeysResponse
 	8, // [8:11] is the sub-list for method output_type
 	5, // [5:8] is the sub-list for method input_type
 	5, // [5:5] is the sub-list for extension type_name

--- a/pkg/api/v1/proto/admin/key.pb.go
+++ b/pkg/api/v1/proto/admin/key.pb.go
@@ -458,6 +458,146 @@ func (x *GetParentKeysResponse) GetKeys() []*Key {
 	return nil
 }
 
+type GetDescendantKeysRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDescendantKeysRequest) Reset() {
+	*x = GetDescendantKeysRequest{}
+	mi := &file_key_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDescendantKeysRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDescendantKeysRequest) ProtoMessage() {}
+
+func (x *GetDescendantKeysRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_key_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDescendantKeysRequest.ProtoReflect.Descriptor instead.
+func (*GetDescendantKeysRequest) Descriptor() ([]byte, []int) {
+	return file_key_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetDescendantKeysRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetDescendantKeysRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+type KeyTree struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keys          []*Key                 `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KeyTree) Reset() {
+	*x = KeyTree{}
+	mi := &file_key_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KeyTree) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KeyTree) ProtoMessage() {}
+
+func (x *KeyTree) ProtoReflect() protoreflect.Message {
+	mi := &file_key_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KeyTree.ProtoReflect.Descriptor instead.
+func (*KeyTree) Descriptor() ([]byte, []int) {
+	return file_key_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *KeyTree) GetKeys() []*Key {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+type GetDescendantKeysResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	KeyTree       []*KeyTree             `protobuf:"bytes,1,rep,name=key_tree,json=keyTree,proto3" json:"key_tree,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDescendantKeysResponse) Reset() {
+	*x = GetDescendantKeysResponse{}
+	mi := &file_key_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDescendantKeysResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDescendantKeysResponse) ProtoMessage() {}
+
+func (x *GetDescendantKeysResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_key_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDescendantKeysResponse.ProtoReflect.Descriptor instead.
+func (*GetDescendantKeysResponse) Descriptor() ([]byte, []int) {
+	return file_key_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetDescendantKeysResponse) GetKeyTree() []*KeyTree {
+	if x != nil {
+		return x.KeyTree
+	}
+	return nil
+}
+
 var File_key_proto protoreflect.FileDescriptor
 
 const file_key_proto_rawDesc = "" +
@@ -503,12 +643,20 @@ const file_key_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"B\n" +
 	"\x15GetParentKeysResponse\x12)\n" +
-	"\x04keys\x18\x01 \x03(\v2\x15.krypton.v1.admin.KeyR\x04keys2\x97\x02\n" +
+	"\x04keys\x18\x01 \x03(\v2\x15.krypton.v1.admin.KeyR\x04keys\"G\n" +
+	"\x18GetDescendantKeysRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"4\n" +
+	"\aKeyTree\x12)\n" +
+	"\x04keys\x18\x01 \x03(\v2\x15.krypton.v1.admin.KeyR\x04keys\"Q\n" +
+	"\x19GetDescendantKeysResponse\x124\n" +
+	"\bkey_tree\x18\x01 \x03(\v2\x19.krypton.v1.admin.KeyTreeR\akeyTree2\x85\x03\n" +
 	"\n" +
 	"KeyService\x12Z\n" +
 	"\vAnnounceKey\x12$.krypton.v1.admin.AnnounceKeyRequest\x1a%.krypton.v1.admin.AnnounceKeyResponse\x12K\n" +
 	"\x06GetKey\x12\x1f.krypton.v1.admin.GetKeyRequest\x1a .krypton.v1.admin.GetKeyResponse\x12`\n" +
-	"\rGetParentKeys\x12&.krypton.v1.admin.GetParentKeysRequest\x1a'.krypton.v1.admin.GetParentKeysResponseB3Z1github.com/openkcm/krypton/pkg/api/v1/proto/adminb\x06proto3"
+	"\rGetParentKeys\x12&.krypton.v1.admin.GetParentKeysRequest\x1a'.krypton.v1.admin.GetParentKeysResponse\x12l\n" +
+	"\x11GetDescendantKeys\x12*.krypton.v1.admin.GetDescendantKeysRequest\x1a+.krypton.v1.admin.GetDescendantKeysResponseB3Z1github.com/openkcm/krypton/pkg/api/v1/proto/adminb\x06proto3"
 
 var (
 	file_key_proto_rawDescOnce sync.Once
@@ -522,35 +670,42 @@ func file_key_proto_rawDescGZIP() []byte {
 	return file_key_proto_rawDescData
 }
 
-var file_key_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_key_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_key_proto_goTypes = []any{
-	(*Key)(nil),                   // 0: krypton.v1.admin.Key
-	(*AnnounceKeyRequest)(nil),    // 1: krypton.v1.admin.AnnounceKeyRequest
-	(*AnnounceKeyResponse)(nil),   // 2: krypton.v1.admin.AnnounceKeyResponse
-	(*GetKeyRequest)(nil),         // 3: krypton.v1.admin.GetKeyRequest
-	(*GetKeyResponse)(nil),        // 4: krypton.v1.admin.GetKeyResponse
-	(*GetParentKeysRequest)(nil),  // 5: krypton.v1.admin.GetParentKeysRequest
-	(*GetParentKeysResponse)(nil), // 6: krypton.v1.admin.GetParentKeysResponse
-	nil,                           // 7: krypton.v1.admin.Key.LabelsEntry
-	nil,                           // 8: krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
+	(*Key)(nil),                       // 0: krypton.v1.admin.Key
+	(*AnnounceKeyRequest)(nil),        // 1: krypton.v1.admin.AnnounceKeyRequest
+	(*AnnounceKeyResponse)(nil),       // 2: krypton.v1.admin.AnnounceKeyResponse
+	(*GetKeyRequest)(nil),             // 3: krypton.v1.admin.GetKeyRequest
+	(*GetKeyResponse)(nil),            // 4: krypton.v1.admin.GetKeyResponse
+	(*GetParentKeysRequest)(nil),      // 5: krypton.v1.admin.GetParentKeysRequest
+	(*GetParentKeysResponse)(nil),     // 6: krypton.v1.admin.GetParentKeysResponse
+	(*GetDescendantKeysRequest)(nil),  // 7: krypton.v1.admin.GetDescendantKeysRequest
+	(*KeyTree)(nil),                   // 8: krypton.v1.admin.KeyTree
+	(*GetDescendantKeysResponse)(nil), // 9: krypton.v1.admin.GetDescendantKeysResponse
+	nil,                               // 10: krypton.v1.admin.Key.LabelsEntry
+	nil,                               // 11: krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
 }
 var file_key_proto_depIdxs = []int32{
-	7, // 0: krypton.v1.admin.Key.labels:type_name -> krypton.v1.admin.Key.LabelsEntry
-	8, // 1: krypton.v1.admin.AnnounceKeyRequest.labels:type_name -> krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
-	0, // 2: krypton.v1.admin.AnnounceKeyResponse.key:type_name -> krypton.v1.admin.Key
-	0, // 3: krypton.v1.admin.GetKeyResponse.key:type_name -> krypton.v1.admin.Key
-	0, // 4: krypton.v1.admin.GetParentKeysResponse.keys:type_name -> krypton.v1.admin.Key
-	1, // 5: krypton.v1.admin.KeyService.AnnounceKey:input_type -> krypton.v1.admin.AnnounceKeyRequest
-	3, // 6: krypton.v1.admin.KeyService.GetKey:input_type -> krypton.v1.admin.GetKeyRequest
-	5, // 7: krypton.v1.admin.KeyService.GetParentKeys:input_type -> krypton.v1.admin.GetParentKeysRequest
-	2, // 8: krypton.v1.admin.KeyService.AnnounceKey:output_type -> krypton.v1.admin.AnnounceKeyResponse
-	4, // 9: krypton.v1.admin.KeyService.GetKey:output_type -> krypton.v1.admin.GetKeyResponse
-	6, // 10: krypton.v1.admin.KeyService.GetParentKeys:output_type -> krypton.v1.admin.GetParentKeysResponse
-	8, // [8:11] is the sub-list for method output_type
-	5, // [5:8] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	10, // 0: krypton.v1.admin.Key.labels:type_name -> krypton.v1.admin.Key.LabelsEntry
+	11, // 1: krypton.v1.admin.AnnounceKeyRequest.labels:type_name -> krypton.v1.admin.AnnounceKeyRequest.LabelsEntry
+	0,  // 2: krypton.v1.admin.AnnounceKeyResponse.key:type_name -> krypton.v1.admin.Key
+	0,  // 3: krypton.v1.admin.GetKeyResponse.key:type_name -> krypton.v1.admin.Key
+	0,  // 4: krypton.v1.admin.GetParentKeysResponse.keys:type_name -> krypton.v1.admin.Key
+	0,  // 5: krypton.v1.admin.KeyTree.keys:type_name -> krypton.v1.admin.Key
+	8,  // 6: krypton.v1.admin.GetDescendantKeysResponse.key_tree:type_name -> krypton.v1.admin.KeyTree
+	1,  // 7: krypton.v1.admin.KeyService.AnnounceKey:input_type -> krypton.v1.admin.AnnounceKeyRequest
+	3,  // 8: krypton.v1.admin.KeyService.GetKey:input_type -> krypton.v1.admin.GetKeyRequest
+	5,  // 9: krypton.v1.admin.KeyService.GetParentKeys:input_type -> krypton.v1.admin.GetParentKeysRequest
+	7,  // 10: krypton.v1.admin.KeyService.GetDescendantKeys:input_type -> krypton.v1.admin.GetDescendantKeysRequest
+	2,  // 11: krypton.v1.admin.KeyService.AnnounceKey:output_type -> krypton.v1.admin.AnnounceKeyResponse
+	4,  // 12: krypton.v1.admin.KeyService.GetKey:output_type -> krypton.v1.admin.GetKeyResponse
+	6,  // 13: krypton.v1.admin.KeyService.GetParentKeys:output_type -> krypton.v1.admin.GetParentKeysResponse
+	9,  // 14: krypton.v1.admin.KeyService.GetDescendantKeys:output_type -> krypton.v1.admin.GetDescendantKeysResponse
+	11, // [11:15] is the sub-list for method output_type
+	7,  // [7:11] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_key_proto_init() }
@@ -564,7 +719,7 @@ func file_key_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_key_proto_rawDesc), len(file_key_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/api/v1/proto/admin/key_convert.go
+++ b/pkg/api/v1/proto/admin/key_convert.go
@@ -24,6 +24,14 @@ func KeyToProto(k model.Key) *Key {
 	}
 }
 
+func KeyTreeToProto(tree model.KeyTreeTraverser) []*KeyTree {
+	var res []*KeyTree
+	for layer := range tree.IterKeysByLayerAsc() {
+		res = append(res, &KeyTree{Keys: KeysToProto(layer)})
+	}
+	return res
+}
+
 func KeysToProto(ks []model.Key) []*Key {
 	res := make([]*Key, len(ks))
 	for i := range ks {

--- a/pkg/api/v1/proto/admin/key_grpc.pb.go
+++ b/pkg/api/v1/proto/admin/key_grpc.pb.go
@@ -20,9 +20,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	KeyService_AnnounceKey_FullMethodName   = "/krypton.v1.admin.KeyService/AnnounceKey"
-	KeyService_GetKey_FullMethodName        = "/krypton.v1.admin.KeyService/GetKey"
-	KeyService_GetParentKeys_FullMethodName = "/krypton.v1.admin.KeyService/GetParentKeys"
+	KeyService_AnnounceKey_FullMethodName       = "/krypton.v1.admin.KeyService/AnnounceKey"
+	KeyService_GetKey_FullMethodName            = "/krypton.v1.admin.KeyService/GetKey"
+	KeyService_GetParentKeys_FullMethodName     = "/krypton.v1.admin.KeyService/GetParentKeys"
+	KeyService_GetDescendantKeys_FullMethodName = "/krypton.v1.admin.KeyService/GetDescendantKeys"
 )
 
 // KeyServiceClient is the client API for KeyService service.
@@ -32,6 +33,7 @@ type KeyServiceClient interface {
 	AnnounceKey(ctx context.Context, in *AnnounceKeyRequest, opts ...grpc.CallOption) (*AnnounceKeyResponse, error)
 	GetKey(ctx context.Context, in *GetKeyRequest, opts ...grpc.CallOption) (*GetKeyResponse, error)
 	GetParentKeys(ctx context.Context, in *GetParentKeysRequest, opts ...grpc.CallOption) (*GetParentKeysResponse, error)
+	GetDescendantKeys(ctx context.Context, in *GetDescendantKeysRequest, opts ...grpc.CallOption) (*GetDescendantKeysResponse, error)
 }
 
 type keyServiceClient struct {
@@ -72,6 +74,16 @@ func (c *keyServiceClient) GetParentKeys(ctx context.Context, in *GetParentKeysR
 	return out, nil
 }
 
+func (c *keyServiceClient) GetDescendantKeys(ctx context.Context, in *GetDescendantKeysRequest, opts ...grpc.CallOption) (*GetDescendantKeysResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetDescendantKeysResponse)
+	err := c.cc.Invoke(ctx, KeyService_GetDescendantKeys_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // KeyServiceServer is the server API for KeyService service.
 // All implementations must embed UnimplementedKeyServiceServer
 // for forward compatibility.
@@ -79,6 +91,7 @@ type KeyServiceServer interface {
 	AnnounceKey(context.Context, *AnnounceKeyRequest) (*AnnounceKeyResponse, error)
 	GetKey(context.Context, *GetKeyRequest) (*GetKeyResponse, error)
 	GetParentKeys(context.Context, *GetParentKeysRequest) (*GetParentKeysResponse, error)
+	GetDescendantKeys(context.Context, *GetDescendantKeysRequest) (*GetDescendantKeysResponse, error)
 	mustEmbedUnimplementedKeyServiceServer()
 }
 
@@ -97,6 +110,9 @@ func (UnimplementedKeyServiceServer) GetKey(context.Context, *GetKeyRequest) (*G
 }
 func (UnimplementedKeyServiceServer) GetParentKeys(context.Context, *GetParentKeysRequest) (*GetParentKeysResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetParentKeys not implemented")
+}
+func (UnimplementedKeyServiceServer) GetDescendantKeys(context.Context, *GetDescendantKeysRequest) (*GetDescendantKeysResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetDescendantKeys not implemented")
 }
 func (UnimplementedKeyServiceServer) mustEmbedUnimplementedKeyServiceServer() {}
 func (UnimplementedKeyServiceServer) testEmbeddedByValue()                    {}
@@ -173,6 +189,24 @@ func _KeyService_GetParentKeys_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _KeyService_GetDescendantKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetDescendantKeysRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KeyServiceServer).GetDescendantKeys(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KeyService_GetDescendantKeys_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KeyServiceServer).GetDescendantKeys(ctx, req.(*GetDescendantKeysRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // KeyService_ServiceDesc is the grpc.ServiceDesc for KeyService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -191,6 +225,10 @@ var KeyService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetParentKeys",
 			Handler:    _KeyService_GetParentKeys_Handler,
+		},
+		{
+			MethodName: "GetDescendantKeys",
+			Handler:    _KeyService_GetDescendantKeys_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/api/v1/proto/admin/key_grpc.pb.go
+++ b/pkg/api/v1/proto/admin/key_grpc.pb.go
@@ -20,9 +20,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	KeyService_AnnounceKey_FullMethodName = "/krypton.v1.admin.KeyService/AnnounceKey"
-	KeyService_GetKey_FullMethodName      = "/krypton.v1.admin.KeyService/GetKey"
-	KeyService_GetKeyChain_FullMethodName = "/krypton.v1.admin.KeyService/GetKeyChain"
+	KeyService_AnnounceKey_FullMethodName   = "/krypton.v1.admin.KeyService/AnnounceKey"
+	KeyService_GetKey_FullMethodName        = "/krypton.v1.admin.KeyService/GetKey"
+	KeyService_GetParentKeys_FullMethodName = "/krypton.v1.admin.KeyService/GetParentKeys"
 )
 
 // KeyServiceClient is the client API for KeyService service.
@@ -31,7 +31,7 @@ const (
 type KeyServiceClient interface {
 	AnnounceKey(ctx context.Context, in *AnnounceKeyRequest, opts ...grpc.CallOption) (*AnnounceKeyResponse, error)
 	GetKey(ctx context.Context, in *GetKeyRequest, opts ...grpc.CallOption) (*GetKeyResponse, error)
-	GetKeyChain(ctx context.Context, in *GetKeyChainRequest, opts ...grpc.CallOption) (*GetKeyChainResponse, error)
+	GetParentKeys(ctx context.Context, in *GetParentKeysRequest, opts ...grpc.CallOption) (*GetParentKeysResponse, error)
 }
 
 type keyServiceClient struct {
@@ -62,10 +62,10 @@ func (c *keyServiceClient) GetKey(ctx context.Context, in *GetKeyRequest, opts .
 	return out, nil
 }
 
-func (c *keyServiceClient) GetKeyChain(ctx context.Context, in *GetKeyChainRequest, opts ...grpc.CallOption) (*GetKeyChainResponse, error) {
+func (c *keyServiceClient) GetParentKeys(ctx context.Context, in *GetParentKeysRequest, opts ...grpc.CallOption) (*GetParentKeysResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GetKeyChainResponse)
-	err := c.cc.Invoke(ctx, KeyService_GetKeyChain_FullMethodName, in, out, cOpts...)
+	out := new(GetParentKeysResponse)
+	err := c.cc.Invoke(ctx, KeyService_GetParentKeys_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *keyServiceClient) GetKeyChain(ctx context.Context, in *GetKeyChainReque
 type KeyServiceServer interface {
 	AnnounceKey(context.Context, *AnnounceKeyRequest) (*AnnounceKeyResponse, error)
 	GetKey(context.Context, *GetKeyRequest) (*GetKeyResponse, error)
-	GetKeyChain(context.Context, *GetKeyChainRequest) (*GetKeyChainResponse, error)
+	GetParentKeys(context.Context, *GetParentKeysRequest) (*GetParentKeysResponse, error)
 	mustEmbedUnimplementedKeyServiceServer()
 }
 
@@ -95,8 +95,8 @@ func (UnimplementedKeyServiceServer) AnnounceKey(context.Context, *AnnounceKeyRe
 func (UnimplementedKeyServiceServer) GetKey(context.Context, *GetKeyRequest) (*GetKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetKey not implemented")
 }
-func (UnimplementedKeyServiceServer) GetKeyChain(context.Context, *GetKeyChainRequest) (*GetKeyChainResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetKeyChain not implemented")
+func (UnimplementedKeyServiceServer) GetParentKeys(context.Context, *GetParentKeysRequest) (*GetParentKeysResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetParentKeys not implemented")
 }
 func (UnimplementedKeyServiceServer) mustEmbedUnimplementedKeyServiceServer() {}
 func (UnimplementedKeyServiceServer) testEmbeddedByValue()                    {}
@@ -155,20 +155,20 @@ func _KeyService_GetKey_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
-func _KeyService_GetKeyChain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetKeyChainRequest)
+func _KeyService_GetParentKeys_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetParentKeysRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(KeyServiceServer).GetKeyChain(ctx, in)
+		return srv.(KeyServiceServer).GetParentKeys(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: KeyService_GetKeyChain_FullMethodName,
+		FullMethod: KeyService_GetParentKeys_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(KeyServiceServer).GetKeyChain(ctx, req.(*GetKeyChainRequest))
+		return srv.(KeyServiceServer).GetParentKeys(ctx, req.(*GetParentKeysRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -189,8 +189,8 @@ var KeyService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _KeyService_GetKey_Handler,
 		},
 		{
-			MethodName: "GetKeyChain",
-			Handler:    _KeyService_GetKeyChain_Handler,
+			MethodName: "GetParentKeys",
+			Handler:    _KeyService_GetParentKeys_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/api/v1/proto/admin/key_service.go
+++ b/pkg/api/v1/proto/admin/key_service.go
@@ -78,12 +78,35 @@ func (s *KeyService) GetParentKeys(ctx context.Context, req *GetParentKeysReques
 			)
 		}
 		return nil, proto.ErrDetailsWithCode(
-			status.New(codes.Internal, "failed to get key chain"),
+			status.New(codes.Internal, "failed to get parent keys"),
 			proto.Code_ERROR_CODE_RETRY,
 		)
 	}
 
 	return &GetParentKeysResponse{
 		Keys: KeysToProto(res.Keys),
+	}, nil
+}
+
+func (s *KeyService) GetDescendantKeys(ctx context.Context, req *GetDescendantKeysRequest) (*GetDescendantKeysResponse, error) {
+	res, err := s.keyStore.GetDescendantKeys(ctx, store.GetDescendantKeysQuery{
+		KeyID:    req.GetId(),
+		TenantID: req.GetTenantId(),
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, proto.ErrDetailsWithCode(
+				status.New(codes.NotFound, "key not found"),
+				proto.Code_ERROR_CODE_ABORT,
+			)
+		}
+		return nil, proto.ErrDetailsWithCode(
+			status.New(codes.Internal, "failed to get descendant keys"),
+			proto.Code_ERROR_CODE_RETRY,
+		)
+	}
+
+	return &GetDescendantKeysResponse{
+		KeyTree: KeyTreeToProto(res.KeyTree),
 	}, nil
 }

--- a/pkg/api/v1/proto/admin/key_service.go
+++ b/pkg/api/v1/proto/admin/key_service.go
@@ -65,8 +65,8 @@ func (s *KeyService) GetKey(ctx context.Context, req *GetKeyRequest) (*GetKeyRes
 	return &GetKeyResponse{Key: KeyToProto(*key)}, nil
 }
 
-func (s *KeyService) GetKeyChain(ctx context.Context, req *GetKeyChainRequest) (*GetKeyChainResponse, error) {
-	res, err := s.keyStore.GetKeyChain(ctx, store.GetKeyChainQuery{
+func (s *KeyService) GetParentKeys(ctx context.Context, req *GetParentKeysRequest) (*GetParentKeysResponse, error) {
+	res, err := s.keyStore.GetParentKeys(ctx, store.GetParentKeysQuery{
 		KeyID:    req.GetId(),
 		TenantID: req.GetTenantId(),
 	})
@@ -83,7 +83,7 @@ func (s *KeyService) GetKeyChain(ctx context.Context, req *GetKeyChainRequest) (
 		)
 	}
 
-	return &GetKeyChainResponse{
+	return &GetParentKeysResponse{
 		Keys: KeysToProto(res.Keys),
 	}, nil
 }

--- a/pkg/api/v1/proto/admin/key_service_test.go
+++ b/pkg/api/v1/proto/admin/key_service_test.go
@@ -220,10 +220,10 @@ func TestGetParentKeys(t *testing.T) {
 
 	cli := setupKeyServerAndClient(t, keyStore)
 
-	t.Run("should get keychain successfully for intermediate", func(t *testing.T) {
+	t.Run("should get parent keys successfully for intermediate", func(t *testing.T) {
 		// when
 		res, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
-			Id:       ha.d.ID,
+			Id:       ha.g.ID,
 			TenantId: tenant.ID,
 		})
 
@@ -231,11 +231,11 @@ func TestGetParentKeys(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, res.GetKeys(), 3)
 		assert.Equal(t, ha.root.ID, res.GetKeys()[0].GetId())
-		assert.Equal(t, ha.b.ID, res.GetKeys()[1].GetId())
-		assert.Equal(t, ha.d.ID, res.GetKeys()[2].GetId())
+		assert.Equal(t, ha.c.ID, res.GetKeys()[1].GetId())
+		assert.Equal(t, ha.g.ID, res.GetKeys()[2].GetId())
 	})
 
-	t.Run("should get keychain successfully for leaf node", func(t *testing.T) {
+	t.Run("should get parent keys successfully for leaf node", func(t *testing.T) {
 		// when
 		res, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
 			Id:       ha.h.ID,
@@ -279,6 +279,124 @@ func TestGetParentKeys(t *testing.T) {
 
 		// when
 		resp, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
+			Id:       uuid.NewString(),
+			TenantId: uuid.NewString(),
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assertErrorDetails(t, proto.Code_ERROR_CODE_RETRY, err)
+	})
+}
+
+func TestGetDescendantKeys(t *testing.T) {
+	// given
+	ctx := t.Context()
+	db := createDatabase(t)
+
+	require.NoError(t, storesql.Migrate(ctx, db))
+	keyStore := storesql.NewKeyStore(db)
+
+	tenant := createTenant(t, db)
+
+	ha := createKeyHierarchy(t, keyStore, tenant)
+
+	cli := setupKeyServerAndClient(t, keyStore)
+
+	t.Run("should get descendant keys successfully for root", func(t *testing.T) {
+		// when
+		res, err := cli.GetDescendantKeys(ctx, &admin.GetDescendantKeysRequest{
+			Id:       ha.root.ID,
+			TenantId: tenant.ID,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, res.GetKeyTree(), 4)                                    // 4 levels in the tree
+		assert.Len(t, res.GetKeyTree()[0].GetKeys(), 1)                       // root level
+		assert.Equal(t, ha.root.ID, res.GetKeyTree()[0].GetKeys()[0].GetId()) // root key
+
+		assert.Len(t, res.GetKeyTree()[1].GetKeys(), 2)                    // level 1 has 2 keys: B and C
+		assert.Equal(t, ha.b.ID, res.GetKeyTree()[1].GetKeys()[0].GetId()) // B key
+		assert.Equal(t, ha.c.ID, res.GetKeyTree()[1].GetKeys()[1].GetId()) // C key
+
+		assert.Len(t, res.GetKeyTree()[2].GetKeys(), 4)                    // level 2 has 4 keys: D, E, F, G
+		assert.Equal(t, ha.d.ID, res.GetKeyTree()[2].GetKeys()[0].GetId()) // D key
+		assert.Equal(t, ha.e.ID, res.GetKeyTree()[2].GetKeys()[1].GetId()) // E key
+		assert.Equal(t, ha.f.ID, res.GetKeyTree()[2].GetKeys()[2].GetId()) // F key
+		assert.Equal(t, ha.g.ID, res.GetKeyTree()[2].GetKeys()[3].GetId()) // G key
+
+		assert.Len(t, res.GetKeyTree()[3].GetKeys(), 1)                    // level 3 has 1 key: H
+		assert.Equal(t, ha.h.ID, res.GetKeyTree()[3].GetKeys()[0].GetId()) // H key
+	})
+
+	t.Run("should get descendant keys successfully for intermediate", func(t *testing.T) {
+		// when
+		res, err := cli.GetDescendantKeys(ctx, &admin.GetDescendantKeysRequest{
+			Id:       ha.c.ID,
+			TenantId: tenant.ID,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, res.GetKeyTree(), 3)
+
+		assert.Len(t, res.GetKeyTree()[0].GetKeys(), 1)
+		assert.Equal(t, ha.c.ID, res.GetKeyTree()[0].GetKeys()[0].GetId())
+
+		assert.Len(t, res.GetKeyTree()[1].GetKeys(), 2)
+		assert.Equal(t, ha.f.ID, res.GetKeyTree()[1].GetKeys()[0].GetId())
+		assert.Equal(t, ha.g.ID, res.GetKeyTree()[1].GetKeys()[1].GetId())
+
+		assert.Len(t, res.GetKeyTree()[2].GetKeys(), 1)
+		assert.Equal(t, ha.h.ID, res.GetKeyTree()[2].GetKeys()[0].GetId())
+	})
+
+	t.Run("should get descendant successfully for leaf node", func(t *testing.T) {
+		// when
+		res, err := cli.GetDescendantKeys(ctx, &admin.GetDescendantKeysRequest{
+			Id:       ha.h.ID,
+			TenantId: tenant.ID,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, res.GetKeyTree(), 1)
+
+		assert.Len(t, res.GetKeyTree()[0].GetKeys(), 1)
+		assert.Equal(t, ha.h.ID, res.GetKeyTree()[0].GetKeys()[0].GetId())
+	})
+
+	t.Run("should return not found for nonexistent key", func(t *testing.T) {
+		// when
+		res, err := cli.GetDescendantKeys(ctx, &admin.GetDescendantKeysRequest{
+			Id:       uuid.NewString(),
+			TenantId: tenant.ID,
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, res)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+		assertErrorDetails(t, proto.Code_ERROR_CODE_ABORT, err)
+	})
+
+	t.Run("should return internal error on database failure", func(t *testing.T) {
+		// given
+		tmpDB := createDatabase(t)
+
+		require.NoError(t, storesql.Migrate(ctx, tmpDB))
+		tmpKeyStore := storesql.NewKeyStore(tmpDB)
+
+		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys")
+		require.NoError(t, err)
+
+		cli := setupKeyServerAndClient(t, tmpKeyStore)
+
+		// when
+		resp, err := cli.GetDescendantKeys(ctx, &admin.GetDescendantKeysRequest{
 			Id:       uuid.NewString(),
 			TenantId: uuid.NewString(),
 		})

--- a/pkg/api/v1/proto/admin/key_service_test.go
+++ b/pkg/api/v1/proto/admin/key_service_test.go
@@ -206,7 +206,7 @@ func TestGetKeyService(t *testing.T) {
 	})
 }
 
-func TestGetKeyChain(t *testing.T) {
+func TestGetParentKeys(t *testing.T) {
 	// given
 	ctx := t.Context()
 	db := createDatabase(t)
@@ -222,7 +222,7 @@ func TestGetKeyChain(t *testing.T) {
 
 	t.Run("should get keychain successfully for intermediate", func(t *testing.T) {
 		// when
-		res, err := cli.GetKeyChain(ctx, &admin.GetKeyChainRequest{
+		res, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
 			Id:       ha.d.ID,
 			TenantId: tenant.ID,
 		})
@@ -237,7 +237,7 @@ func TestGetKeyChain(t *testing.T) {
 
 	t.Run("should get keychain successfully for leaf node", func(t *testing.T) {
 		// when
-		res, err := cli.GetKeyChain(ctx, &admin.GetKeyChainRequest{
+		res, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
 			Id:       ha.h.ID,
 			TenantId: tenant.ID,
 		})
@@ -253,7 +253,7 @@ func TestGetKeyChain(t *testing.T) {
 
 	t.Run("should return not found for nonexistent key", func(t *testing.T) {
 		// when
-		res, err := cli.GetKeyChain(ctx, &admin.GetKeyChainRequest{
+		res, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
 			Id:       uuid.NewString(),
 			TenantId: tenant.ID,
 		})
@@ -278,7 +278,7 @@ func TestGetKeyChain(t *testing.T) {
 		cli := setupKeyServerAndClient(t, tmpKeyStore)
 
 		// when
-		resp, err := cli.GetKeyChain(ctx, &admin.GetKeyChainRequest{
+		resp, err := cli.GetParentKeys(ctx, &admin.GetParentKeysRequest{
 			Id:       uuid.NewString(),
 			TenantId: uuid.NewString(),
 		})

--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -12,24 +12,24 @@ var ErrKeyNotFound = errors.New("key not found")
 type Key interface {
 	CreateKey(ctx context.Context, key model.Key) error
 	GetKeyByID(ctx context.Context, id, tenantID string) (*model.Key, error)
-	GetKeyChain(ctx context.Context, query GetKeyChainQuery) (GetKeyChainResult, error)
-	GetKeyTree(ctx context.Context, query GetKeyTreeQuery) (GetKeyTreeResult, error)
+	GetParentKeys(ctx context.Context, query GetParentKeysQuery) (GetParentKeysResult, error)
+	GetDescendantKeys(ctx context.Context, query GetDescendantKeysQuery) (GetDescendantKeysResult, error)
 }
 
-type GetKeyChainQuery struct {
+type GetParentKeysQuery struct {
 	KeyID    string
 	TenantID string
 }
 
-type GetKeyChainResult struct {
+type GetParentKeysResult struct {
 	Keys []model.Key
 }
 
-type GetKeyTreeQuery struct {
+type GetDescendantKeysQuery struct {
 	KeyID    string
 	TenantID string
 }
 
-type GetKeyTreeResult struct {
+type GetDescendantKeysResult struct {
 	KeyTree model.KeyTreeTraverser
 }

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -58,8 +58,8 @@ func (ks *KeyStore) GetKeyByID(ctx context.Context, id, tenantID string) (*model
 	return scanKey(row)
 }
 
-// GetKeyChain returns all ancestors of the given key (including itself) by traversing parent_id up to the root.
-func (ks *KeyStore) GetKeyChain(ctx context.Context, query store.GetKeyChainQuery) (store.GetKeyChainResult, error) {
+// GetParentKeys returns all ancestors of the given key (including itself) by traversing parent_id up to the root.
+func (ks *KeyStore) GetParentKeys(ctx context.Context, query store.GetParentKeysQuery) (store.GetParentKeysResult, error) {
 	stmt := `
 		WITH RECURSIVE key_chain AS (
 			SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at, 0 AS depth
@@ -79,7 +79,7 @@ func (ks *KeyStore) GetKeyChain(ctx context.Context, query store.GetKeyChainQuer
 
 	rows, err := ks.db.QueryContext(ctx, stmt, query.KeyID, query.TenantID)
 	if err != nil {
-		return store.GetKeyChainResult{}, err
+		return store.GetParentKeysResult{}, err
 	}
 	defer rows.Close()
 
@@ -87,26 +87,26 @@ func (ks *KeyStore) GetKeyChain(ctx context.Context, query store.GetKeyChainQuer
 	for rows.Next() {
 		key, err := scanKey(rows)
 		if err != nil {
-			return store.GetKeyChainResult{}, err
+			return store.GetParentKeysResult{}, err
 		}
 		keys = append(keys, *key)
 	}
 
 	if err := rows.Err(); err != nil {
-		return store.GetKeyChainResult{}, err
+		return store.GetParentKeysResult{}, err
 	}
 
 	if len(keys) == 0 {
-		return store.GetKeyChainResult{}, store.ErrKeyNotFound
+		return store.GetParentKeysResult{}, store.ErrKeyNotFound
 	}
 
-	return store.GetKeyChainResult{Keys: keys}, nil
+	return store.GetParentKeysResult{Keys: keys}, nil
 }
 
-// GetKeyTree returns all descendants of the given key (including itself)
+// GetDescendantKeys returns all descendants of the given key (including itself)
 // by traversing parent_id down to the leaves.
 // The result is grouped by depth level.
-func (ks *KeyStore) GetKeyTree(ctx context.Context, query store.GetKeyTreeQuery) (store.GetKeyTreeResult, error) {
+func (ks *KeyStore) GetDescendantKeys(ctx context.Context, query store.GetDescendantKeysQuery) (store.GetDescendantKeysResult, error) {
 	stmt := `
 		WITH RECURSIVE key_tree AS (
 			SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, state, created_at, updated_at, 0 AS depth
@@ -126,7 +126,7 @@ func (ks *KeyStore) GetKeyTree(ctx context.Context, query store.GetKeyTreeQuery)
 
 	rows, err := ks.db.QueryContext(ctx, stmt, query.KeyID, query.TenantID)
 	if err != nil {
-		return store.GetKeyTreeResult{}, err
+		return store.GetDescendantKeysResult{}, err
 	}
 	defer rows.Close()
 
@@ -151,12 +151,12 @@ func (ks *KeyStore) GetKeyTree(ctx context.Context, query store.GetKeyTreeQuery)
 			&depth,
 		)
 		if err != nil {
-			return store.GetKeyTreeResult{}, err
+			return store.GetDescendantKeysResult{}, err
 		}
 
 		if len(labelsData) > 0 {
 			if err := json.Unmarshal(labelsData, &key.Labels); err != nil {
-				return store.GetKeyTreeResult{}, err
+				return store.GetDescendantKeysResult{}, err
 			}
 		}
 
@@ -171,14 +171,14 @@ func (ks *KeyStore) GetKeyTree(ctx context.Context, query store.GetKeyTreeQuery)
 	}
 
 	if err := rows.Err(); err != nil {
-		return store.GetKeyTreeResult{}, err
+		return store.GetDescendantKeysResult{}, err
 	}
 
 	if !found {
-		return store.GetKeyTreeResult{}, store.ErrKeyNotFound
+		return store.GetDescendantKeysResult{}, store.ErrKeyNotFound
 	}
 
-	return store.GetKeyTreeResult{KeyTree: layers}, nil
+	return store.GetDescendantKeysResult{KeyTree: layers}, nil
 }
 
 func scanKey(row interface{ Scan(...any) error }) (*model.Key, error) {

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -171,7 +171,7 @@ func TestGetKey(t *testing.T) {
 	})
 }
 
-func TestGetKeyChain(t *testing.T) {
+func TestGetParentKeys(t *testing.T) {
 	// given
 	ctx := t.Context()
 	db, err := sql.Open("postgres", pgConnStr)
@@ -184,12 +184,12 @@ func TestGetKeyChain(t *testing.T) {
 
 	h := createKeyHierarchy(t, keyStore, tenantStore)
 
-	t.Run("should get full key chain for leaf node", func(t *testing.T) {
+	t.Run("should get full parent keys for leaf node", func(t *testing.T) {
 		// given
-		query := store.GetKeyChainQuery{KeyID: h.h.ID, TenantID: h.tenant.ID}
+		query := store.GetParentKeysQuery{KeyID: h.h.ID, TenantID: h.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyChain(ctx, query)
+		result, err := keyStore.GetParentKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -200,12 +200,12 @@ func TestGetKeyChain(t *testing.T) {
 		assert.Equal(t, h.h.ID, result.Keys[3].ID)    // H
 	})
 
-	t.Run("should get key chain for intermediate node", func(t *testing.T) {
+	t.Run("should get parent keys for intermediate node", func(t *testing.T) {
 		// given
-		query := store.GetKeyChainQuery{KeyID: h.c.ID, TenantID: h.tenant.ID}
+		query := store.GetParentKeysQuery{KeyID: h.c.ID, TenantID: h.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyChain(ctx, query)
+		result, err := keyStore.GetParentKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -214,12 +214,12 @@ func TestGetKeyChain(t *testing.T) {
 		assert.Equal(t, h.c.ID, result.Keys[1].ID)    // C
 	})
 
-	t.Run("should get key chain for second intermediate node", func(t *testing.T) {
+	t.Run("should get parent keys for second intermediate node", func(t *testing.T) {
 		// given
-		query := store.GetKeyChainQuery{KeyID: h.e.ID, TenantID: h.tenant.ID}
+		query := store.GetParentKeysQuery{KeyID: h.e.ID, TenantID: h.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyChain(ctx, query)
+		result, err := keyStore.GetParentKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -229,12 +229,12 @@ func TestGetKeyChain(t *testing.T) {
 		assert.Equal(t, h.e.ID, result.Keys[2].ID)    // E
 	})
 
-	t.Run("should get key chain for root node", func(t *testing.T) {
+	t.Run("should get parent keys for root node", func(t *testing.T) {
 		// given
-		query := store.GetKeyChainQuery{KeyID: h.root.ID, TenantID: h.tenant.ID}
+		query := store.GetParentKeysQuery{KeyID: h.root.ID, TenantID: h.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyChain(ctx, query)
+		result, err := keyStore.GetParentKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -244,10 +244,10 @@ func TestGetKeyChain(t *testing.T) {
 
 	t.Run("should return not found for nonexistent key", func(t *testing.T) {
 		// given
-		query := store.GetKeyChainQuery{KeyID: uuid.NewString(), TenantID: h.tenant.ID}
+		query := store.GetParentKeysQuery{KeyID: uuid.NewString(), TenantID: h.tenant.ID}
 
 		// when
-		_, err := keyStore.GetKeyChain(ctx, query)
+		_, err := keyStore.GetParentKeys(ctx, query)
 
 		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
@@ -255,17 +255,17 @@ func TestGetKeyChain(t *testing.T) {
 
 	t.Run("should return not found for wrong tenant", func(t *testing.T) {
 		// given
-		query := store.GetKeyChainQuery{KeyID: h.h.ID, TenantID: uuid.NewString()}
+		query := store.GetParentKeysQuery{KeyID: h.h.ID, TenantID: uuid.NewString()}
 
 		// when
-		_, err := keyStore.GetKeyChain(ctx, query)
+		_, err := keyStore.GetParentKeys(ctx, query)
 
 		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 }
 
-func TestGetKeyTree(t *testing.T) {
+func TestGetDescendantKeys(t *testing.T) {
 	ctx := t.Context()
 	db, err := sql.Open("postgres", pgConnStr)
 	require.NoError(t, err)
@@ -279,10 +279,10 @@ func TestGetKeyTree(t *testing.T) {
 
 	t.Run("should get all key tree for root node", func(t *testing.T) {
 		// given
-		query := store.GetKeyTreeQuery{KeyID: k.root.ID, TenantID: k.tenant.ID}
+		query := store.GetDescendantKeysQuery{KeyID: k.root.ID, TenantID: k.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyTree(ctx, query)
+		result, err := keyStore.GetDescendantKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -313,10 +313,10 @@ func TestGetKeyTree(t *testing.T) {
 
 	t.Run("should get tree for intermediate node", func(t *testing.T) {
 		// given
-		query := store.GetKeyTreeQuery{KeyID: k.c.ID, TenantID: k.tenant.ID}
+		query := store.GetDescendantKeysQuery{KeyID: k.c.ID, TenantID: k.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyTree(ctx, query)
+		result, err := keyStore.GetDescendantKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -341,10 +341,10 @@ func TestGetKeyTree(t *testing.T) {
 
 	t.Run("should get only self for leaf node", func(t *testing.T) {
 		// given
-		query := store.GetKeyTreeQuery{KeyID: k.h.ID, TenantID: k.tenant.ID}
+		query := store.GetDescendantKeysQuery{KeyID: k.h.ID, TenantID: k.tenant.ID}
 
 		// when
-		result, err := keyStore.GetKeyTree(ctx, query)
+		result, err := keyStore.GetDescendantKeys(ctx, query)
 
 		// then
 		require.NoError(t, err)
@@ -362,10 +362,10 @@ func TestGetKeyTree(t *testing.T) {
 
 	t.Run("should return not found for nonexistent key", func(t *testing.T) {
 		// given
-		query := store.GetKeyTreeQuery{KeyID: uuid.NewString(), TenantID: k.tenant.ID}
+		query := store.GetDescendantKeysQuery{KeyID: uuid.NewString(), TenantID: k.tenant.ID}
 
 		// when
-		_, err := keyStore.GetKeyTree(ctx, query)
+		_, err := keyStore.GetDescendantKeys(ctx, query)
 
 		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
@@ -373,10 +373,10 @@ func TestGetKeyTree(t *testing.T) {
 
 	t.Run("should return not found for wrong tenant", func(t *testing.T) {
 		// given
-		query := store.GetKeyTreeQuery{KeyID: k.root.ID, TenantID: uuid.NewString()}
+		query := store.GetDescendantKeysQuery{KeyID: k.root.ID, TenantID: uuid.NewString()}
 
 		// when
-		_, err := keyStore.GetKeyTree(ctx, query)
+		_, err := keyStore.GetDescendantKeys(ctx, query)
 
 		// then
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)


### PR DESCRIPTION
This PR adds 
1.  Renamed  `GetKeyChain` -> `GetParentKeys`
2. `GetDescendentKeys` endpoint 