### PR TITLE
feat: add ListKeys with cursor-based pagination and filtering

### DIFF
--- a/integration/key_test.go
+++ b/integration/key_test.go
@@ -204,16 +204,19 @@ type keyTreeRow struct {
 	Status    string
 }
 
-// keyHierarchy holds a test key tree with the following structure:
+// keyHierarchy holds a test key tree with 8 keys across 4 levels (K0-K3).
+// Each key is assigned to a different managing agent to test cross-agent hierarchy traversal.
 //
-//	A(K0)
-//	  B(K1)
-//	    D(K2)
-//	    E(K2)
-//	  C(K1)
-//	    F(K2)
-//	    G(K2)
-//	      H(K3)
+// Tree structure:
+//
+//	A (K0, root)
+//	├── B (K1, root)
+//	│   ├── D (K2, agent-aws)
+//	│   └── E (K2, agent-azure)
+//	└── C (K1, root)
+//	    ├── F (K2, agent-gcp)
+//	    └── G (K2, agent-onprem)
+//	        └── H (K3, agent-onprem-2)
 type keyHierarchy struct {
 	root model.Key // A
 	b    model.Key
@@ -225,17 +228,9 @@ type keyHierarchy struct {
 	h    model.Key
 }
 
-// createKeyHierarchy sets up a test key hierarchy with 8 keys across 4 levels and returns the created keys for reference in tests.
-// keyHierarchy holds a test key tree with the following structure:
-//
-//	A(K0)
-//	  B(K1)
-//	    D(K2)
-//	    E(K2)
-//	  C(K1)
-//	    F(K2)
-//	    G(K2)
-//	      H(K3)
+// createKeyHierarchy creates 8 keys forming the tree documented on [keyHierarchy].
+// All keys start in pre-activation state with no labels. Each key is assigned to a distinct
+// managing agent to support integration tests for cross-agent key distribution and hierarchy queries.
 func createKeyHierarchy(t *testing.T, keyStore store.Key, tenantID string) keyHierarchy {
 	t.Helper()
 	ctx := t.Context()

--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -18,6 +18,7 @@ type Key interface {
 	GetKeyByName(ctx context.Context, query GetKeyByNameQuery) (*model.Key, error)
 	GetParentKeys(ctx context.Context, query GetParentKeysQuery) (GetParentKeysResult, error)
 	GetDescendantKeys(ctx context.Context, query GetDescendantKeysQuery) (GetDescendantKeysResult, error)
+	ListKeys(ctx context.Context, query ListKeysQuery) (ListKeysResult, error)
 	UpdateKeyLifeCycleState(ctx context.Context, query UpdateKeyLifeCycleStateQuery) error
 	UpdateKeyProcessingState(ctx context.Context, query UpdateKeyProcessingStateQuery) error
 }
@@ -43,6 +44,23 @@ type GetDescendantKeysQuery struct {
 
 type GetDescendantKeysResult struct {
 	KeyTree model.KeyTreeTraverser
+}
+
+type ListKeysQuery struct {
+	TenantID              string
+	Name                  string
+	Kind                  model.KeyKind
+	State                 model.KeyLifeCycleState
+	ManagedBy             string
+	Labels                model.Labels
+	IsOrderByCreatedAtAsc bool
+	Cursor                string
+	Limit                 int
+}
+
+type ListKeysResult struct {
+	Keys   []model.Key
+	Cursor string
 }
 
 type UpdateKeyLifeCycleStateQuery struct {

--- a/pkg/store/sql/cursor.go
+++ b/pkg/store/sql/cursor.go
@@ -1,0 +1,40 @@
+package sql
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/openkcm/krypton/internal/clock"
+)
+
+type cursor struct {
+	ID        string         `json:"id"`
+	CreatedAt clock.UnixNano `json:"created_at"`
+}
+
+func NewCursor(id string, createdAt clock.UnixNano) cursor {
+	return cursor{
+		ID:        id,
+		CreatedAt: createdAt,
+	}
+}
+
+func (c cursor) Encode() (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func DecodeCursor(es string) (cursor, error) {
+	var c cursor
+	b, err := base64.RawURLEncoding.DecodeString(es)
+	if err != nil {
+		return c, err
+	}
+	if err := json.Unmarshal(b, &c); err != nil {
+		return c, err
+	}
+	return c, nil
+}

--- a/pkg/store/sql/cursor_test.go
+++ b/pkg/store/sql/cursor_test.go
@@ -1,0 +1,92 @@
+package sql_test
+
+import (
+	"encoding/base64"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/krypton/internal/clock"
+	"github.com/openkcm/krypton/pkg/store/sql"
+)
+
+func TestCursorEncodeDecode(t *testing.T) {
+	// Matches base64url characters only (no padding)
+	var b64urlRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+	tests := []struct {
+		name      string
+		id        string
+		createdAt clock.UnixNano
+	}{
+		{
+			name:      "valid cursor with special characters",
+			id:        "123e4567-e89b-12d3-a456-426614174000.+/~!@#$%^&*(){}[]|:;'<>,.?",
+			createdAt: 1620000000000000000,
+		},
+		{
+			name:      "for zero createdAt",
+			id:        "123e4567-e89b-12d3-a456-426614174001",
+			createdAt: 0,
+		},
+		{
+			name:      "for empty id",
+			id:        "",
+			createdAt: 426614174000,
+		},
+		{
+			name:      "for empty id and zero createdAt",
+			id:        "",
+			createdAt: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			subj := sql.NewCursor(tt.id, tt.createdAt)
+
+			// when
+			encoded, err := subj.Encode()
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, b64urlRe.MatchString(encoded))
+
+			// when
+			decoded, err := sql.DecodeCursor(encoded)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tt.id, decoded.ID)
+			assert.Equal(t, tt.createdAt, decoded.CreatedAt)
+		})
+	}
+}
+
+func TestDecodeCursor_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "invalid base64",
+			input: "not-valid-base64!!!",
+		},
+		{
+			name:  "valid base64 but invalid JSON",
+			input: base64.RawURLEncoding.EncodeToString([]byte("{not json")),
+		},
+		{
+			name:  "empty string",
+			input: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sql.DecodeCursor(tt.input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/store/sql/cursor_test.go
+++ b/pkg/store/sql/cursor_test.go
@@ -66,6 +66,7 @@ func TestCursorEncodeDecode(t *testing.T) {
 }
 
 func TestDecodeCursor_Invalid(t *testing.T) {
+	// given
 	tests := []struct {
 		name  string
 		input string
@@ -85,8 +86,11 @@ func TestDecodeCursor_Invalid(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// when
 			_, err := sql.DecodeCursor(tt.input)
-			require.Error(t, err)
+
+			// then
+			assert.Error(t, err)
 		})
 	}
 }

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 
@@ -215,43 +217,102 @@ func (ks *KeyStore) GetDescendantKeys(ctx context.Context, query store.GetDescen
 	return store.GetDescendantKeysResult{KeyTree: layers}, nil
 }
 
-func scanKey(row interface{ Scan(...any) error }) (*model.Key, error) {
-	var key model.Key
-	var labelsData []byte
-	var processingJobID sql.NullString
+func (ks *KeyStore) ListKeys(ctx context.Context, query store.ListKeysQuery) (store.ListKeysResult, error) {
+	params := make([]any, 0, 12)
+	nextParam := func(vals ...any) string {
+		placeholders := make([]string, len(vals))
+		for i, v := range vals {
+			params = append(params, v)
+			placeholders[i] = fmt.Sprintf("$%d", len(params))
+		}
+		return strings.Join(placeholders, ", ")
+	}
 
-	err := row.Scan(
-		&key.ID,
-		&key.TenantID,
-		&key.Kind,
-		&key.Name,
-		&key.ParentID,
-		&key.ManagedBy,
-		&labelsData,
-		&key.LifeCycleState,
-		&key.KeyProcessingState.Status,
-		&processingJobID,
-		&key.CreatedAt,
-		&key.UpdatedAt,
-	)
+	var q strings.Builder
+
+	fmt.Fprintf(&q, `SELECT id, tenant_id, kind, name, parent_id, managed_by, labels, life_cycle_state, processing_status, processing_job_id, created_at, updated_at 
+	FROM keys 
+	WHERE tenant_id = %s `, nextParam(query.TenantID))
+
+	if query.Kind != "" {
+		fmt.Fprintf(&q, "AND kind = %s ", nextParam(query.Kind))
+	}
+
+	if query.State != "" {
+		fmt.Fprintf(&q, "AND life_cycle_state = %s ", nextParam(query.State))
+	}
+
+	if query.Name != "" {
+		fmt.Fprintf(&q, "AND name ILIKE %s ", nextParam("%"+query.Name+"%"))
+	}
+
+	if query.ManagedBy != "" {
+		fmt.Fprintf(&q, "AND managed_by = %s ", nextParam(query.ManagedBy))
+	}
+
+	for k, v := range query.Labels {
+		labelJSON, err := json.Marshal(map[string]string{k: v})
+		if err != nil {
+			return store.ListKeysResult{}, err
+		}
+		fmt.Fprintf(&q, "AND labels @> %s::jsonb ", nextParam(string(labelJSON)))
+	}
+
+	if query.Cursor != "" {
+		cursor, err := DecodeCursor(query.Cursor)
+		if err != nil {
+			return store.ListKeysResult{}, fmt.Errorf("invalid cursor: %w", err)
+		}
+		op := "<"
+		if query.IsOrderByCreatedAtAsc {
+			op = ">"
+		}
+		fmt.Fprintf(&q, "AND (created_at, id) %s (%s) ", op, nextParam(cursor.CreatedAt, cursor.ID))
+	}
+
+	if query.IsOrderByCreatedAtAsc {
+		q.WriteString("ORDER BY created_at ASC, id ASC ")
+	} else {
+		q.WriteString("ORDER BY created_at DESC, id DESC ")
+	}
+
+	pageSize := query.Limit
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+	fetchLimit := pageSize + 1
+
+	fmt.Fprintf(&q, "LIMIT %s ", nextParam(fetchLimit))
+
+	rows, err := ks.db.QueryContext(ctx, q.String(), params...)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, store.ErrKeyNotFound
+		return store.ListKeysResult{}, err
+	}
+	defer rows.Close()
+
+	keys := make([]model.Key, 0, fetchLimit)
+	for rows.Next() {
+		key, err := scanKey(rows)
+		if err != nil {
+			return store.ListKeysResult{}, err
 		}
-		return nil, err
+		keys = append(keys, *key)
+	}
+	if err := rows.Err(); err != nil {
+		return store.ListKeysResult{}, err
 	}
 
-	if processingJobID.Valid {
-		key.KeyProcessingState.JobID = processingJobID.String
-	}
-
-	if len(labelsData) > 0 {
-		if err := json.Unmarshal(labelsData, &key.Labels); err != nil {
-			return nil, err
+	var cursor string
+	if len(keys) == fetchLimit {
+		last := keys[pageSize-1]
+		cursor, err = NewCursor(last.ID, last.CreatedAt).Encode()
+		if err != nil {
+			return store.ListKeysResult{}, err
 		}
+		keys = keys[:pageSize]
 	}
 
-	return &key, nil
+	return store.ListKeysResult{Keys: keys, Cursor: cursor}, nil
 }
 
 func (ks *KeyStore) UpdateKeyLifeCycleState(ctx context.Context, query store.UpdateKeyLifeCycleStateQuery) error {
@@ -301,4 +362,43 @@ func nullableJobID(jobID string) any {
 		return nil
 	}
 	return jobID
+}
+
+func scanKey(row interface{ Scan(...any) error }) (*model.Key, error) {
+	var key model.Key
+	var labelsData []byte
+	var processingJobID sql.NullString
+
+	err := row.Scan(
+		&key.ID,
+		&key.TenantID,
+		&key.Kind,
+		&key.Name,
+		&key.ParentID,
+		&key.ManagedBy,
+		&labelsData,
+		&key.LifeCycleState,
+		&key.KeyProcessingState.Status,
+		&processingJobID,
+		&key.CreatedAt,
+		&key.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, store.ErrKeyNotFound
+		}
+		return nil, err
+	}
+
+	if processingJobID.Valid {
+		key.KeyProcessingState.JobID = processingJobID.String
+	}
+
+	if len(labelsData) > 0 {
+		if err := json.Unmarshal(labelsData, &key.Labels); err != nil {
+			return nil, err
+		}
+	}
+
+	return &key, nil
 }

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -2,6 +2,7 @@ package sql_test
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"testing"
 
 	"github.com/google/uuid"
@@ -15,19 +16,27 @@ import (
 	storesql "github.com/openkcm/krypton/pkg/store/sql"
 )
 
-// keyHierarchy holds a test key tree with the following structure:
+// keyHierarchy holds a test key tree with 10 keys across 4 levels (K0-K3).
+// Each key has a distinct lifecycle state, managing agent, and labels to enable
+// targeted filtering, lifecycle transition, and hierarchy traversal tests.
 //
-//	A(K0)
-//	  B(K1)
-//	    D(K2)
-//	    E(K2)
-//	  C(K1)
-//	    F(K2)
-//	    G(K2)
-//	      H(K3)
+// Tree structure:
+//
+//	A (K0, root, active, cloud=gcp)
+//	├── aB (K1, root, pre-activation, cloud=gcp)
+//	├── BA (K1, root, pre-activation, cloud=aws1)
+//	├── B (K1, root, active, cloud=gcp)
+//	│   ├── D (K2, agent-aws, suspended, cloud=aws)
+//	│   └── E (K2, agent-azure, pre-activation, cloud=azure, environment=prod)
+//	└── C (K1, root, pre-activation, cloud=azure)
+//	    ├── F (K2, agent-gcp, pre-activation, cloud=aws, environment=prod)
+//	    └── G (K2, agent-onprem, pre-activation, cloud=azure)
+//	        └── H (K3, agent-onprem-2, pre-activation, cloud=aws)
 type keyHierarchy struct {
 	tenant model.Tenant
 	root   model.Key // A
+	ab     model.Key // aB
+	ba     model.Key // BA
 	b      model.Key
 	c      model.Key
 	d      model.Key
@@ -457,14 +466,16 @@ func TestGetDescendantKeys(t *testing.T) {
 				require.Len(t, layer, 1)                // depth 0: A
 				assert.Equal(t, k.root.ID, layer[0].ID) // A
 			case 1:
-				require.Len(t, layer, 2)             // depth 1: B, C
-				assert.Equal(t, k.b.ID, layer[0].ID) // B
-				assert.Equal(t, k.c.ID, layer[1].ID) // C
+				require.Len(t, layer, 4)              // depth 1: AB,BA, B, C
+				assert.Equal(t, k.ab.ID, layer[0].ID) // AB
+				assert.Equal(t, k.ba.ID, layer[1].ID) // BA
+				assert.Equal(t, k.b.ID, layer[2].ID)  // B
+				assert.Equal(t, k.c.ID, layer[3].ID)  // C
 			case 2:
 				require.Len(t, layer, 4)             // depth 2: D, E, F, G
+				assert.Equal(t, k.f.ID, layer[2].ID) // F
 				assert.Equal(t, k.d.ID, layer[0].ID) // D
 				assert.Equal(t, k.e.ID, layer[1].ID) // E
-				assert.Equal(t, k.f.ID, layer[2].ID) // F
 				assert.Equal(t, k.g.ID, layer[3].ID) // G
 			case 3:
 				require.Len(t, layer, 1)             // depth 3: H
@@ -547,50 +558,361 @@ func TestGetDescendantKeys(t *testing.T) {
 	})
 }
 
-// createKeyHierarchy sets up a test key hierarchy with 8 keys across 4 levels and returns the created keys for reference in tests.
-// keyHierarchy holds a test key tree with the following structure:
-//
-//	A(K0)
-//	  B(K1)
-//	    D(K2)
-//	    E(K2)
-//	  C(K1)
-//	    F(K2)
-//	    G(K2)
-//	      H(K3)
+func TestListKeys(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	tenantStore := storesql.NewTenantStore(db)
+	require.NoError(t, storesql.Migrate(ctx, db))
+	keyStore := storesql.NewKeyStore(db)
+
+	h := createKeyHierarchy(t, keyStore, tenantStore)
+
+	t.Run("should list all keys in descending order", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, IsOrderByCreatedAtAsc: false}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 10)
+		assert.Equal(t, h.h.ID, result.Keys[0].ID)    // H
+		assert.Equal(t, h.g.ID, result.Keys[1].ID)    // G
+		assert.Equal(t, h.f.ID, result.Keys[2].ID)    // F
+		assert.Equal(t, h.e.ID, result.Keys[3].ID)    // E
+		assert.Equal(t, h.d.ID, result.Keys[4].ID)    // D
+		assert.Equal(t, h.c.ID, result.Keys[5].ID)    // C
+		assert.Equal(t, h.b.ID, result.Keys[6].ID)    // B
+		assert.Equal(t, h.ba.ID, result.Keys[7].ID)   // BA
+		assert.Equal(t, h.ab.ID, result.Keys[8].ID)   // AB
+		assert.Equal(t, h.root.ID, result.Keys[9].ID) // A
+	})
+
+	t.Run("should list all keys in ascending order", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, IsOrderByCreatedAtAsc: true}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 10)
+		assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
+		assert.Equal(t, h.ab.ID, result.Keys[1].ID)   // AB
+		assert.Equal(t, h.ba.ID, result.Keys[2].ID)   // BA
+		assert.Equal(t, h.b.ID, result.Keys[3].ID)    // B
+		assert.Equal(t, h.c.ID, result.Keys[4].ID)    // C
+		assert.Equal(t, h.d.ID, result.Keys[5].ID)    // D
+		assert.Equal(t, h.e.ID, result.Keys[6].ID)    // E
+		assert.Equal(t, h.f.ID, result.Keys[7].ID)    // F
+		assert.Equal(t, h.g.ID, result.Keys[8].ID)    // G
+		assert.Equal(t, h.h.ID, result.Keys[9].ID)    // H
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		t.Run("should paginate through all pages in descending order", func(t *testing.T) {
+			// given
+			query := store.ListKeysQuery{TenantID: h.tenant.ID, Limit: 3}
+
+			// when
+			result, err := keyStore.ListKeys(ctx, query)
+
+			// then
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 3)
+
+			assert.Equal(t, h.h.ID, result.Keys[0].ID) // H
+			assert.Equal(t, h.g.ID, result.Keys[1].ID) // G
+			assert.Equal(t, h.f.ID, result.Keys[2].ID) // F
+			assert.NotEmpty(t, result.Cursor)
+
+			query.Cursor = result.Cursor
+			result, err = keyStore.ListKeys(ctx, query)
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 3)
+			assert.Equal(t, h.e.ID, result.Keys[0].ID) // E
+			assert.Equal(t, h.d.ID, result.Keys[1].ID) // D
+			assert.Equal(t, h.c.ID, result.Keys[2].ID) // C
+			assert.NotEmpty(t, result.Cursor)
+
+			query.Cursor = result.Cursor
+			result, err = keyStore.ListKeys(ctx, query)
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 3)
+			assert.Equal(t, h.b.ID, result.Keys[0].ID)  // B
+			assert.Equal(t, h.ba.ID, result.Keys[1].ID) // BA
+			assert.Equal(t, h.ab.ID, result.Keys[2].ID) // AB
+			assert.NotEmpty(t, result.Cursor)
+
+			query.Cursor = result.Cursor
+			result, err = keyStore.ListKeys(ctx, query)
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 1)
+			assert.Equal(t, h.root.ID, result.Keys[0].ID) // A
+			assert.Empty(t, result.Cursor)
+		})
+
+		t.Run("should return empty cursor when limit equals total records", func(t *testing.T) {
+			// given
+			query := store.ListKeysQuery{TenantID: h.tenant.ID, Limit: 10}
+
+			// when
+			result, err := keyStore.ListKeys(ctx, query)
+
+			// then
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 10)
+			assert.Empty(t, result.Cursor)
+		})
+
+		t.Run("should return empty cursor when limit exceeds total records", func(t *testing.T) {
+			// given
+			query := store.ListKeysQuery{TenantID: h.tenant.ID, Limit: 20}
+
+			// when
+			result, err := keyStore.ListKeys(ctx, query)
+
+			// then
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 10)
+			assert.Empty(t, result.Cursor)
+		})
+
+		t.Run("should return empty cursor when limit is negative as default limit is 50", func(t *testing.T) {
+			// given
+			query := store.ListKeysQuery{TenantID: h.tenant.ID, Limit: -1}
+
+			// when
+			result, err := keyStore.ListKeys(ctx, query)
+
+			// then
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 10)
+			assert.Empty(t, result.Cursor)
+		})
+
+		t.Run("should return empty cursor when limit is zero as default limit is 50", func(t *testing.T) {
+			// given
+			query := store.ListKeysQuery{TenantID: h.tenant.ID, Limit: 0}
+
+			// when
+			result, err := keyStore.ListKeys(ctx, query)
+
+			// then
+			require.NoError(t, err)
+			require.Len(t, result.Keys, 10)
+			assert.Empty(t, result.Cursor)
+		})
+
+		t.Run("should return error for tampered cursor", func(t *testing.T) {
+			// given
+			query := store.ListKeysQuery{
+				TenantID: h.tenant.ID,
+				Cursor:   base64.RawURLEncoding.EncodeToString([]byte("{not json")),
+			}
+
+			// when
+			_, err := keyStore.ListKeys(ctx, query)
+
+			// then
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid cursor")
+		})
+	})
+
+	t.Run("should return empty list for tenant with no keys", func(t *testing.T) {
+		// given
+		tenant := createTenant(t, tenantStore)
+		query := store.ListKeysQuery{TenantID: tenant.ID}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result.Keys)
+	})
+
+	t.Run("should filter by kind", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, Kind: "K1"}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 4)
+		assert.Equal(t, h.ab.ID, result.Keys[3].ID) // AB
+		assert.Equal(t, h.ba.ID, result.Keys[2].ID) // BA
+		assert.Equal(t, h.b.ID, result.Keys[1].ID)  // B
+		assert.Equal(t, h.c.ID, result.Keys[0].ID)  // C
+	})
+
+	t.Run("should filter by lifecycle state", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, State: model.KeyLifeCycleSuspended}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 1)
+		assert.Equal(t, h.d.ID, result.Keys[0].ID) // D
+	})
+
+	t.Run("should filter by managing agent", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, ManagedBy: "agent-onprem"}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 1)
+		assert.Equal(t, h.g.ID, result.Keys[0].ID) // G
+	})
+
+	t.Run("should filter by labels", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, Labels: model.Labels{"cloud": "aws"}}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 3)
+		assert.Equal(t, h.h.ID, result.Keys[0].ID) // H
+		assert.Equal(t, h.f.ID, result.Keys[1].ID) // F
+		assert.Equal(t, h.d.ID, result.Keys[2].ID) // D
+	})
+
+	t.Run("should filter by multiple labels", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, Labels: model.Labels{"cloud": "azure", "environment": "prod"}}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 1)
+		assert.Equal(t, h.e.ID, result.Keys[0].ID) // E
+	})
+
+	t.Run("should filter by name substring", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{TenantID: h.tenant.ID, Name: "a"}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 3)
+		assert.Equal(t, h.root.ID, result.Keys[2].ID) // A
+		assert.Equal(t, h.ab.ID, result.Keys[1].ID)   // AB
+		assert.Equal(t, h.ba.ID, result.Keys[0].ID)   // BA
+	})
+
+	t.Run("should filter by multiple criteria", func(t *testing.T) {
+		// given
+		query := store.ListKeysQuery{
+			TenantID:  h.tenant.ID,
+			Kind:      "K2",
+			State:     model.KeyLifeCyclePreActivation,
+			ManagedBy: "agent-azure",
+			Labels:    model.Labels{"environment": "prod"},
+		}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, result.Keys, 1)
+		assert.Equal(t, h.e.ID, result.Keys[0].ID) // E
+	})
+}
+
+// createKeyHierarchy creates a tenant and inserts 10 keys forming the tree documented on [keyHierarchy].
+// Keys are created with varying lifecycle states (active, suspended, pre-activation), managing agents
+// (root, agent-aws, agent-azure, agent-gcp, agent-onprem, agent-onprem-2), and labels (cloud, environment)
+// to support filtering, lifecycle transition, and hierarchy traversal tests.
 func createKeyHierarchy(t *testing.T, keyStore *storesql.KeyStore, tenantStore *storesql.TenantStore) keyHierarchy {
 	t.Helper()
 	ctx := t.Context()
 
 	tenant := createTenant(t, tenantStore)
 
-	root := model.NewKey(tenant.ID, "A", "K0", nil, "root", nil)
+	root := model.NewKey(tenant.ID, "A", "K0", nil, "root", model.Labels{
+		"cloud": "gcp",
+	})
+	root.LifeCycleState = model.KeyLifeCycleActive
 	require.NoError(t, keyStore.CreateKey(ctx, root))
 
-	b := model.NewKey(tenant.ID, "B", "K1", &root.ID, "root", nil)
+	ab := model.NewKey(tenant.ID, "aB", "K1", &root.ID, "root", model.Labels{
+		"cloud": "gcp",
+	})
+	require.NoError(t, keyStore.CreateKey(ctx, ab))
+
+	ba := model.NewKey(tenant.ID, "BA", "K1", &root.ID, "root", model.Labels{
+		"cloud": "aws1",
+	})
+	require.NoError(t, keyStore.CreateKey(ctx, ba))
+
+	b := model.NewKey(tenant.ID, "B", "K1", &root.ID, "root", model.Labels{
+		"cloud": "gcp",
+	})
+	b.LifeCycleState = model.KeyLifeCycleActive
 	require.NoError(t, keyStore.CreateKey(ctx, b))
 
-	c := model.NewKey(tenant.ID, "C", "K1", &root.ID, "root", nil)
+	c := model.NewKey(tenant.ID, "C", "K1", &root.ID, "root", model.Labels{
+		"cloud": "azure",
+	})
 	require.NoError(t, keyStore.CreateKey(ctx, c))
 
-	d := model.NewKey(tenant.ID, "D", "K2", &b.ID, "agent-aws", nil)
+	d := model.NewKey(tenant.ID, "D", "K2", &b.ID, "agent-aws", model.Labels{
+		"cloud": "aws",
+	})
+	d.LifeCycleState = model.KeyLifeCycleSuspended
 	require.NoError(t, keyStore.CreateKey(ctx, d))
 
-	e := model.NewKey(tenant.ID, "E", "K2", &b.ID, "agent-azure", nil)
+	e := model.NewKey(tenant.ID, "E", "K2", &b.ID, "agent-azure", model.Labels{
+		"cloud":       "azure",
+		"environment": "prod",
+	})
 	require.NoError(t, keyStore.CreateKey(ctx, e))
 
-	f := model.NewKey(tenant.ID, "F", "K2", &c.ID, "agent-gcp", nil)
+	f := model.NewKey(tenant.ID, "F", "K2", &c.ID, "agent-gcp", model.Labels{
+		"cloud":       "aws",
+		"environment": "prod",
+	})
 	require.NoError(t, keyStore.CreateKey(ctx, f))
 
-	g := model.NewKey(tenant.ID, "G", "K2", &c.ID, "agent-onprem", nil)
+	g := model.NewKey(tenant.ID, "G", "K2", &c.ID, "agent-onprem", model.Labels{
+		"cloud": "azure",
+	})
 	require.NoError(t, keyStore.CreateKey(ctx, g))
 
-	h := model.NewKey(tenant.ID, "H", "K3", &g.ID, "agent-onprem-2", nil)
+	h := model.NewKey(tenant.ID, "H", "K3", &g.ID, "agent-onprem-2", model.Labels{
+		"cloud": "aws",
+	})
 	require.NoError(t, keyStore.CreateKey(ctx, h))
 
 	return keyHierarchy{
 		tenant: tenant,
 		root:   root,
+		ab:     ab,
+		ba:     ba,
 		b:      b,
 		c:      c,
 		d:      d,


### PR DESCRIPTION
Implement ListKeys on the Key store interface with support for:
- Cursor-based pagination using base64-encoded (created_at, id) tuples
- Configurable sort order (ascending/descending by created_at)
- Filtering by kind, lifecycle state, managing agent, name (ILIKE substring), and JSONB label containment
- Default page size of 50 when no limit is specified Also enriches the test key hierarchy (8 → 10 keys) with distinct lifecycle states, managing agents, and labels to support targeted filter assertions.
