### PR TITLE
feat: add identity selector

### DIFF
--- a/internal/identity/selector.go
+++ b/internal/identity/selector.go
@@ -1,0 +1,187 @@
+package identity
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrInvalidSelectorPath = errors.New("invalid selector path")
+
+const (
+	// AnyName matches any single name in a field position.
+	AnyName = "*"
+
+	// AnyRemaining matches all remaining fields from its position onward.
+	AnyRemaining = "**"
+)
+
+type (
+	// FieldSelector matches a single Field.
+	FieldSelector struct {
+		Type string
+		Name string
+	}
+
+	// Selector matches identities using a kryptonid:// URI with support for wildcards:
+	//
+	//   - kryptonid://domain/type/name              exact field match, no further fields
+	//   - kryptonid://domain/type/*                 any name for the type, no further fields
+	//   - kryptonid://domain/type/*/othertype/name  any name for first type, exact second field
+	//   - kryptonid://domain/type/**                type must match, any name and any further fields
+	//   - kryptonid://domain/**                     any identity in the domain
+	//
+	// Matching is positional and ** is always terminal.
+	Selector struct {
+		Domain Domain
+		Fields []FieldSelector
+	}
+)
+
+// Matches reports whether the field selector matches the given field.
+func (fs FieldSelector) Matches(f Field) bool {
+	if fs.Type == AnyRemaining {
+		return true
+	}
+	if fs.Type != f.Type {
+		return false
+	}
+	if fs.Name == AnyName || fs.Name == AnyRemaining {
+		return true
+	}
+	return fs.Name == f.Name
+}
+
+// Validate validates that the field selector has valid type and name patterns.
+func (fs FieldSelector) Validate() error {
+	if fs.Type == AnyRemaining {
+		return nil
+	}
+	if fs.Type == "" {
+		return ErrEmptyField
+	}
+	if strings.ContainsAny(fs.Type, invalidChars) {
+		return ErrInvalidCharacters
+	}
+
+	if fs.Name == AnyName || fs.Name == AnyRemaining {
+		return nil
+	}
+	if fs.Name == "" {
+		return ErrEmptyField
+	}
+	if strings.ContainsAny(fs.Name, invalidChars) {
+		return ErrInvalidCharacters
+	}
+
+	return nil
+}
+
+// Matches reports whether the selector matches the given identity.
+func (s Selector) Matches(id Identity) bool {
+	if s.Domain != id.Domain {
+		return false
+	}
+
+	for i, fs := range s.Fields {
+		if fs.Type == AnyRemaining {
+			return true
+		}
+		if i >= len(id.Fields) || !fs.Matches(id.Fields[i]) {
+			return false
+		}
+		if fs.Name == AnyRemaining {
+			return true
+		}
+	}
+
+	return len(id.Fields) == len(s.Fields)
+}
+
+// String returns the kryptonid:// pattern string representation.
+func (s Selector) String() string {
+	var b strings.Builder
+
+	b.WriteString(Scheme)
+	b.WriteString("://")
+	b.WriteString(string(s.Domain))
+
+	for _, fs := range s.Fields {
+		b.WriteByte('/')
+		b.WriteString(fs.Type)
+		if fs.Type == AnyRemaining {
+			break
+		}
+		b.WriteByte('/')
+		b.WriteString(fs.Name)
+	}
+
+	return b.String()
+}
+
+// ParseSelector parses a kryptonid:// pattern string into a Selector.
+// Returns an error if the scheme is wrong, the domain is invalid,
+// or the path contains invalid or incomplete field patterns.
+//
+// Example pattern: kryptonid://acme-corp/node/**
+func ParseSelector(raw string) (Selector, error) {
+	after, found := strings.CutPrefix(raw, Scheme+"://")
+	if !found {
+		return Selector{}, ErrInvalidScheme
+	}
+
+	d, path, _ := strings.Cut(after, "/")
+	if err := Domain(d).Validate(); err != nil {
+		return Selector{}, err
+	}
+
+	fields, err := parseFields(path)
+	if err != nil {
+		return Selector{}, err
+	}
+
+	return Selector{
+		Domain: Domain(d),
+		Fields: fields,
+	}, nil
+}
+
+func parseFields(path string) ([]FieldSelector, error) {
+	if path == "" {
+		return nil, fmt.Errorf("%w: cannot be empty", ErrInvalidSelectorPath)
+	}
+
+	parts := strings.Split(path, "/")
+
+	for i, p := range parts {
+		if p == AnyRemaining && i != len(parts)-1 {
+			return nil, fmt.Errorf("%w: ** must be the last segment", ErrInvalidSelectorPath)
+		}
+	}
+
+	var fields []FieldSelector
+
+	for len(parts) > 0 {
+		if parts[0] == AnyRemaining {
+			fields = append(fields, FieldSelector{Type: AnyRemaining})
+			break
+		}
+
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("%w: incomplete type/name pair", ErrInvalidSelectorPath)
+		}
+
+		fs := FieldSelector{Type: parts[0], Name: parts[1]}
+		if err := fs.Validate(); err != nil {
+			return nil, err
+		}
+
+		fields = append(fields, fs)
+		if fs.Name == AnyRemaining {
+			break
+		}
+		parts = parts[2:]
+	}
+
+	return fields, nil
+}

