### PR TITLE
feat: add secret and cryptor provider

### DIFF
--- a/internal/cryptor/aes256gcm/aes256gcm.go
+++ b/internal/cryptor/aes256gcm/aes256gcm.go
@@ -14,12 +14,27 @@ import (
 	"github.com/openkcm/krypton/internal/securemem"
 )
 
+// TypeAES256GCM identifies the AES-256-GCM cryptor implementation.
+const TypeAES256GCM cryptor.Type = "aes256gcm"
+
 const (
 	// plainTextKey is the vault key used to store decrypted plaintext in secure memory.
 	plainTextKey = "plainText"
 	// cipherTextKey is the vault key used to store encrypted ciphertext in secure memory.
 	cipherTextKey = "cipherText"
 )
+
+// KeySize is the required key size in bytes for AES-256.
+const KeySize = 32
+
+// Config holds configuration for the AES-256-GCM cryptor.
+type Config struct{}
+
+var _ cryptor.Config = (*Config)(nil)
+
+func (c *Config) ValidateCryptorConfig() error {
+	return nil
+}
 
 // AES256GCM implements the Cryptor interface using AES-256 in Galois/Counter Mode.
 // All key material and intermediate plaintext/ciphertext are handled in mlock'd
@@ -30,18 +45,16 @@ type AES256GCM struct {
 
 var _ cryptor.Cryptor = &AES256GCM{}
 
-// InfoNameAES256GCM indicates that the Cryptor supports AES-256 in Galois/Counter Mode (GCM).
-const InfoNameAES256GCM cryptor.InfoName = "AES256-GCM"
-
 // ErrAllocatedDataNotFound indicates that data reserved in the secure memory vault
 // could not be retrieved after the cryptographic operation completed.
 var ErrAllocatedDataNotFound = errors.New("allocated data not found in vault")
 
-// New returns a ready-to-use AES-256-GCM cryptor.
-func New() *AES256GCM {
+// New returns a ready-to-use AES-256-GCM cryptor with the given instance name.
+func New(name string) *AES256GCM {
 	return &AES256GCM{
 		info: cryptor.Info{
-			Name:                     InfoNameAES256GCM,
+			Name:                     name,
+			Type:                     TypeAES256GCM,
 			DecryptionSecretRequired: true,
 		},
 	}
@@ -67,8 +80,8 @@ func (a *AES256GCM) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*c
 	}
 
 	secretSize := len(req.Secret.Data.SecureBytes())
-	if secretSize != 32 {
-		return nil, fmt.Errorf("invalid key size: expected 32 bytes, got %d: %w", secretSize, cryptor.ErrRequest)
+	if secretSize != KeySize {
+		return nil, fmt.Errorf("invalid key size: expected %d bytes, got %d: %w", KeySize, secretSize, cryptor.ErrRequest)
 	}
 
 	resp, err := securemem.Run(ctx, func(ctx context.Context, hr *securemem.HandlerRequest) error {
@@ -141,8 +154,8 @@ func (a *AES256GCM) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*c
 	}
 
 	secretSize := len(req.Secret.Data.SecureBytes())
-	if secretSize != 32 {
-		return nil, fmt.Errorf("invalid key size: expected 32 bytes, got %d: %w", secretSize, cryptor.ErrRequest)
+	if secretSize != KeySize {
+		return nil, fmt.Errorf("invalid key size: expected %d bytes, got %d: %w", KeySize, secretSize, cryptor.ErrRequest)
 	}
 
 	resp, err := securemem.Run(ctx, func(ctx context.Context, hr *securemem.HandlerRequest) error {

--- a/internal/cryptor/aes256gcm/aes256gcm_test.go
+++ b/internal/cryptor/aes256gcm/aes256gcm_test.go
@@ -15,7 +15,7 @@ import (
 func TestAES256GCM_Encrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj := aes256gcm.New()
+	subj := aes256gcm.New("test-aes256gcm")
 
 	t.Run("should fail if encrypt request validation fails", func(t *testing.T) {
 		// given
@@ -215,7 +215,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 func TestAES256GCM_Decrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj := aes256gcm.New()
+	subj := aes256gcm.New("test-aes256gcm")
 
 	t.Run("should fail if decrypt request validation fails", func(t *testing.T) {
 		// given
@@ -376,7 +376,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj := aes256gcm.New()
+	subj := aes256gcm.New("test-aes256gcm")
 
 	t.Run("should encrypt and decrypt plaintext successfully", func(t *testing.T) {
 		// given
@@ -687,13 +687,14 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 func TestAES256GCM_Info(t *testing.T) {
 	// given
-	subj := aes256gcm.New()
+	subj := aes256gcm.New("test-aes256gcm")
 
 	// when
 	info := subj.Info()
 
 	// then
-	assert.Equal(t, aes256gcm.InfoNameAES256GCM, info.Name)
+	assert.Equal(t, "test-aes256gcm", info.Name)
+	assert.Equal(t, aes256gcm.TypeAES256GCM, info.Type)
 	assert.True(t, info.DecryptionSecretRequired)
 }
 

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -73,7 +73,7 @@ type DecryptResponse struct {
 	Plaintext *securemem.Data
 }
 
-// Info describes a Cryptor instance's identity and capabilities.
+// Info describes a Cryptor instance's capabilities.
 type Info struct {
 	// Name is a user-defined instance name from configuration.
 	Name string

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -16,8 +16,8 @@ type KeyAlgorithm string
 // KeyAlgorithmAES256 represents the AES-256 encryption algorithm.
 const KeyAlgorithmAES256 KeyAlgorithm = "AES256"
 
-// InfoName identifies the type of information returned by the Info() method of a Cryptor.
-type InfoName string
+// Type identifies a cryptor implementation for configuration deserialization.
+type Type string
 
 // Secret pairs a key algorithm with its key material stored in secure memory.
 type Secret struct {
@@ -73,12 +73,20 @@ type DecryptResponse struct {
 	Plaintext *securemem.Data
 }
 
-// Info describes a Cryptor implementation's capabilities.
+// Info describes a Cryptor instance's identity and capabilities.
 type Info struct {
-	// Name is a human-readable identifier for the implementation.
-	Name InfoName
+	// Name is a user-defined instance name from configuration.
+	Name string
+	// Type identifies the cryptor implementation (e.g., "aes256gcm").
+	Type Type
 	// DecryptionSecretRequired is false if cryptor manages its own secret (e.g., HSM).
 	DecryptionSecretRequired bool
+}
+
+// Bundle pairs a Cryptor with an optional SecretGenerator for key material creation.
+type Bundle struct {
+	Cryptor         Cryptor
+	SecretGenerator SecretGenerator
 }
 
 // Encryptor performs encryption.
@@ -98,7 +106,16 @@ type Cryptor interface {
 	Info() Info
 }
 
-var ErrRequest = errors.New("invalid cryptographic request")
+// Config is implemented by cryptor-specific configuration structs to support validation.
+type Config interface {
+	ValidateCryptorConfig() error
+}
+
+var (
+	ErrRequest       = errors.New("invalid cryptographic request")
+	ErrUnknownType   = errors.New("unknown cryptor type")
+	ErrConfigInvalid = errors.New("invalid cryptor config")
+)
 
 func (req EncryptRequest) Validate() error {
 	if req.TenantID == "" {

--- a/internal/cryptor/cryptorprovider/provider.go
+++ b/internal/cryptor/cryptorprovider/provider.go
@@ -19,6 +19,7 @@ var ErrCryptorNameEmpty = errors.New("cryptor name is empty")
 type Spec struct {
 	Name   string         `yaml:"name"`
 	Type   cryptor.Type   `yaml:"type"`
+	// Config is marshaled/unmarshaled via custom MarshalYAML/UnmarshalYAML, not by the default YAML codec.
 	Config cryptor.Config `yaml:"-"`
 }
 

--- a/internal/cryptor/cryptorprovider/provider.go
+++ b/internal/cryptor/cryptorprovider/provider.go
@@ -1,0 +1,130 @@
+package cryptorprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
+)
+
+var ErrCryptorNameEmpty = errors.New("cryptor name is empty")
+
+// Spec describes which cryptor implementation to use and how to configure it.
+type Spec struct {
+	Name   string         `yaml:"name"`
+	Type   cryptor.Type   `yaml:"type"`
+	Config cryptor.Config `yaml:"-"`
+}
+
+var (
+	_ yaml.Unmarshaler = (*Spec)(nil)
+	_ yaml.Marshaler   = (*Spec)(nil)
+)
+
+func (s *Spec) MarshalYAML() (any, error) {
+	type alias Spec
+	return struct {
+		alias `yaml:",inline"`
+
+		Config cryptor.Config `yaml:"config"`
+	}{
+		alias:  alias(*s),
+		Config: s.Config,
+	}, nil
+}
+
+func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
+	type alias Spec
+	var raw struct {
+		alias `yaml:",inline"`
+
+		Config yaml.Node `yaml:"config"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return fmt.Errorf("failed to decode cryptor spec: %w", err)
+	}
+
+	cfg, err := newCryptorConfig(raw.Type)
+	if err != nil {
+		return err
+	}
+
+	if raw.Config.Kind != 0 {
+		if err := raw.Config.Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode cryptor config: %w", err)
+		}
+	}
+
+	*s = Spec(raw.alias)
+	s.Config = cfg
+	return nil
+}
+
+// Validate checks the Spec for structural correctness.
+func (s *Spec) Validate() error {
+	if s.Name == "" {
+		return ErrCryptorNameEmpty
+	}
+	if s.Config != nil {
+		if err := s.Config.ValidateCryptorConfig(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetBundle constructs a ready-to-use cryptor Bundle from the given Spec.
+func GetBundle(ctx context.Context, spec Spec) (cryptor.Bundle, error) {
+	switch c := spec.Config.(type) {
+	case *aes256gcm.Config:
+		_ = c // no config fields to use
+		return cryptor.Bundle{
+			Cryptor:         aes256gcm.New(spec.Name),
+			SecretGenerator: cryptor.NewAES256SecretGenerator(),
+		}, nil
+	case *staticsecret.Config:
+		secret, err := getSecret(ctx, c)
+		if err != nil {
+			return cryptor.Bundle{}, err
+		}
+		cryp, err := staticsecret.New(spec.Name, secret.Data)
+		if err != nil {
+			return cryptor.Bundle{}, err
+		}
+		return cryptor.Bundle{
+			Cryptor: cryp,
+		}, nil
+	default:
+		return cryptor.Bundle{}, fmt.Errorf("%w: %T", cryptor.ErrUnknownType, spec.Config)
+	}
+}
+
+// newCryptorConfig is a factory that creates the correct Config struct by cryptor type.
+func newCryptorConfig(t cryptor.Type) (cryptor.Config, error) {
+	switch t {
+	case aes256gcm.TypeAES256GCM:
+		return &aes256gcm.Config{}, nil
+	case staticsecret.TypeStaticSecret:
+		return &staticsecret.Config{}, nil
+	default:
+		return nil, fmt.Errorf("%w: %q", cryptor.ErrUnknownType, t)
+	}
+}
+
+// getSecret gets the cryptor secret for a static-secret cryptor via the configured secret source.
+func getSecret(ctx context.Context, cfg *staticsecret.Config) (cryptor.Secret, error) {
+	data, err := secretprovider.GetSecret(ctx, cfg.Secret)
+	if err != nil {
+		return cryptor.Secret{}, err
+	}
+	return cryptor.Secret{
+		Algorithm: cryptor.KeyAlgorithmAES256,
+		Data:      data,
+	}, nil
+}

--- a/internal/cryptor/cryptorprovider/provider.go
+++ b/internal/cryptor/cryptorprovider/provider.go
@@ -84,7 +84,6 @@ func (s *Spec) Validate() error {
 func GetBundle(ctx context.Context, spec Spec) (cryptor.Bundle, error) {
 	switch c := spec.Config.(type) {
 	case *aes256gcm.Config:
-		_ = c // no config fields to use
 		return cryptor.Bundle{
 			Cryptor:         aes256gcm.New(spec.Name),
 			SecretGenerator: cryptor.NewAES256SecretGenerator(),

--- a/internal/cryptor/cryptorprovider/provider.go
+++ b/internal/cryptor/cryptorprovider/provider.go
@@ -17,8 +17,8 @@ var ErrCryptorNameEmpty = errors.New("cryptor name is empty")
 
 // Spec describes which cryptor implementation to use and how to configure it.
 type Spec struct {
-	Name   string         `yaml:"name"`
-	Type   cryptor.Type   `yaml:"type"`
+	Name string       `yaml:"name"`
+	Type cryptor.Type `yaml:"type"`
 	// Config is marshaled/unmarshaled via custom MarshalYAML/UnmarshalYAML, not by the default YAML codec.
 	Config cryptor.Config `yaml:"-"`
 }

--- a/internal/cryptor/cryptorprovider/provider_test.go
+++ b/internal/cryptor/cryptorprovider/provider_test.go
@@ -1,0 +1,213 @@
+package cryptorprovider_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
+	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
+)
+
+// testKey is a 32-byte AES-256 key for testing.
+var testKey = []byte("01234567890123456789012345678901")
+
+// testKeyBase64 is testKey encoded as base64 (standard encoding).
+var testKeyBase64 = base64.StdEncoding.EncodeToString(testKey)
+
+func TestSpec_Validate(t *testing.T) {
+	tts := []struct {
+		name   string
+		spec   cryptorprovider.Spec
+		expErr error
+	}{
+		{
+			name: "should fail for empty name",
+			spec: cryptorprovider.Spec{
+				Name:   "",
+				Type:   aes256gcm.TypeAES256GCM,
+				Config: &aes256gcm.Config{},
+			},
+			expErr: cryptorprovider.ErrCryptorNameEmpty,
+		},
+		{
+			name: "should pass for valid aes256gcm spec",
+			spec: cryptorprovider.Spec{
+				Name:   "my-cryptor",
+				Type:   aes256gcm.TypeAES256GCM,
+				Config: &aes256gcm.Config{},
+			},
+		},
+		{
+			name: "should propagate config validation error",
+			spec: cryptorprovider.Spec{
+				Name: "my-cryptor",
+				Type: staticsecret.TypeStaticSecret,
+				Config: &staticsecret.Config{
+					Secret: secretprovider.Spec{
+						Type: "",
+					},
+				},
+			},
+			expErr: secretprovider.ErrUnknownType,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.spec.Validate()
+
+			// then
+			if tt.expErr != nil {
+				assert.ErrorIs(t, err, tt.expErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSpec_UnmarshalYAML(t *testing.T) {
+	t.Run("should unmarshal aes256gcm spec", func(t *testing.T) {
+		// given
+		input := `
+name: root-cryptor
+type: aes256gcm
+config: {}
+`
+		// when
+		var spec cryptorprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "root-cryptor", spec.Name)
+		assert.Equal(t, aes256gcm.TypeAES256GCM, spec.Type)
+		assert.IsType(t, &aes256gcm.Config{}, spec.Config)
+	})
+
+	t.Run("should unmarshal staticsecret spec with nested secret config", func(t *testing.T) {
+		// given
+		input := `
+name: static-cryptor
+type: aes256gcm-staticsecret
+config:
+  secret:
+    type: envvar
+    config:
+      name: MY_ROOT_KEY
+`
+		// when
+		var spec cryptorprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "static-cryptor", spec.Name)
+		assert.Equal(t, staticsecret.TypeStaticSecret, spec.Type)
+
+		cfg, ok := spec.Config.(*staticsecret.Config)
+		require.True(t, ok)
+		assert.Equal(t, envvar.Type, cfg.Secret.Type)
+
+		envCfg, ok := cfg.Secret.Config.(*envvar.Config)
+		require.True(t, ok)
+		assert.Equal(t, "MY_ROOT_KEY", envCfg.Name)
+	})
+
+	t.Run("should return error for unknown cryptor type", func(t *testing.T) {
+		// given
+		input := `
+name: bad-cryptor
+type: unknown-type
+config: {}
+`
+		// when
+		var spec cryptorprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		assert.ErrorIs(t, err, cryptor.ErrUnknownType)
+	})
+}
+
+func TestGetBundle(t *testing.T) {
+	t.Run("should return bundle with cryptor and secret generator for aes256gcm", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		spec := cryptorprovider.Spec{
+			Name:   "test-cryptor",
+			Type:   aes256gcm.TypeAES256GCM,
+			Config: &aes256gcm.Config{},
+		}
+
+		// when
+		bundle, err := cryptorprovider.GetBundle(ctx, spec)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, bundle.Cryptor)
+		assert.NotNil(t, bundle.SecretGenerator)
+
+		info := bundle.Cryptor.Info()
+		assert.Equal(t, "test-cryptor", info.Name)
+		assert.Equal(t, aes256gcm.TypeAES256GCM, info.Type)
+		assert.True(t, info.DecryptionSecretRequired)
+	})
+
+	t.Run("should return bundle with cryptor for staticsecret", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		t.Setenv("TEST_STATIC_KEY", testKeyBase64)
+
+		spec := cryptorprovider.Spec{
+			Name: "static-cryptor",
+			Type: staticsecret.TypeStaticSecret,
+			Config: &staticsecret.Config{
+				Secret: secretprovider.Spec{
+					Type: envvar.Type,
+					Config: &envvar.Config{
+						Name: "TEST_STATIC_KEY",
+					},
+				},
+			},
+		}
+
+		// when
+		bundle, err := cryptorprovider.GetBundle(ctx, spec)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, bundle.Cryptor)
+		assert.Nil(t, bundle.SecretGenerator)
+
+		info := bundle.Cryptor.Info()
+		assert.Equal(t, "static-cryptor", info.Name)
+		assert.Equal(t, staticsecret.TypeStaticSecret, info.Type)
+		assert.False(t, info.DecryptionSecretRequired)
+	})
+
+	t.Run("should return error for unknown config type", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		spec := cryptorprovider.Spec{
+			Name: "bad",
+			Type: "unknown",
+		}
+
+		// when
+		bundle, err := cryptorprovider.GetBundle(ctx, spec)
+
+		// then
+		assert.ErrorIs(t, err, cryptor.ErrUnknownType)
+		assert.Zero(t, bundle)
+	})
+}

--- a/internal/cryptor/staticsecret/staticsecret.go
+++ b/internal/cryptor/staticsecret/staticsecret.go
@@ -9,8 +9,23 @@ import (
 
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
 	"github.com/openkcm/krypton/internal/securemem"
 )
+
+// TypeStaticSecret identifies the static-secret cryptor implementation.
+const TypeStaticSecret cryptor.Type = "aes256gcm-staticsecret"
+
+// Config holds configuration for the static-secret cryptor.
+type Config struct {
+	Secret secretprovider.Spec `yaml:"secret"`
+}
+
+var _ cryptor.Config = (*Config)(nil)
+
+func (c *Config) ValidateCryptorConfig() error {
+	return c.Secret.Validate()
+}
 
 // StaticSecret is a [Cryptor] that wraps [AES256GCM] with a pre-configured key,
 // so callers don't need to supply secrets per-request. It rejects requests that
@@ -30,25 +45,23 @@ var ErrInitializationFailed = errors.New("static secret initialization failed")
 
 var _ cryptor.Cryptor = &StaticSecret{}
 
-// InfoNameStaticSecret indicates a Cryptor that manages its own static key material.
-const InfoNameStaticSecret cryptor.InfoName = "AES256-GCM-STATIC-SECRET"
-
-// New returns a StaticSecret for the given algorithm name and key material.
-// Currently only [InfoNameStaticSecret] is supported. The secret must be non-nil and non-empty.
-func New(name cryptor.InfoName, secret *securemem.Data) (*StaticSecret, error) {
-	if name != InfoNameStaticSecret {
-		return nil, fmt.Errorf("unsupported algorithm name: %s: %w", name, ErrInitializationFailed)
+// New returns a StaticSecret with the given instance name and key material.
+// The secret must be non-nil and exactly 32 bytes (AES-256).
+func New(name string, secret *securemem.Data) (*StaticSecret, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name must not be empty: %w", ErrInitializationFailed)
 	}
 
-	if secret == nil || len(secret.SecureBytes()) != 32 {
+	if secret == nil || len(secret.SecureBytes()) != aes256gcm.KeySize {
 		return nil, fmt.Errorf("invalid secret: %w", ErrInitializationFailed)
 	}
 
 	return &StaticSecret{
 		secret:    secret,
-		aes256gcm: aes256gcm.New(),
+		aes256gcm: aes256gcm.New(name),
 		info: cryptor.Info{
 			Name:                     name,
+			Type:                     TypeStaticSecret,
 			DecryptionSecretRequired: false,
 		},
 	}, nil

--- a/internal/cryptor/staticsecret/staticsecret_test.go
+++ b/internal/cryptor/staticsecret/staticsecret_test.go
@@ -20,13 +20,13 @@ func TestStaticSecret_New(t *testing.T) {
 
 	tts := []struct {
 		name    string
-		nameArg cryptor.InfoName
+		nameArg string
 		keyArg  *securemem.Data
 		wantErr bool
 	}{
 		{
 			name:    "should not return error for valid name and key",
-			nameArg: staticsecret.InfoNameStaticSecret,
+			nameArg: "test-static-secret",
 			keyArg:  newSecretKey(t),
 			wantErr: false,
 		},
@@ -38,26 +38,20 @@ func TestStaticSecret_New(t *testing.T) {
 		},
 		{
 			name:    "should return error for nil secret",
-			nameArg: staticsecret.InfoNameStaticSecret,
+			nameArg: "test-static-secret",
 			keyArg:  nil,
 			wantErr: true,
 		},
 		{
 			name:    "should return error for empty secret",
-			nameArg: staticsecret.InfoNameStaticSecret,
+			nameArg: "test-static-secret",
 			keyArg:  &securemem.Data{},
 			wantErr: true,
 		},
 		{
 			name:    "should return error for invalid secret size",
-			nameArg: staticsecret.InfoNameStaticSecret,
+			nameArg: "test-static-secret",
 			keyArg:  secretWithInvalidLen,
-			wantErr: true,
-		},
-		{
-			name:    "should return error if name is unknown",
-			nameArg: "unknown-name",
-			keyArg:  newSecretKey(t),
 			wantErr: true,
 		},
 	}
@@ -83,7 +77,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
 
-	subj, err := staticsecret.New(staticsecret.InfoNameStaticSecret, newSecretKey(t))
+	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
 	t.Run("should fail if encrypt request validation fails", func(t *testing.T) {
@@ -237,7 +231,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 func TestStaticSecret_Decrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
-	subj, err := staticsecret.New(staticsecret.InfoNameStaticSecret, newSecretKey(t))
+	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
 	t.Run("should fail if decrypt request validation fails", func(t *testing.T) {
@@ -369,7 +363,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 	// given
 	ctx := t.Context()
 
-	subj, err := staticsecret.New(staticsecret.InfoNameStaticSecret, newSecretKey(t))
+	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
 	t.Run("should encrypt and decrypt plaintext successfully", func(t *testing.T) {
@@ -497,7 +491,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 
 		// when
 		// decrypt with different staticsecret must fail
-		subj1, err := staticsecret.New(staticsecret.InfoNameStaticSecret, newSecretKey(t))
+		subj1, err := staticsecret.New("test-static-secret", newSecretKey(t))
 		require.NoError(t, err)
 
 		decResp, err := subj1.Decrypt(ctx, cryptor.DecryptRequest{
@@ -618,14 +612,15 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 
 func TestStaticSecret_Info(t *testing.T) {
 	// given
-	subj, err := staticsecret.New(staticsecret.InfoNameStaticSecret, newSecretKey(t))
+	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
 	// when
 	info := subj.Info()
 
 	// then
-	assert.Equal(t, staticsecret.InfoNameStaticSecret, info.Name)
+	assert.Equal(t, "test-static-secret", info.Name)
+	assert.Equal(t, staticsecret.TypeStaticSecret, info.Type)
 	assert.False(t, info.DecryptionSecretRequired)
 }
 

--- a/internal/secret/envvar/envvar.go
+++ b/internal/secret/envvar/envvar.go
@@ -1,0 +1,89 @@
+// Package envvar provides a secret source that loads key material
+// from a base64-encoded environment variable.
+package envvar
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/openkcm/krypton/internal/secret"
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+// Type identifies the environment variable secret source.
+const Type secret.Type = "envvar"
+
+// Config holds configuration for loading a secret from an environment variable.
+// The referenced variable must contain the secret as a base64-encoded string (standard encoding).
+type Config struct {
+	Name string `yaml:"name"` // environment variable name
+}
+
+var _ secret.Config = (*Config)(nil)
+
+// ValidateSecretConfig checks that the environment variable name is set.
+func (c *Config) ValidateSecretConfig() error {
+	if c.Name == "" {
+		return errors.New("environment variable name must not be empty")
+	}
+	return nil
+}
+
+var (
+	ErrEnvVarEmpty  = errors.New("environment variable is empty or not set")
+	ErrBase64Decode = errors.New("failed to base64-decode secret")
+	ErrSecureMemory = errors.New("secure memory error")
+)
+
+// Loader loads secret key material from a base64-encoded environment variable.
+type Loader struct {
+	cfg *Config
+}
+
+var _ secret.Loader = (*Loader)(nil)
+
+// New creates a Loader bound to the given config.
+func New(cfg *Config) *Loader {
+	return &Loader{cfg: cfg}
+}
+
+const memKey = "envvar-secret"
+
+// LoadSecret reads and base64-decodes the secret from the configured environment variable.
+func (l *Loader) LoadSecret(ctx context.Context) (*securemem.Data, error) {
+	raw := os.Getenv(l.cfg.Name)
+	if raw == "" {
+		return nil, fmt.Errorf("%w: %s", ErrEnvVarEmpty, l.cfg.Name)
+	}
+
+	resp, err := securemem.Run(ctx, func(_ context.Context, req *securemem.HandlerRequest) error {
+		keyBytes, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrBase64Decode, err)
+		}
+
+		b, err := req.PersistentVault().Reserve(memKey, len(keyBytes))
+		if err != nil {
+			return err
+		}
+		copy(b, keyBytes)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrSecureMemory, err)
+	}
+
+	secdata, ok := resp.MemVault().Get(memKey)
+	if !ok {
+		destroyErr := resp.MemVault().DestroyAll()
+		return nil, errors.Join(
+			fmt.Errorf("%w: could not retrieve key from vault", ErrSecureMemory),
+			destroyErr,
+		)
+	}
+
+	return secdata, nil
+}

--- a/internal/secret/envvar/envvar_test.go
+++ b/internal/secret/envvar/envvar_test.go
@@ -1,0 +1,105 @@
+package envvar_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/krypton/internal/secret/envvar"
+)
+
+// testKey is a 32-byte AES-256 key for testing.
+var testKey = []byte("01234567890123456789012345678901")
+
+// testKeyBase64 is testKey encoded as base64 (standard encoding).
+var testKeyBase64 = base64.StdEncoding.EncodeToString(testKey)
+
+func TestConfig_ValidateSecretConfig(t *testing.T) {
+	tts := []struct {
+		name   string
+		cfg    envvar.Config
+		expErr bool
+	}{
+		{
+			name: "should pass for non-empty name",
+			cfg: envvar.Config{
+				Name: "MY_SECRET",
+			},
+		},
+		{
+			name: "should fail for empty name",
+			cfg: envvar.Config{
+				Name: "",
+			},
+			expErr: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.cfg.ValidateSecretConfig()
+
+			// then
+			if tt.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestLoader_LoadSecret(t *testing.T) {
+	t.Run("should load base64-encoded secret from env var", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		t.Setenv("TEST_SECRET_KEY", testKeyBase64)
+
+		loader := envvar.New(&envvar.Config{
+			Name: "TEST_SECRET_KEY",
+		})
+
+		// when
+		data, err := loader.LoadSecret(ctx)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, testKey, []byte(data.SecureBytes()))
+		t.Cleanup(func() { _ = data.Destroy() })
+	})
+
+	t.Run("should return error when env var is not set", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		loader := envvar.New(&envvar.Config{
+			Name: "NONEXISTENT_VAR_12345",
+		})
+
+		// when
+		data, err := loader.LoadSecret(ctx)
+
+		// then
+		assert.ErrorIs(t, err, envvar.ErrEnvVarEmpty)
+		assert.Nil(t, data)
+	})
+
+	t.Run("should return error for invalid base64", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		t.Setenv("TEST_BAD_SECRET", "not-valid-base64!!!")
+
+		loader := envvar.New(&envvar.Config{
+			Name: "TEST_BAD_SECRET",
+		})
+
+		// when
+		data, err := loader.LoadSecret(ctx)
+
+		// then
+		assert.ErrorIs(t, err, envvar.ErrSecureMemory)
+		assert.Nil(t, data)
+	})
+}

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -1,0 +1,22 @@
+// Package secret defines interfaces for loading cryptographic key material
+// from external sources (environment variables, files, vaults, etc.).
+package secret
+
+import (
+	"context"
+
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+// Type identifies a secret source implementation for configuration deserialization.
+type Type string
+
+// Config is implemented by each secret source's configuration struct.
+type Config interface {
+	ValidateSecretConfig() error
+}
+
+// Loader loads secret key material from an external source.
+type Loader interface {
+	LoadSecret(ctx context.Context) (*securemem.Data, error)
+}

--- a/internal/secret/secretprovider/provider.go
+++ b/internal/secret/secretprovider/provider.go
@@ -17,6 +17,7 @@ var ErrUnknownType = errors.New("unknown secret source type")
 // Spec describes which secret source implementation to use and how to configure it.
 type Spec struct {
 	Type   secret.Type   `yaml:"type"`
+	// Config is marshaled/unmarshaled via custom MarshalYAML/UnmarshalYAML, not by the default YAML codec.
 	Config secret.Config `yaml:"-"`
 }
 

--- a/internal/secret/secretprovider/provider.go
+++ b/internal/secret/secretprovider/provider.go
@@ -1,0 +1,111 @@
+package secretprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/openkcm/krypton/internal/secret"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+var ErrUnknownType = errors.New("unknown secret source type")
+
+// Spec describes which secret source implementation to use and how to configure it.
+type Spec struct {
+	Type   secret.Type   `yaml:"type"`
+	Config secret.Config `yaml:"-"`
+}
+
+var (
+	_ yaml.Unmarshaler = (*Spec)(nil)
+	_ yaml.Marshaler   = (*Spec)(nil)
+)
+
+// MarshalYAML implements [yaml.Marshaler].
+func (s *Spec) MarshalYAML() (any, error) {
+	type alias Spec
+	return struct {
+		alias `yaml:",inline"`
+
+		Config secret.Config `yaml:"config"`
+	}{
+		alias:  alias(*s),
+		Config: s.Config,
+	}, nil
+}
+
+// UnmarshalYAML implements [yaml.Unmarshaler].
+func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
+	type alias Spec
+	var raw struct {
+		alias `yaml:",inline"`
+
+		Config yaml.Node `yaml:"config"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return fmt.Errorf("failed to decode secret source spec: %w", err)
+	}
+
+	cfg, err := newConfig(raw.Type)
+	if err != nil {
+		return err
+	}
+
+	if raw.Config.Kind != 0 {
+		if err := raw.Config.Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode secret source config: %w", err)
+		}
+	}
+
+	*s = Spec(raw.alias)
+	s.Config = cfg
+	return nil
+}
+
+// Validate checks the Spec for structural correctness.
+func (s *Spec) Validate() error {
+	if s.Type == "" {
+		return fmt.Errorf("%w: type is empty", ErrUnknownType)
+	}
+	if s.Config != nil {
+		return s.Config.ValidateSecretConfig()
+	}
+	return nil
+}
+
+// GetSecret creates the appropriate Loader from the Spec and loads the secret.
+func GetSecret(ctx context.Context, spec Spec) (*securemem.Data, error) {
+	loader, err := newLoader(spec)
+	if err != nil {
+		return nil, err
+	}
+	return loader.LoadSecret(ctx)
+}
+
+// newLoader constructs the appropriate Loader bound to its config.
+func newLoader(spec Spec) (secret.Loader, error) {
+	switch spec.Type {
+	case envvar.Type:
+		cfg, ok := spec.Config.(*envvar.Config)
+		if !ok {
+			return nil, fmt.Errorf("expected *envvar.Config for type %q, got %T", spec.Type, spec.Config)
+		}
+		return envvar.New(cfg), nil
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnknownType, spec.Type)
+	}
+}
+
+// newConfig is a factory that creates the correct Config struct by source type.
+func newConfig(t secret.Type) (secret.Config, error) {
+	switch t {
+	case envvar.Type:
+		return &envvar.Config{}, nil
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnknownType, t)
+	}
+}

--- a/internal/secret/secretprovider/provider.go
+++ b/internal/secret/secretprovider/provider.go
@@ -16,7 +16,7 @@ var ErrUnknownType = errors.New("unknown secret source type")
 
 // Spec describes which secret source implementation to use and how to configure it.
 type Spec struct {
-	Type   secret.Type   `yaml:"type"`
+	Type secret.Type `yaml:"type"`
 	// Config is marshaled/unmarshaled via custom MarshalYAML/UnmarshalYAML, not by the default YAML codec.
 	Config secret.Config `yaml:"-"`
 }

--- a/internal/secret/secretprovider/provider_test.go
+++ b/internal/secret/secretprovider/provider_test.go
@@ -1,0 +1,168 @@
+package secretprovider_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
+)
+
+// testKey is a 32-byte AES-256 key for testing.
+var testKey = []byte("01234567890123456789012345678901")
+
+// testKeyBase64 is testKey encoded as base64 (standard encoding).
+var testKeyBase64 = base64.StdEncoding.EncodeToString(testKey)
+
+func TestSpec_Validate(t *testing.T) {
+	tts := []struct {
+		name   string
+		spec   secretprovider.Spec
+		expErr bool
+	}{
+		{
+			name: "should fail for empty type",
+			spec: secretprovider.Spec{
+				Type: "",
+			},
+			expErr: true,
+		},
+		{
+			name: "should pass for valid envvar spec",
+			spec: secretprovider.Spec{
+				Type: envvar.Type,
+				Config: &envvar.Config{
+					Name: "MY_KEY",
+				},
+			},
+		},
+		{
+			name: "should fail when config validation fails",
+			spec: secretprovider.Spec{
+				Type: envvar.Type,
+				Config: &envvar.Config{
+					Name: "",
+				},
+			},
+			expErr: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.spec.Validate()
+
+			// then
+			if tt.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSpec_UnmarshalYAML(t *testing.T) {
+	t.Run("should unmarshal valid envvar spec", func(t *testing.T) {
+		// given
+		input := `
+type: envvar
+config:
+  name: MY_SECRET_KEY
+`
+		// when
+		var spec secretprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, envvar.Type, spec.Type)
+
+		cfg, ok := spec.Config.(*envvar.Config)
+		require.True(t, ok)
+		assert.Equal(t, "MY_SECRET_KEY", cfg.Name)
+	})
+
+	t.Run("should return error for unknown type", func(t *testing.T) {
+		// given
+		input := `
+type: unknown-type
+config:
+  foo: bar
+`
+		// when
+		var spec secretprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		assert.ErrorIs(t, err, secretprovider.ErrUnknownType)
+	})
+}
+
+func TestSpec_MarshalYAML(t *testing.T) {
+	// given
+	spec := secretprovider.Spec{
+		Type: envvar.Type,
+		Config: &envvar.Config{
+			Name: "MY_KEY",
+		},
+	}
+
+	// when
+	data, err := yaml.Marshal(&spec)
+
+	// then
+	require.NoError(t, err)
+
+	var roundTrip secretprovider.Spec
+	err = yaml.Unmarshal(data, &roundTrip)
+	require.NoError(t, err)
+
+	assert.Equal(t, spec.Type, roundTrip.Type)
+	cfg, ok := roundTrip.Config.(*envvar.Config)
+	require.True(t, ok)
+	assert.Equal(t, "MY_KEY", cfg.Name)
+}
+
+func TestGetSecret(t *testing.T) {
+	t.Run("should load secret via envvar loader", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		t.Setenv("TEST_PROVIDER_KEY", testKeyBase64)
+
+		spec := secretprovider.Spec{
+			Type: envvar.Type,
+			Config: &envvar.Config{
+				Name: "TEST_PROVIDER_KEY",
+			},
+		}
+
+		// when
+		data, err := secretprovider.GetSecret(ctx, spec)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, testKey, []byte(data.SecureBytes()))
+		t.Cleanup(func() { _ = data.Destroy() })
+	})
+
+	t.Run("should return error for unknown type", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		spec := secretprovider.Spec{
+			Type: "nonexistent",
+		}
+
+		// when
+		data, err := secretprovider.GetSecret(ctx, spec)
+
+		// then
+		assert.ErrorIs(t, err, secretprovider.ErrUnknownType)
+		assert.Nil(t, data)
+	})
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add secret and cryptor provider

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Add a provider layer for cryptors and an independent secret-loading package so that cryptor bundles and their key material can be resolved from YAML configuration at runtime.
