### PR TITLE
fix: analysis.sh to cleanup tmp dir

### DIFF
--- a/internal/securemem/test/dump/analysis.sh
+++ b/internal/securemem/test/dump/analysis.sh
@@ -13,6 +13,7 @@ cleanup() {
   # Cleanup
   rm -f "$TRIGGER_ID"
   rm -f "secret_${TRIGGER_ID}"
+  rm -f "exposed_${TRIGGER_ID}"
   rm -f "start_${TRIGGER_ID}"
   rm -f "core.${pid}"
   echo "FINISHED"


### PR DESCRIPTION
This cleanup the `exposed-xxxxxx` test files from tmp directory
Please cleanup the the root `./tmp` directory
