### PR TITLE
fix: deregister agent before closing RPC server during shutdown

### DIFF
--- a/integration/registration_test.go
+++ b/integration/registration_test.go
@@ -70,6 +70,9 @@ func TestRegistration(t *testing.T) {
 		err = agentCmd.Start()
 		require.NoError(t, err, "failed to start agent process")
 
+		// wait for agent to be fully ready (operator RPC server listening)
+		waitForPort(t, agentPort)
+
 		// then
 		// wait for agent registration to appear in store with registered status
 		require.Eventually(t, func() bool {


### PR DESCRIPTION
The following tests was failing in my local cause the agent server port was not checked.
```
--- FAIL: TestRegistration (13.32s)
    --- FAIL: TestRegistration/agent_registration (10.54s)
        --- FAIL: TestRegistration/agent_registration/should_deregister_agent_on_shutdown (10.00s)
            registration_test.go:91:
                        Error Trace:    /Users/I752122/Workspace/apeiro/krypton/integration/registration_test.go:91
                        Error:          Condition never satisfied
                        Test:           TestRegistration/agent_registration/should_deregister_agent_on_shutdown
                        Messages:       expected agent to be deregistered in store after shutdown
```