### PR TITLE
feat: add get keys CLI command with filtering and pagination

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -14,6 +14,7 @@ func getCmd() *cobra.Command {
 	cmd.AddCommand(getTenantsCmd())
 	cmd.AddCommand(getKeyParentsCmd())
 	cmd.AddCommand(getKeyDescendantsCmd())
+	cmd.AddCommand(getKeysCmd())
 
 	return cmd
 }

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -11,25 +11,35 @@ import (
 
 	"github.com/openkcm/krypton/cli/output"
 	"github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
+	"github.com/openkcm/krypton/pkg/model"
 )
 
-type keyTreeRow struct {
-	Kind      string
-	ID        string
-	ParentID  string
-	Name      string
-	ManagedBy string
-	Status    string
+type keyRows struct {
+	Keys   []keyRow
+	Cursor string
 }
 
-func newKeyTreeRow(k *keys.Key) keyTreeRow {
-	return keyTreeRow{
-		Kind:      k.GetKind(),
-		ID:        k.GetId(),
-		ParentID:  k.GetParentId(),
-		Name:      k.GetName(),
-		ManagedBy: k.GetManagedBy(),
-		Status:    k.GetKeyProcessingState().GetStatus(),
+type keyRow struct {
+	Kind           model.KeyKind
+	ID             string
+	ParentID       string
+	Name           string
+	LifeCycleState model.KeyLifeCycleState
+	Labels         model.Labels
+	ManagedBy      string
+	Status         model.KeyProcessingStatus
+}
+
+func newKeyRow(k *keys.Key) keyRow {
+	return keyRow{
+		Kind:           model.KeyKind(k.GetKind()),
+		ID:             k.GetId(),
+		ParentID:       k.GetParentId(),
+		Name:           k.GetName(),
+		LifeCycleState: model.KeyLifeCycleState(k.GetLifeCycleState()),
+		Labels:         k.GetLabels(),
+		ManagedBy:      k.GetManagedBy(),
+		Status:         model.KeyProcessingStatus(k.GetKeyProcessingState().GetStatus()),
 	}
 }
 
@@ -42,6 +52,14 @@ func getKeyParentsCmd() *cobra.Command {
 		Short: "Get parent keys by tenant & key ID",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if tenantID == "" {
+				tID, err := selectedTenantID()
+				if err != nil {
+					return fmt.Errorf("failed to get selected tenant: %w", err)
+				}
+				tenantID = tID
+			}
+
 			// TODO: insecure.NewCredentials is a temporary workaround until TLS is configured
 			conn, err := grpc.NewClient(
 				serverAddr,
@@ -66,12 +84,12 @@ func getKeyParentsCmd() *cobra.Command {
 			}
 
 			ks := resp.GetKeys()
-			treeRows := make([]keyTreeRow, 0, len(ks))
+			keyRows := make([]keyRow, 0, len(ks))
 			for _, k := range ks {
-				treeRows = append(treeRows, newKeyTreeRow(k))
+				keyRows = append(keyRows, newKeyRow(k))
 			}
 
-			builder, err := output.From(treeRows)
+			builder, err := output.From(keyRows)
 			if err != nil {
 				return fmt.Errorf("failed to format output: %w", err)
 			}
@@ -84,7 +102,6 @@ func getKeyParentsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "id of the tenant")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output in JSON format")
 	_ = cmd.MarkFlagRequired("key-id")
-	_ = cmd.MarkFlagRequired("tenant-id")
 
 	return cmd
 }
@@ -98,6 +115,14 @@ func getKeyDescendantsCmd() *cobra.Command {
 		Short: "Get descendants by key & tenant ID",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if tenantID == "" {
+				tID, err := selectedTenantID()
+				if err != nil {
+					return fmt.Errorf("failed to get selected tenant: %w", err)
+				}
+				tenantID = tID
+			}
+
 			// TODO: insecure.NewCredentials is a temporary workaround until TLS is configured
 			conn, err := grpc.NewClient(
 				serverAddr,
@@ -130,17 +155,17 @@ func getKeyDescendantsCmd() *cobra.Command {
 				}
 			}
 
-			treeRows := make([]keyTreeRow, 0, totalLen)
+			keyRows := make([]keyRow, 0, totalLen)
 			for _, tree := range trees {
 				for _, k := range tree.GetKeys() {
-					treeRows = append(treeRows, newKeyTreeRow(k))
+					keyRows = append(keyRows, newKeyRow(k))
 				}
 				if !asJSON {
-					treeRows = append(treeRows, keyTreeRow{}) // add empty row for space between layers
+					keyRows = append(keyRows, keyRow{}) // add empty row for space between layers
 				}
 			}
 
-			builder, err := output.From(treeRows)
+			builder, err := output.From(keyRows)
 			if err != nil {
 				return fmt.Errorf("failed to format output: %w", err)
 			}
@@ -153,7 +178,101 @@ func getKeyDescendantsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "id of the tenant")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output in JSON format")
 	_ = cmd.MarkFlagRequired("key-id")
-	_ = cmd.MarkFlagRequired("tenant-id")
+
+	return cmd
+}
+
+func getKeysCmd() *cobra.Command {
+	var tenantID, name, kind, lifeCycleState, managedBy, cursor, order string
+	var labels map[string]string
+	var limit int32
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "keys",
+		Short: "List keys with optional filters",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if tenantID == "" {
+				tID, err := selectedTenantID()
+				if err != nil {
+					return fmt.Errorf("failed to get selected tenant: %w", err)
+				}
+				tenantID = tID
+			}
+
+			isOrderByCreatedAtAsc := order == "asc"
+
+			// TODO: insecure.NewCredentials is a temporary workaround until TLS is configured
+			conn, err := grpc.NewClient(
+				serverAddr,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to connect: %w", err)
+			}
+			defer conn.Close()
+
+			client := keys.NewKeyServiceClient(conn)
+
+			resp, err := client.ListKeys(cmd.Context(), &keys.ListKeysRequest{
+				TenantId:              tenantID,
+				Name:                  name,
+				Kind:                  kind,
+				LifeCycleState:        lifeCycleState,
+				ManagedBy:             managedBy,
+				Labels:                labels,
+				IsOrderByCreatedAtAsc: isOrderByCreatedAtAsc,
+				Cursor:                cursor,
+				Limit:                 limit,
+			})
+
+			if err != nil {
+				if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+					return fmt.Errorf("keys for tenant:[%s] not found", tenantID)
+				}
+				return fmt.Errorf("failed to list keys: %w", err)
+			}
+
+			ks := resp.GetKeys()
+			krs := keyRows{
+				Keys:   make([]keyRow, 0, len(ks)),
+				Cursor: resp.GetCursor(),
+			}
+
+			for _, k := range ks {
+				krs.Keys = append(krs.Keys, newKeyRow(k))
+			}
+
+			var input any = krs
+			if !asJSON {
+				input = krs.Keys
+			}
+
+			builder, err := output.From(input)
+			if err != nil {
+				return fmt.Errorf("failed to format output: %w", err)
+			}
+			err = formatOutput(builder, asJSON).To(cmd.OutOrStdout())
+
+			if asJSON || err != nil || krs.Cursor == "" {
+				return err
+			}
+
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "\nCursor: %s\n", krs.Cursor)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "Tenant identifier to filter keys by")
+	cmd.Flags().StringVar(&name, "name", "", "Filter keys by name")
+	cmd.Flags().StringVar(&kind, "kind", "", "Filter keys by kind")
+	cmd.Flags().StringVar(&lifeCycleState, "lifecycle-state", "", "Filter keys by lifecycle state")
+	cmd.Flags().StringVar(&managedBy, "managed-by", "", "Filter keys by managing entity")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "Pagination cursor from a previous response")
+	cmd.Flags().StringToStringVar(&labels, "labels", nil, "Filter by labels as key=value pairs (repeatable)")
+	cmd.Flags().StringVar(&order, "order", "desc", "Sort order by creation time: asc or desc")
+	cmd.Flags().Int32Var(&limit, "limit", 0, "Maximum number of keys to return (0 for no limit)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output in JSON format")
 
 	return cmd
 }