--- a/internal/identity/selector.go
+++ b/internal/identity/selector.go
@@ -159,8 +159,7 @@ func parseFields(path string) ([]FieldSelector, error) {
 		}
 	}
 
-	var fields []FieldSelector
-
+	fields := make([]FieldSelector, 0, (len(parts)+1)/2)
 	for len(parts) > 0 {
 		if parts[0] == AnyRemaining {
 			fields = append(fields, FieldSelector{Type: AnyRemaining})

--- a/internal/identity/selector_test.go
+++ b/internal/identity/selector_test.go
@@ -1,0 +1,652 @@
+package identity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/internal/identity"
+)
+
+func TestSelectorMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector identity.Selector
+		identity identity.Identity
+		expMatch bool
+	}{
+		{
+			name: "exact match single field",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "root"}},
+			},
+			expMatch: true,
+		},
+		{
+			name: "exact match multiple fields",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			name: "domain mismatch",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+			identity: identity.Identity{
+				Domain: "other",
+				Fields: []identity.Field{{Type: "node", Name: "root"}},
+			},
+			expMatch: false,
+		},
+		{
+			name: "name mismatch",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "agent-01"}},
+			},
+			expMatch: false,
+		},
+		{
+			name: "type mismatch",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "user", Name: "root"}},
+			},
+			expMatch: false,
+		},
+		{
+			name: "selector longer than identity",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "root"}},
+			},
+			expMatch: false,
+		},
+		{
+			name: "identity longer than selector",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expMatch: false,
+		},
+		{
+			name: "single wildcard matches any name",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: identity.AnyName}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "agent-01"}},
+			},
+			expMatch: true,
+		},
+		{
+			name: "any name requires type match",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: identity.AnyName}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "user", Name: "alice"}},
+			},
+			expMatch: false,
+		},
+		{
+			name: "any remaining matches everything from position",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: identity.AnyRemaining}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			name: "any remaining after prefix matches everything from position",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: identity.AnyRemaining},
+				},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			name: "any remaining after prefix with no remaining fields matches everything",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: identity.AnyRemaining},
+				},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "root"}},
+			},
+			expMatch: true,
+		},
+		{
+			name: "type-prefix any remaining matches any identity starting with type",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "user", Name: identity.AnyRemaining}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "user", Name: "alice"}},
+			},
+			expMatch: true,
+		},
+		{
+			name: "type-prefix any remaining matches deeper identity",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "user", Name: identity.AnyRemaining}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{
+					{Type: "user", Name: "alice"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			name: "type-prefix any remaining rejects wrong type",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "user", Name: identity.AnyRemaining}},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "agent-01"}},
+			},
+			expMatch: false,
+		},
+		{
+			name: "type-prefix any remaining after exact prefix",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: identity.AnyRemaining},
+				},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expMatch: true,
+		},
+		{
+			name: "type-prefix any remaining rejects when identity too short",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: identity.AnyRemaining},
+				},
+			},
+			identity: identity.Identity{
+				Domain: "acme",
+				Fields: []identity.Field{{Type: "node", Name: "root"}},
+			},
+			expMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			got := tt.selector.Matches(tt.identity)
+
+			// then
+			assert.Equal(t, tt.expMatch, got)
+		})
+	}
+}
+
+func TestFieldSelectorMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		fsel     identity.FieldSelector
+		field    identity.Field
+		expMatch bool
+	}{
+		{
+			name:     "exact match",
+			fsel:     identity.FieldSelector{Type: "node", Name: "root"},
+			field:    identity.Field{Type: "node", Name: "root"},
+			expMatch: true,
+		},
+		{
+			name:     "type mismatch",
+			fsel:     identity.FieldSelector{Type: "node", Name: "root"},
+			field:    identity.Field{Type: "user", Name: "root"},
+			expMatch: false,
+		},
+		{
+			name:     "name mismatch",
+			fsel:     identity.FieldSelector{Type: "node", Name: "root"},
+			field:    identity.Field{Type: "node", Name: "agent-01"},
+			expMatch: false,
+		},
+		{
+			name:     "wildcard name matches any",
+			fsel:     identity.FieldSelector{Type: "node", Name: identity.AnyName},
+			field:    identity.Field{Type: "node", Name: "anything"},
+			expMatch: true,
+		},
+		{
+			name:     "wildcard name requires type match",
+			fsel:     identity.FieldSelector{Type: "node", Name: identity.AnyName},
+			field:    identity.Field{Type: "user", Name: "anything"},
+			expMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			got := tt.fsel.Matches(tt.field)
+
+			// then
+			assert.Equal(t, tt.expMatch, got)
+		})
+	}
+}
+
+func TestFieldSelectorValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		fsel   identity.FieldSelector
+		expErr error
+	}{
+		{
+			name: "valid exact",
+			fsel: identity.FieldSelector{Type: "node", Name: "root"},
+		},
+		{
+			name: "valid wildcard name",
+			fsel: identity.FieldSelector{Type: "node", Name: identity.AnyName},
+		},
+		{
+			name: "valid type-prefix any remaining",
+			fsel: identity.FieldSelector{Type: "node", Name: identity.AnyRemaining},
+		},
+		{
+			name: "valid any remaining",
+			fsel: identity.FieldSelector{Type: identity.AnyRemaining},
+		},
+		{
+			name:   "empty type",
+			fsel:   identity.FieldSelector{Type: "", Name: "root"},
+			expErr: identity.ErrEmptyField,
+		},
+		{
+			name:   "empty name",
+			fsel:   identity.FieldSelector{Type: "node", Name: ""},
+			expErr: identity.ErrEmptyField,
+		},
+		{
+			name:   "invalid characters in type",
+			fsel:   identity.FieldSelector{Type: "no de", Name: "root"},
+			expErr: identity.ErrInvalidCharacters,
+		},
+		{
+			name:   "invalid characters in name",
+			fsel:   identity.FieldSelector{Type: "node", Name: "ro\tot"},
+			expErr: identity.ErrInvalidCharacters,
+		},
+		{
+			name:   "slash in type",
+			fsel:   identity.FieldSelector{Type: "no/de", Name: "root"},
+			expErr: identity.ErrInvalidCharacters,
+		},
+		{
+			name:   "wildcard in type",
+			fsel:   identity.FieldSelector{Type: "no*de", Name: "root"},
+			expErr: identity.ErrInvalidCharacters,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.fsel.Validate()
+
+			// then
+			if tt.expErr != nil {
+				assert.ErrorIs(t, err, tt.expErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestParseSelector(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		expSelector identity.Selector
+		expErr      error
+	}{
+		{
+			name: "exact single field",
+			raw:  "kryptonid://acme/node/root",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+		},
+		{
+			name: "exact multiple fields",
+			raw:  "kryptonid://acme/node/root/service/kms",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+		},
+		{
+			name: "single wildcard in name",
+			raw:  "kryptonid://acme/node/*",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: identity.AnyName}},
+			},
+		},
+		{
+			name: "any remaining at start",
+			raw:  "kryptonid://acme/**",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: identity.AnyRemaining}},
+			},
+		},
+		{
+			name: "any remaining after prefix",
+			raw:  "kryptonid://acme/node/root/**",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: identity.AnyRemaining},
+				},
+			},
+		},
+		{
+			name: "type-prefix any remaining",
+			raw:  "kryptonid://acme/user/**",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "user", Name: identity.AnyRemaining}},
+			},
+		},
+		{
+			name: "type-prefix any remaining after exact field",
+			raw:  "kryptonid://acme/node/root/service/**",
+			expSelector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: identity.AnyRemaining},
+				},
+			},
+		},
+		{
+			name:   "wrong scheme",
+			raw:    "https://acme/node/root",
+			expErr: identity.ErrInvalidScheme,
+		},
+		{
+			name:   "no scheme",
+			raw:    "acme/node/root",
+			expErr: identity.ErrInvalidScheme,
+		},
+		{
+			name:   "empty domain",
+			raw:    "kryptonid:///node/root",
+			expErr: identity.ErrEmptyDomain,
+		},
+		{
+			name:   "empty path",
+			raw:    "kryptonid://acme",
+			expErr: identity.ErrInvalidSelectorPath,
+		},
+		{
+			name:   "odd path segments",
+			raw:    "kryptonid://acme/node",
+			expErr: identity.ErrInvalidSelectorPath,
+		},
+		{
+			name:   "trailing type without name",
+			raw:    "kryptonid://acme/node/root/service",
+			expErr: identity.ErrInvalidSelectorPath,
+		},
+		{
+			name:   "empty type segment",
+			raw:    "kryptonid://acme//root",
+			expErr: identity.ErrEmptyField,
+		},
+		{
+			name:   "empty name segment",
+			raw:    "kryptonid://acme/node/",
+			expErr: identity.ErrEmptyField,
+		},
+		{
+			name:   "invalid characters in type",
+			raw:    "kryptonid://acme/no de/root",
+			expErr: identity.ErrInvalidCharacters,
+		},
+		{
+			name:   "invalid characters in name",
+			raw:    "kryptonid://acme/node/ro\tot",
+			expErr: identity.ErrInvalidCharacters,
+		},
+		{
+			name:   "wildcard in type",
+			raw:    "kryptonid://acme/no*de/root",
+			expErr: identity.ErrInvalidCharacters,
+		},
+		{
+			name:   "non-terminal any remaining in type position",
+			raw:    "kryptonid://acme/**/service/kms",
+			expErr: identity.ErrInvalidSelectorPath,
+		},
+		{
+			name:   "non-terminal any remaining in name position",
+			raw:    "kryptonid://acme/node/**/service/kms",
+			expErr: identity.ErrInvalidSelectorPath,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			got, err := identity.ParseSelector(tt.raw)
+
+			// then
+			if tt.expErr != nil {
+				assert.ErrorIs(t, err, tt.expErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expSelector, got)
+		})
+	}
+}
+
+func TestSelectorString(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector identity.Selector
+		expStr   string
+	}{
+		{
+			name: "exact single field",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: "root"}},
+			},
+			expStr: "kryptonid://acme/node/root",
+		},
+		{
+			name: "exact multiple fields",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: "kms"},
+				},
+			},
+			expStr: "kryptonid://acme/node/root/service/kms",
+		},
+		{
+			name: "any remaining at start",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: identity.AnyRemaining}},
+			},
+			expStr: "kryptonid://acme/**",
+		},
+		{
+			name: "any remaining after prefix",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: identity.AnyRemaining},
+				},
+			},
+			expStr: "kryptonid://acme/node/root/**",
+		},
+		{
+			name: "type-prefix any remaining",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "user", Name: identity.AnyRemaining}},
+			},
+			expStr: "kryptonid://acme/user/**",
+		},
+		{
+			name: "type-prefix any remaining after exact field",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{
+					{Type: "node", Name: "root"},
+					{Type: "service", Name: identity.AnyRemaining},
+				},
+			},
+			expStr: "kryptonid://acme/node/root/service/**",
+		},
+		{
+			name: "single wildcard in name",
+			selector: identity.Selector{
+				Domain: "acme",
+				Fields: []identity.FieldSelector{{Type: "node", Name: identity.AnyName}},
+			},
+			expStr: "kryptonid://acme/node/*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			got := tt.selector.String()
+
+			// then
+			assert.Equal(t, tt.expStr, got)
+		})
+	}
+}
+
+func TestParseSelectorRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "exact", raw: "kryptonid://acme/node/root/service/kms"},
+		{name: "wildcard name", raw: "kryptonid://acme/node/*/service/kms"},
+		{name: "any remaining", raw: "kryptonid://acme/**"},
+		{name: "any remaining after prefix", raw: "kryptonid://acme/node/root/**"},
+		{name: "type-prefix any remaining", raw: "kryptonid://acme/user/**"},
+		{name: "type-prefix any remaining after prefix", raw: "kryptonid://acme/node/root/service/**"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			parsed, err := identity.ParseSelector(tt.raw)
+
+			// then
+			assert.NoError(t, err)
+			assert.Equal(t, tt.raw, parsed.String())
+		})
+	}
+}

--- a/internal/identity/selector_test.go
+++ b/internal/identity/selector_test.go
@@ -305,6 +305,12 @@ func TestFieldSelectorMatches(t *testing.T) {
 			field:    identity.Field{Type: "user", Name: "anything"},
 			expMatch: false,
 		},
+		{
+			name:     "type any remaining matches any field",
+			fsel:     identity.FieldSelector{Type: identity.AnyRemaining},
+			field:    identity.Field{Type: "node", Name: "root"},
+			expMatch: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   identity selector

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Add identity selector with pattern string parsing, validation and identity matching.