--- a/integration/announce_key_test.go
+++ b/integration/announce_key_test.go
@@ -2,9 +2,6 @@ package integration
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -270,12 +267,4 @@ func decodeAnnouncedKey(t *testing.T, output []byte) []announcedKeyRow {
 		assert.FailNowf(t, "failed to decode response", "output: %s, error: %v", string(output), err)
 	}
 	return rows
-}
-
-func seedSelectedTenant(t *testing.T, homeDir, tenantID, tenantName string) {
-	t.Helper()
-	dir := filepath.Join(homeDir, ".krypton")
-	require.NoError(t, os.MkdirAll(dir, 0700))
-	payload := fmt.Appendf(nil, `{"tenant":{"id":%q,"name":%q}}`, tenantID, tenantName)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "state.lock"), payload, 0600))
 }

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -305,4 +306,12 @@ func writeTempFile(t *testing.T, pattern, content string) string {
 	require.NoError(t, f.Close())
 
 	return f.Name()
+}
+
+func seedSelectedTenant(t *testing.T, homeDir, tenantID, tenantName string) {
+	t.Helper()
+	dir := filepath.Join(homeDir, ".krypton")
+	require.NoError(t, os.MkdirAll(dir, 0700))
+	payload := fmt.Appendf(nil, `{"tenant":{"id":%q,"name":%q}}`, tenantID, tenantName)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "state.lock"), payload, 0600))
 }

--- a/integration/key_test.go
+++ b/integration/key_test.go
@@ -40,8 +40,16 @@ func TestGetKeys(t *testing.T) {
 
 	// create tenant
 	// `kr create tenant --name <name> --json --server <server-addr>`
-	expName := "tenant-" + uuid.NewString()
-	cmd := newCLICommand(t.Context(), t.TempDir(), "create", "tenant", "--name", expName, "--json", "--server", serverAddr)
+	expTenantName := "tenant-" + uuid.NewString()
+	cmd := newCLICommand(
+		t.Context(),
+		t.TempDir(),
+		"create",
+		"tenant",
+		"--name", expTenantName,
+		"--json",
+		"--server", serverAddr,
+	)
 	output, err := cmd.CombinedOutput()
 	assert.NoError(t, err, "command should succeed, output: %s", string(output))
 
@@ -57,13 +65,22 @@ func TestGetKeys(t *testing.T) {
 	t.Run("parent-keys", func(t *testing.T) {
 		t.Run("should get all parent keys", func(t *testing.T) {
 			// when
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "parent-keys", "--key-id", hierarchy.e.ID, "--tenant-id", tenantID, "--json", "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"parent-keys",
+				"--key-id", hierarchy.e.ID,
+				"--tenant-id", tenantID,
+				"--json",
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
 			assert.NoError(t, err, "command should succeed, output: %s", string(output))
 
-			actRes := decodeKeyTreeRow(t, output)
+			actRes := decodeKeyRow(t, output)
 			assert.Len(t, actRes, 3)
 			assert.Equal(t, "A", actRes[0].Name)
 			assert.Equal(t, hierarchy.root.Kind, actRes[0].Kind)
@@ -75,10 +92,45 @@ func TestGetKeys(t *testing.T) {
 			assert.Equal(t, hierarchy.e.Kind, actRes[2].Kind)
 		})
 
+		t.Run("should fall back to selected tenant when tenant-id is not provided", func(t *testing.T) {
+			//given
+			// create selected tenant in store to test fetching tenant id from store when not provided as parameter
+			tmpDir := t.TempDir()
+			seedSelectedTenant(t, tmpDir, tenantID, expTenantName)
+
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				tmpDir,
+				"get",
+				"parent-keys",
+				"--key-id", hierarchy.e.ID,
+				"--json",
+				"--server", serverAddr,
+			)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actRes := decodeKeyRow(t, output)
+			assert.Len(t, actRes, 3)
+			assert.Equal(t, "A", actRes[0].Name)
+			assert.Equal(t, hierarchy.root.Kind, actRes[0].Kind)
+		})
+
 		t.Run("should fail if no parent keys exist", func(t *testing.T) {
 			// when
 			unknownID := uuid.NewString()
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "parent-keys", "--key-id", unknownID, "--tenant-id", tenantID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"parent-keys",
+				"--key-id", unknownID,
+				"--tenant-id", tenantID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
@@ -89,7 +141,15 @@ func TestGetKeys(t *testing.T) {
 		t.Run("should fail if tenant does not exist", func(t *testing.T) {
 			// when
 			unknownTenantID := uuid.NewString()
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "parent-keys", "--key-id", hierarchy.e.ID, "--tenant-id", unknownTenantID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"parent-keys",
+				"--key-id", hierarchy.e.ID,
+				"--tenant-id", unknownTenantID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
@@ -99,7 +159,14 @@ func TestGetKeys(t *testing.T) {
 
 		t.Run("should fail if key id parameter is not provided", func(t *testing.T) {
 			// when
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "parent-keys", "--tenant-id", tenantID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"parent-keys",
+				"--tenant-id", tenantID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
@@ -109,25 +176,41 @@ func TestGetKeys(t *testing.T) {
 
 		t.Run("should fail if tenant id parameter is not provided", func(t *testing.T) {
 			// when
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "parent-keys", "--key-id", hierarchy.e.ID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"parent-keys",
+				"--key-id", hierarchy.e.ID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
 			assert.Error(t, err)
-			assert.Contains(t, string(output), "required flag(s) \"tenant-id\" not set")
+			assert.Contains(t, string(output), "failed to get selected tenant: no tenant selected")
 		})
 	})
 
 	t.Run("descendant-keys", func(t *testing.T) {
 		t.Run("should get all descendant keys", func(t *testing.T) {
 			// when
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "descendant-keys", "--key-id", hierarchy.root.ID, "--tenant-id", tenantID, "--json", "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"descendant-keys",
+				"--key-id", hierarchy.root.ID,
+				"--tenant-id", tenantID,
+				"--json",
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
 			assert.NoError(t, err, "command should succeed, output: %s", string(output))
 
-			actRes := decodeKeyTreeRow(t, output)
+			actRes := decodeKeyRow(t, output)
 			assert.Len(t, actRes, 8)
 
 			assert.Equal(t, "A", actRes[0].Name)
@@ -151,10 +234,46 @@ func TestGetKeys(t *testing.T) {
 			assert.Equal(t, hierarchy.h.Kind, actRes[7].Kind)
 		})
 
+		t.Run("should fall back to selected tenant when tenant-id is not provided", func(t *testing.T) {
+			//given
+			// create selected tenant in store to test fetching tenant id from store when not provided as parameter
+			tmpDir := t.TempDir()
+			seedSelectedTenant(t, tmpDir, tenantID, expTenantName)
+
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				tmpDir,
+				"get",
+				"descendant-keys",
+				"--key-id", hierarchy.root.ID,
+				"--json",
+				"--server", serverAddr,
+			)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actRes := decodeKeyRow(t, output)
+			assert.Len(t, actRes, 8)
+
+			assert.Equal(t, "A", actRes[0].Name)
+			assert.Equal(t, hierarchy.root.Kind, actRes[0].Kind)
+		})
+
 		t.Run("should fail if no descendant keys exist", func(t *testing.T) {
 			// when
 			unknownID := uuid.NewString()
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "descendant-keys", "--key-id", unknownID, "--tenant-id", tenantID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"descendant-keys",
+				"--key-id", unknownID,
+				"--tenant-id", tenantID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
@@ -165,7 +284,15 @@ func TestGetKeys(t *testing.T) {
 		t.Run("should fail if tenant does not exist", func(t *testing.T) {
 			// when
 			unknownTenantID := uuid.NewString()
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "descendant-keys", "--key-id", hierarchy.e.ID, "--tenant-id", unknownTenantID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"descendant-keys",
+				"--key-id", hierarchy.e.ID,
+				"--tenant-id", unknownTenantID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
@@ -175,7 +302,14 @@ func TestGetKeys(t *testing.T) {
 
 		t.Run("should fail if key id parameter is not provided", func(t *testing.T) {
 			// when
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "descendant-keys", "--tenant-id", tenantID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"descendant-keys",
+				"--tenant-id", tenantID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
@@ -185,23 +319,432 @@ func TestGetKeys(t *testing.T) {
 
 		t.Run("should fail if tenant id parameter is not provided", func(t *testing.T) {
 			// when
-			cmd = newCLICommand(t.Context(), t.TempDir(), "get", "descendant-keys", "--key-id", hierarchy.e.ID, "--server", serverAddr)
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"descendant-keys",
+				"--key-id", hierarchy.e.ID,
+				"--server", serverAddr,
+			)
 			output, err = cmd.CombinedOutput()
 
 			// then
 			assert.Error(t, err)
-			assert.Contains(t, string(output), "required flag(s) \"tenant-id\" not set")
+			assert.Contains(t, string(output), "failed to get selected tenant: no tenant selected")
+		})
+	})
+
+	t.Run("keys", func(t *testing.T) {
+		t.Run("should get all keys for tenant descending order", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 8)
+
+			assert.Equal(t, "H", actKeys[0].Name)
+			assert.Equal(t, hierarchy.h.Kind, actKeys[0].Kind)
+
+			assert.Equal(t, "G", actKeys[1].Name)
+			assert.Equal(t, hierarchy.g.Kind, actKeys[1].Kind)
+
+			assert.Equal(t, "F", actKeys[2].Name)
+			assert.Equal(t, hierarchy.f.Kind, actKeys[2].Kind)
+
+			assert.Equal(t, "E", actKeys[3].Name)
+			assert.Equal(t, hierarchy.e.Kind, actKeys[3].Kind)
+
+			assert.Equal(t, "D", actKeys[4].Name)
+			assert.Equal(t, hierarchy.d.Kind, actKeys[4].Kind)
+
+			assert.Equal(t, "C", actKeys[5].Name)
+			assert.Equal(t, hierarchy.c.Kind, actKeys[5].Kind)
+
+			assert.Equal(t, "B", actKeys[6].Name)
+			assert.Equal(t, hierarchy.b.Kind, actKeys[6].Kind)
+
+			assert.Equal(t, "A", actKeys[7].Name)
+			assert.Equal(t, hierarchy.root.Kind, actKeys[7].Kind)
+		})
+
+		t.Run("should get all keys for tenant ascending order", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--order", "asc",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 8)
+
+			assert.Equal(t, "A", actKeys[0].Name)
+			assert.Equal(t, hierarchy.root.Kind, actKeys[0].Kind)
+
+			assert.Equal(t, "B", actKeys[1].Name)
+			assert.Equal(t, hierarchy.b.Kind, actKeys[1].Kind)
+
+			assert.Equal(t, "C", actKeys[2].Name)
+			assert.Equal(t, hierarchy.c.Kind, actKeys[2].Kind)
+
+			assert.Equal(t, "D", actKeys[3].Name)
+			assert.Equal(t, hierarchy.d.Kind, actKeys[3].Kind)
+
+			assert.Equal(t, "E", actKeys[4].Name)
+			assert.Equal(t, hierarchy.e.Kind, actKeys[4].Kind)
+
+			assert.Equal(t, "F", actKeys[5].Name)
+			assert.Equal(t, hierarchy.f.Kind, actKeys[5].Kind)
+
+			assert.Equal(t, "G", actKeys[6].Name)
+			assert.Equal(t, hierarchy.g.Kind, actKeys[6].Kind)
+
+			assert.Equal(t, "H", actKeys[7].Name)
+			assert.Equal(t, hierarchy.h.Kind, actKeys[7].Kind)
+		})
+
+		t.Run("should fall back to selected tenant when tenant-id is not provided", func(t *testing.T) {
+			//given
+			// create selected tenant in store to test fetching tenant id from store when not provided as parameter
+			tmpDir := t.TempDir()
+			seedSelectedTenant(t, tmpDir, tenantID, expTenantName)
+
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				tmpDir,
+				"get",
+				"keys",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 8)
+			assert.Equal(t, "H", actKeys[0].Name)
+			assert.Equal(t, hierarchy.h.Kind, actKeys[0].Kind)
+		})
+
+		t.Run("should fail if tenant does not exist", func(t *testing.T) {
+			// when
+			unknownTenantID := uuid.NewString()
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", unknownTenantID,
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.Error(t, err)
+			assert.Contains(t, string(output), "not found")
+		})
+
+		t.Run("should fail if tenant id parameter is not provided", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.Error(t, err)
+			assert.Contains(t, string(output), "no tenant selected")
+		})
+
+		t.Run("should filter by name", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--name", "B",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 1)
+			assert.Equal(t, "B", actKeys[0].Name)
+			assert.Equal(t, hierarchy.b.Kind, actKeys[0].Kind)
+		})
+
+		t.Run("should filter by kind", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--kind", "K2",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 4)
+			expectedNames := []string{"G", "F", "E", "D"}
+			for i, expectedName := range expectedNames {
+				assert.Equal(t, expectedName, actKeys[i].Name)
+				assert.Equal(t, model.KeyKind("K2"), actKeys[i].Kind)
+			}
+		})
+
+		t.Run("should filter by life cycle state", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--lifecycle-state", string(model.KeyLifeCycleActive),
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 1)
+			assert.Equal(t, "E", actKeys[0].Name)
+			assert.Equal(t, model.KeyLifeCycleActive, actKeys[0].LifeCycleState)
+		})
+
+		t.Run("should filter by managed-by", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--managed-by", "agent-azure",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 1)
+			assert.Equal(t, "E", actKeys[0].Name)
+			assert.Equal(t, "agent-azure", actKeys[0].ManagedBy)
+		})
+
+		t.Run("should filter by labels", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--labels", "env=prod",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 1)
+			assert.Equal(t, "C", actKeys[0].Name)
+			assert.Equal(t, model.Labels{"env": "prod"}, actKeys[0].Labels)
+		})
+
+		t.Run("should limit number of results", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--limit", "3",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 3)
+			assert.Equal(t, "H", actKeys[0].Name)
+			assert.Equal(t, "G", actKeys[1].Name)
+			assert.Equal(t, "F", actKeys[2].Name)
+		})
+
+		t.Run("should fetch next page by cursor", func(t *testing.T) {
+			// given
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--limit", "3",
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows := decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys := actKeyRows[0].Keys
+			require.Len(t, actKeys, 3)
+			assert.Equal(t, "H", actKeys[0].Name)
+			assert.Equal(t, "G", actKeys[1].Name)
+			assert.Equal(t, "F", actKeys[2].Name)
+
+			cursor := actKeyRows[0].Cursor
+
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--limit", "3",
+				"--cursor", cursor,
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeyRows = decodeKeyRows(t, output)
+			require.Len(t, actKeyRows, 1, "expected one page of results")
+
+			actKeys = actKeyRows[0].Keys
+			assert.Len(t, actKeys, 3)
+			assert.Equal(t, "E", actKeys[0].Name)
+			assert.Equal(t, "D", actKeys[1].Name)
+			assert.Equal(t, "C", actKeys[2].Name)
+		})
+
+		t.Run("should show cursor in tabular when more pages exist", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--limit", "3",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+			assert.Contains(t, string(output), "Cursor:")
+		})
+
+		t.Run("should hide cursor in tabular when no more pages", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"keys",
+				"--tenant-id", tenantID,
+				"--limit", "20",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+			assert.NotContains(t, string(output), "Cursor:")
 		})
 	})
 }
 
-type keyTreeRow struct {
-	Kind      model.KeyKind
-	ID        string
-	ParentID  string
-	Name      string
-	ManagedBy string
-	Status    string
+type keyRow struct {
+	Kind           model.KeyKind
+	ID             string
+	ParentID       string
+	Name           string
+	LifeCycleState model.KeyLifeCycleState
+	Labels         model.Labels
+	ManagedBy      string
+	Status         model.KeyProcessingStatus
+}
+
+type keyRows struct {
+	Keys   []keyRow
+	Cursor string
 }
 
 // keyHierarchy holds a test key tree with 8 keys across 4 levels (K0-K3).
@@ -244,6 +787,7 @@ func createKeyHierarchy(t *testing.T, keyStore store.Key, tenantID string) keyHi
 	require.NoError(t, err)
 
 	c := model.NewKey(tenantID, "C", "K1", &root.ID, "root", nil)
+	c.Labels = model.Labels{"env": "prod"}
 	err = keyStore.CreateKey(ctx, c)
 	require.NoError(t, err)
 
@@ -252,6 +796,7 @@ func createKeyHierarchy(t *testing.T, keyStore store.Key, tenantID string) keyHi
 	require.NoError(t, err)
 
 	e := model.NewKey(tenantID, "E", "K2", &b.ID, "agent-azure", nil)
+	e.LifeCycleState = model.KeyLifeCycleActive
 	err = keyStore.CreateKey(ctx, e)
 	require.NoError(t, err)
 
@@ -264,6 +809,7 @@ func createKeyHierarchy(t *testing.T, keyStore store.Key, tenantID string) keyHi
 	require.NoError(t, err)
 
 	h := model.NewKey(tenantID, "H", "K3", &g.ID, "agent-onprem-2", nil)
+	h.Labels = model.Labels{"env": "dev"}
 	err = keyStore.CreateKey(ctx, h)
 	require.NoError(t, err)
 
@@ -279,9 +825,19 @@ func createKeyHierarchy(t *testing.T, keyStore store.Key, tenantID string) keyHi
 	}
 }
 
-func decodeKeyTreeRow(t *testing.T, output []byte) []keyTreeRow {
+func decodeKeyRow(t *testing.T, output []byte) []keyRow {
 	t.Helper()
-	var ts []keyTreeRow
+	var ts []keyRow
+	err := json.Unmarshal(output, &ts)
+	if err != nil {
+		assert.FailNowf(t, "failed to decode response", "output: %s, error: %v", string(output), err)
+	}
+	return ts
+}
+
+func decodeKeyRows(t *testing.T, output []byte) []keyRows {
+	t.Helper()
+	var ts []keyRows
 	err := json.Unmarshal(output, &ts)
 	if err != nil {
 		assert.FailNowf(t, "failed to decode response", "output: %s, error: %v", string(output), err)


### PR DESCRIPTION
## Summary
- Add `kr get keys` CLI command that lists keys with filtering and cursor-based pagination
- Make `--tenant-id` optional on `parent-keys`, `descendant-keys`, and `keys` commands by falling back to the selected tenant from the state store