### PR TITLE
feat: add key processor

### DIFF
--- a/internal/keyprocessor/export_test.go
+++ b/internal/keyprocessor/export_test.go
@@ -9,14 +9,13 @@ import (
 	"github.com/openkcm/krypton/pkg/model"
 )
 
-func NewProcessor(name string, v vault.Vault, c cryptor.Cryptor, sg cryptor.SecretGenerator, internal *Processor, parent *Processor) *Processor {
+func NewProcessor(generator cryptor.SecretGenerator, wrapper, sealer cryptor.Cryptor, v vault.Vault, parent *Processor) *Processor {
 	return &Processor{
-		name:            name,
-		vault:           v,
-		cryptor:         c,
-		secretGenerator: sg,
-		internal:        internal,
-		parent:          parent,
+		generator: generator,
+		wrapper:   wrapper,
+		sealer:    sealer,
+		vault:     v,
+		parent:    parent,
 	}
 }
 

--- a/internal/keyprocessor/export_test.go
+++ b/internal/keyprocessor/export_test.go
@@ -1,0 +1,25 @@
+package keyprocessor
+
+import (
+	"context"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/securemem"
+	"github.com/openkcm/krypton/internal/vault"
+	"github.com/openkcm/krypton/pkg/model"
+)
+
+func NewProcessor(name string, v vault.Vault, c cryptor.Cryptor, sg cryptor.SecretGenerator, internal *Processor, parent *Processor) *Processor {
+	return &Processor{
+		name:            name,
+		vault:           v,
+		cryptor:         c,
+		secretGenerator: sg,
+		internal:        internal,
+		parent:          parent,
+	}
+}
+
+func (p *Processor) ResolveSecret(ctx context.Context, keyChain []model.Key) (*securemem.Data, error) {
+	return p.resolveSecret(ctx, keyChain)
+}

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -3,6 +3,7 @@ package keyprocessor
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/securemem"
@@ -10,8 +11,15 @@ import (
 	"github.com/openkcm/krypton/pkg/model"
 )
 
-// ErrEmptyKeyChain is returned when an operation receives an empty key chain.
-var ErrEmptyKeyChain = errors.New("empty key chain")
+const persistSecName = "persistedSec"
+
+var (
+	// ErrEmptyKeyChain is returned when an operation receives an empty key chain.
+	ErrEmptyKeyChain = errors.New("empty key chain")
+	// ErrSecNotPersisted is returned when a handler completes successfully
+	// but the secret is missing from the persistent vault, indicating a bug
+	ErrSecNotPersisted = errors.New("persisted secret missing from handler response")
+)
 
 // Processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
 // It destroys all intermediate secrets that pass through its operations.
@@ -76,95 +84,114 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		return CreateSecretResponse{}, err
 	}
 
-	genResp, err := p.generator.GenerateSecret(ctx)
-	if err != nil {
-		return CreateSecretResponse{}, err
-	}
+	_, err = securemem.Run(ctx, func(ctx context.Context, _ *securemem.HandlerRequest) error {
+		resp, err := p.generator.GenerateSecret(ctx)
+		if err != nil {
+			return err
+		}
+		defer destroySec(resp.Secret)
 
-	sec, err := p.seal(ctx, key, genResp.Secret, req.AAD)
-	if err != nil {
-		return CreateSecretResponse{}, err
-	}
+		sealSec, err := p.seal(ctx, key, resp.Secret, req.AAD)
+		if err != nil {
+			return err
+		}
+		defer destroySec(sealSec)
 
-	sec, err = p.parentWrap(ctx, req.KeyChain, sec, req.AAD)
-	if err != nil {
-		return CreateSecretResponse{}, err
-	}
+		wrapSec, err := p.parentWrap(ctx, req.KeyChain, sealSec, req.AAD)
+		if err != nil {
+			return err
+		}
+		defer destroySec(wrapSec)
 
-	_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
-		TenantID:    key.TenantID,
-		KeyID:       key.ID,
-		KeyVersion:  1,
-		KeyMaterial: sec,
-		AAD:         req.AAD,
+		_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    key.TenantID,
+			KeyID:       key.ID,
+			KeyVersion:  1,
+			KeyMaterial: wrapSec,
+			AAD:         req.AAD,
+		})
+		return err
 	})
-	return CreateSecretResponse{}, errors.Join(err, destroySec(sec))
+
+	return CreateSecretResponse{}, err
 }
 
 // WrapSecret resolves the wrapping secret from the key chain and encrypts the given secret.
 // When the wrapper manages its own decryption key, it encrypts directly without resolving.
 func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
-	sec, err := p.resolveSecret(ctx, req.KeyChain)
-	if err != nil {
-		return WrapSecretResponse{}, err
-	}
-
-	key, err := lastKey(req.KeyChain)
-	if err != nil {
-		return WrapSecretResponse{}, errors.Join(err, destroySec(sec))
-	}
-
-	encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
-		TenantID:   key.TenantID,
-		KeyID:      key.ID,
-		KeyVersion: 1,
-		Secret:     toCryptorSecret(sec),
-		Plaintext:  req.Secret,
-		AAD:        req.AAD,
-	})
-	if err := errors.Join(err, destroySec(sec)); err != nil {
-		if encResp != nil {
-			return WrapSecretResponse{}, errors.Join(err, destroySec(encResp.Ciphertext))
+	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
+		sec, err := p.resolveSecret(ctx, req.KeyChain)
+		if err != nil {
+			return err
 		}
+		defer destroySec(sec)
+
+		key, err := lastKey(req.KeyChain)
+		if err != nil {
+			return err
+		}
+
+		encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
+			TenantID:   key.TenantID,
+			KeyID:      key.ID,
+			KeyVersion: 1,
+			Secret:     toCryptorSecret(sec),
+			Plaintext:  req.Secret,
+			AAD:        req.AAD,
+		})
+		if err != nil {
+			return err
+		}
+
+		return sreq.PersistentVault().Import(persistSecName, encResp.Ciphertext)
+	})
+	if err != nil {
 		return WrapSecretResponse{}, err
 	}
+	sec, err := getPersistedSec(resp)
 
 	return WrapSecretResponse{
-		WrappedSecret: encResp.Ciphertext,
-	}, nil
+		WrappedSecret: sec,
+	}, err
 }
 
 // UnwrapSecret resolves the wrapping secret from the key chain and decrypts the given wrapped secret.
 // When the wrapper manages its own decryption key, it decrypts directly without resolving.
 func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
-	sec, err := p.resolveSecret(ctx, req.KeyChain)
-	if err != nil {
-		return UnwrapSecretResponse{}, err
-	}
-
-	key, err := lastKey(req.KeyChain)
-	if err != nil {
-		return UnwrapSecretResponse{}, errors.Join(err, destroySec(sec))
-	}
-
-	decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
-		TenantID:   key.TenantID,
-		KeyID:      key.ID,
-		KeyVersion: 1,
-		Secret:     toCryptorSecret(sec),
-		Ciphertext: req.WrappedSecret,
-		AAD:        req.AAD,
-	})
-	if err := errors.Join(err, destroySec(sec)); err != nil {
-		if decResp != nil {
-			return UnwrapSecretResponse{}, errors.Join(err, destroySec(decResp.Plaintext))
+	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
+		sec, err := p.resolveSecret(ctx, req.KeyChain)
+		if err != nil {
+			return err
 		}
+		defer destroySec(sec)
+
+		key, err := lastKey(req.KeyChain)
+		if err != nil {
+			return err
+		}
+
+		decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
+			TenantID:   key.TenantID,
+			KeyID:      key.ID,
+			KeyVersion: 1,
+			Secret:     toCryptorSecret(sec),
+			Ciphertext: req.WrappedSecret,
+			AAD:        req.AAD,
+		})
+		if err != nil {
+			return err
+		}
+
+		return sreq.PersistentVault().Import(persistSecName, decResp.Plaintext)
+	})
+	if err != nil {
 		return UnwrapSecretResponse{}, err
 	}
+	sec, err := getPersistedSec(resp)
 
 	return UnwrapSecretResponse{
-		Secret: decResp.Plaintext,
-	}, nil
+		Secret: sec,
+	}, err
 }
 
 // DeleteSecret removes the wrapping secret from the vault.
@@ -195,20 +222,41 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 		return nil, err
 	}
 
-	exported, err := p.vault.ExportKey(ctx, vault.ExportKeyRequest{
-		TenantID: key.TenantID,
-		KeyID:    key.ID,
+	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
+		exported, err := p.vault.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID: key.TenantID,
+			KeyID:    key.ID,
+		})
+		if err != nil {
+			return err
+		}
+		defer destroySec(exported.KeyMaterial)
+
+		unwrapSec, err := p.parentUnwrap(ctx, keyChain, exported.KeyMaterial, exported.AAD)
+		if err != nil {
+			return err
+		}
+		defer destroySec(unwrapSec)
+
+		unsealSec, err := p.unseal(ctx, key, unwrapSec, exported.AAD)
+		if err != nil {
+			return err
+		}
+		defer destroySec(unsealSec)
+
+		// copy so that defers can unconditionally destroy all intermediates.
+		sec, err := copySec(unsealSec)
+		if err != nil {
+			return nil
+		}
+
+		return sreq.PersistentVault().Import(persistSecName, sec)
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	sec, err := p.parentUnwrap(ctx, keyChain, exported.KeyMaterial, exported.AAD)
-	if err != nil {
-		return nil, err
-	}
-
-	return p.unseal(ctx, key, sec, exported.AAD)
+	return getPersistedSec(resp)
 }
 
 func (p *Processor) seal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
@@ -222,10 +270,7 @@ func (p *Processor) seal(ctx context.Context, key model.Key, sec *securemem.Data
 		Plaintext:  sec,
 		AAD:        aad,
 	})
-	if err := errors.Join(err, destroySec(sec)); err != nil {
-		if resp.Ciphertext != nil {
-			return nil, errors.Join(err, destroySec(resp.Ciphertext))
-		}
+	if err != nil {
 		return nil, err
 	}
 	return resp.Ciphertext, nil
@@ -242,10 +287,7 @@ func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Da
 		Ciphertext: sec,
 		AAD:        aad,
 	})
-	if err := errors.Join(err, destroySec(sec)); err != nil {
-		if resp.Plaintext != nil {
-			return nil, errors.Join(err, destroySec(resp.Plaintext))
-		}
+	if err != nil {
 		return nil, err
 	}
 	return resp.Plaintext, nil
@@ -260,8 +302,8 @@ func (p *Processor) parentWrap(ctx context.Context, keyChain []model.Key, sec *s
 		Secret:   sec,
 		AAD:      aad,
 	})
-	if err := errors.Join(err, destroySec(sec)); err != nil {
-		return nil, errors.Join(err, destroySec(resp.WrappedSecret))
+	if err != nil {
+		return nil, err
 	}
 	return resp.WrappedSecret, nil
 }
@@ -275,8 +317,8 @@ func (p *Processor) parentUnwrap(ctx context.Context, keyChain []model.Key, sec 
 		WrappedSecret: sec,
 		AAD:           aad,
 	})
-	if err := errors.Join(err, destroySec(sec)); err != nil {
-		return nil, errors.Join(err, destroySec(resp.Secret))
+	if err != nil {
+		return nil, err
 	}
 	return resp.Secret, nil
 }
@@ -288,11 +330,31 @@ func lastKey(keyChain []model.Key) (model.Key, error) {
 	return keyChain[len(keyChain)-1], nil
 }
 
-func destroySec(sec *securemem.Data) error {
-	if sec != nil {
-		return sec.Destroy()
+func destroySec(sec *securemem.Data) {
+	if sec == nil {
+		return
 	}
-	return nil
+	if err := sec.Destroy(); err != nil {
+		slog.Error("failed to destroy secret", "name", sec.Name(), "error", err)
+	}
+}
+
+func getPersistedSec(resp *securemem.HandlerResponse) (*securemem.Data, error) {
+	sec, ok := resp.MemVault().Get(persistSecName)
+	if !ok {
+		err := resp.MemVault().DestroyAll()
+		return nil, errors.Join(ErrSecNotPersisted, err)
+	}
+	return sec, nil
+}
+
+func copySec(src *securemem.Data) (*securemem.Data, error) {
+	dst, err := securemem.NewData(src.Name(), len(src.SecureBytes()))
+	if err != nil {
+		return nil, err
+	}
+	copy(dst.SecureBytes(), src.SecureBytes())
+	return dst, nil
 }
 
 func toCryptorSecret(data *securemem.Data) *cryptor.Secret {

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -1,0 +1,323 @@
+package keyprocessor
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/securemem"
+	"github.com/openkcm/krypton/internal/vault"
+	"github.com/openkcm/krypton/pkg/model"
+)
+
+// ErrEmptyKeyChain is returned when an operation receives an empty key chain.
+var ErrEmptyKeyChain = errors.New("empty key chain")
+
+// Processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
+// It destroys all intermediate secrets that pass through its operations.
+type Processor struct {
+	name            string
+	vault           vault.Vault
+	cryptor         cryptor.Cryptor
+	secretGenerator cryptor.SecretGenerator
+	internal        *Processor
+	parent          *Processor
+}
+
+// CreateSecretRequest is the input for CreateSecret.
+type CreateSecretRequest struct {
+	KeyChain []model.Key
+	AAD      []byte
+}
+
+// CreateSecretResponse is the output of CreateSecret.
+type CreateSecretResponse struct{}
+
+// WrapSecretRequest is the input for WrapSecret.
+type WrapSecretRequest struct {
+	KeyChain []model.Key
+	Secret   *securemem.Data
+	AAD      []byte
+}
+
+// WrapSecretResponse is the output of WrapSecret.
+type WrapSecretResponse struct {
+	WrappedSecret *securemem.Data
+}
+
+// UnwrapSecretRequest is the input for UnwrapSecret.
+type UnwrapSecretRequest struct {
+	KeyChain      []model.Key
+	WrappedSecret *securemem.Data
+	AAD           []byte
+}
+
+// UnwrapSecretResponse is the output of UnwrapSecret.
+type UnwrapSecretResponse struct {
+	Secret *securemem.Data
+}
+
+// DeleteSecretRequest is the input for DeleteSecret.
+type DeleteSecretRequest struct {
+	Key model.Key
+}
+
+// DeleteSecretResponse is the output of DeleteSecret.
+type DeleteSecretResponse struct{}
+
+// CreateSecret generates a secret, wraps it through the internal and parent chain, and stores it in the vault.
+// It is a no-op when the cryptor manages its own decryption key regardless of internal or parent configuration.
+func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (CreateSecretResponse, error) {
+	if !p.cryptor.Info().DecryptionSecretRequired {
+		return CreateSecretResponse{}, nil
+	}
+
+	key, err := lastKey(req.KeyChain)
+	if err != nil {
+		return CreateSecretResponse{}, err
+	}
+
+	genResp, err := p.secretGenerator.GenerateSecret(ctx)
+	if err != nil {
+		return CreateSecretResponse{}, err
+	}
+
+	sec := genResp.Secret
+
+	if p.internal != nil {
+		_, err := p.internal.CreateSecret(ctx, CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: key.TenantID, ID: key.ID}},
+			AAD:      req.AAD,
+		})
+		if err != nil {
+			return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret))
+		}
+
+		resp, err := p.internal.WrapSecret(ctx, WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: key.TenantID, ID: key.ID}},
+			Secret:   sec,
+			AAD:      req.AAD,
+		})
+		if err != nil {
+			return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret))
+		}
+		if err := destroyAll(sec); err != nil {
+			return CreateSecretResponse{}, err
+		}
+		sec = resp.WrappedSecret
+	}
+
+	if p.parent != nil {
+		resp, err := p.parent.WrapSecret(ctx, WrapSecretRequest{
+			KeyChain: req.KeyChain[:len(req.KeyChain)-1],
+			Secret:   sec,
+			AAD:      req.AAD,
+		})
+		if err != nil {
+			return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret, sec))
+		}
+		if err := destroyAll(sec); err != nil {
+			return CreateSecretResponse{}, err
+		}
+		sec = resp.WrappedSecret
+	}
+
+	_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
+		TenantID:    key.TenantID,
+		KeyID:       p.keyID(key.ID),
+		KeyVersion:  1,
+		KeyMaterial: sec,
+		AAD:         req.AAD,
+	})
+	if err != nil {
+		return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret, sec))
+	}
+
+	if err := destroyAll(genResp.Secret, sec); err != nil {
+		return CreateSecretResponse{}, err
+	}
+	return CreateSecretResponse{}, nil
+}
+
+// WrapSecret resolves the processor's secret from the vault and uses it to encrypt the given plaintext.
+// When the cryptor manages its own decryption key, it encrypts directly without resolving.
+func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
+	sec, err := p.resolveSecret(ctx, req.KeyChain)
+	if err != nil {
+		return WrapSecretResponse{}, err
+	}
+
+	key, err := lastKey(req.KeyChain)
+	if err != nil {
+		return WrapSecretResponse{}, errors.Join(err, destroyAll(sec))
+	}
+
+	encResp, err := p.cryptor.Encrypt(ctx, cryptor.EncryptRequest{
+		TenantID:   key.TenantID,
+		KeyID:      p.keyID(key.ID),
+		KeyVersion: 1,
+		Secret:     toCryptorSecret(sec),
+		Plaintext:  req.Secret,
+		AAD:        req.AAD,
+	})
+	if err != nil {
+		return WrapSecretResponse{}, errors.Join(err, destroyAll(sec))
+	}
+
+	if err := destroyAll(sec); err != nil {
+		return WrapSecretResponse{}, err
+	}
+	return WrapSecretResponse{
+		WrappedSecret: encResp.Ciphertext,
+	}, nil
+}
+
+// UnwrapSecret resolves the processor's secret from the vault and uses it to decrypt the given ciphertext.
+// When the cryptor manages its own decryption key, it decrypts directly without resolving.
+func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
+	sec, err := p.resolveSecret(ctx, req.KeyChain)
+	if err != nil {
+		return UnwrapSecretResponse{}, err
+	}
+
+	key, err := lastKey(req.KeyChain)
+	if err != nil {
+		return UnwrapSecretResponse{}, errors.Join(err, destroyAll(sec))
+	}
+
+	decResp, err := p.cryptor.Decrypt(ctx, cryptor.DecryptRequest{
+		TenantID:   key.TenantID,
+		KeyID:      p.keyID(key.ID),
+		KeyVersion: 1,
+		Secret:     toCryptorSecret(sec),
+		Ciphertext: req.WrappedSecret,
+		AAD:        req.AAD,
+	})
+	if err != nil {
+		return UnwrapSecretResponse{}, errors.Join(err, destroyAll(sec))
+	}
+
+	if err := destroyAll(sec); err != nil {
+		return UnwrapSecretResponse{}, err
+	}
+	return UnwrapSecretResponse{
+		Secret: decResp.Plaintext,
+	}, nil
+}
+
+// DeleteSecret removes the processor's secret and its internal processor's secret from the vault.
+// It is a no-op when the cryptor manages its own decryption key regardless of internal or parent configuration.
+func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (DeleteSecretResponse, error) {
+	if !p.cryptor.Info().DecryptionSecretRequired {
+		return DeleteSecretResponse{}, nil
+	}
+
+	_, err := p.vault.DestroyKey(ctx, vault.DestroyKeyRequest{
+		TenantID: req.Key.TenantID,
+		KeyID:    p.keyID(req.Key.ID),
+	})
+	if err != nil {
+		return DeleteSecretResponse{}, err
+	}
+
+	if p.internal != nil {
+		_, err = p.internal.DeleteSecret(ctx, DeleteSecretRequest{
+			Key: model.Key{TenantID: req.Key.TenantID, ID: req.Key.ID},
+		})
+		if err != nil {
+			return DeleteSecretResponse{}, err
+		}
+	}
+
+	return DeleteSecretResponse{}, nil
+}
+
+func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*securemem.Data, error) {
+	if !p.cryptor.Info().DecryptionSecretRequired {
+		return nil, nil //nolint:nilnil
+	}
+
+	key, err := lastKey(keyChain)
+	if err != nil {
+		return nil, err
+	}
+
+	exported, err := p.vault.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID: key.TenantID,
+		KeyID:    p.keyID(key.ID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sec := exported.KeyMaterial
+	aad := exported.AAD
+
+	if p.parent != nil {
+		resp, err := p.parent.UnwrapSecret(ctx, UnwrapSecretRequest{
+			KeyChain:      keyChain[:len(keyChain)-1],
+			WrappedSecret: sec,
+			AAD:           aad,
+		})
+		if err != nil {
+			return nil, errors.Join(err, destroyAll(sec))
+		}
+		if err := destroyAll(sec); err != nil {
+			return nil, err
+		}
+		sec = resp.Secret
+	}
+
+	if p.internal != nil {
+		resp, err := p.internal.UnwrapSecret(ctx, UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: key.TenantID, ID: key.ID}},
+			WrappedSecret: sec,
+			AAD:           aad,
+		})
+		if err != nil {
+			return nil, errors.Join(err, destroyAll(sec))
+		}
+		if err := destroyAll(sec); err != nil {
+			return nil, err
+		}
+		sec = resp.Secret
+	}
+
+	return sec, nil
+}
+
+func (p *Processor) keyID(id string) string {
+	if p.name == "" {
+		return id
+	}
+	return p.name + "/" + id
+}
+
+func lastKey(keyChain []model.Key) (model.Key, error) {
+	if len(keyChain) == 0 {
+		return model.Key{}, ErrEmptyKeyChain
+	}
+	return keyChain[len(keyChain)-1], nil
+}
+
+func destroyAll(secrets ...*securemem.Data) error {
+	var errs []error
+	for _, s := range secrets {
+		if s != nil {
+			if err := s.Destroy(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func toCryptorSecret(data *securemem.Data) *cryptor.Secret {
+	if data == nil {
+		return nil
+	}
+	return &cryptor.Secret{
+		Algorithm: cryptor.KeyAlgorithmAES256,
+		Data:      data,
+	}
+}

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -90,7 +90,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 			AAD:      req.AAD,
 		})
 		if err != nil {
-			return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret))
+			return CreateSecretResponse{}, errors.Join(err, destroySec(sec))
 		}
 
 		resp, err := p.internal.WrapSecret(ctx, WrapSecretRequest{
@@ -98,10 +98,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 			Secret:   sec,
 			AAD:      req.AAD,
 		})
-		if err != nil {
-			return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret))
-		}
-		if err := destroyAll(sec); err != nil {
+		if err := errors.Join(err, destroySec(sec)); err != nil {
 			return CreateSecretResponse{}, err
 		}
 		sec = resp.WrappedSecret
@@ -113,10 +110,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 			Secret:   sec,
 			AAD:      req.AAD,
 		})
-		if err != nil {
-			return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret, sec))
-		}
-		if err := destroyAll(sec); err != nil {
+		if err := errors.Join(err, destroySec(sec)); err != nil {
 			return CreateSecretResponse{}, err
 		}
 		sec = resp.WrappedSecret
@@ -129,14 +123,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		KeyMaterial: sec,
 		AAD:         req.AAD,
 	})
-	if err != nil {
-		return CreateSecretResponse{}, errors.Join(err, destroyAll(genResp.Secret, sec))
-	}
-
-	if err := destroyAll(genResp.Secret, sec); err != nil {
-		return CreateSecretResponse{}, err
-	}
-	return CreateSecretResponse{}, nil
+	return CreateSecretResponse{}, errors.Join(err, destroySec(sec))
 }
 
 // WrapSecret resolves the processor's secret from the vault and uses it to encrypt the given plaintext.
@@ -149,7 +136,7 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 
 	key, err := lastKey(req.KeyChain)
 	if err != nil {
-		return WrapSecretResponse{}, errors.Join(err, destroyAll(sec))
+		return WrapSecretResponse{}, errors.Join(err, destroySec(sec))
 	}
 
 	encResp, err := p.cryptor.Encrypt(ctx, cryptor.EncryptRequest{
@@ -160,13 +147,10 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		Plaintext:  req.Secret,
 		AAD:        req.AAD,
 	})
-	if err != nil {
-		return WrapSecretResponse{}, errors.Join(err, destroyAll(sec))
-	}
-
-	if err := destroyAll(sec); err != nil {
+	if err := errors.Join(err, destroySec(sec)); err != nil {
 		return WrapSecretResponse{}, err
 	}
+
 	return WrapSecretResponse{
 		WrappedSecret: encResp.Ciphertext,
 	}, nil
@@ -182,7 +166,7 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 
 	key, err := lastKey(req.KeyChain)
 	if err != nil {
-		return UnwrapSecretResponse{}, errors.Join(err, destroyAll(sec))
+		return UnwrapSecretResponse{}, errors.Join(err, destroySec(sec))
 	}
 
 	decResp, err := p.cryptor.Decrypt(ctx, cryptor.DecryptRequest{
@@ -193,13 +177,10 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		Ciphertext: req.WrappedSecret,
 		AAD:        req.AAD,
 	})
-	if err != nil {
-		return UnwrapSecretResponse{}, errors.Join(err, destroyAll(sec))
-	}
-
-	if err := destroyAll(sec); err != nil {
+	if err := errors.Join(err, destroySec(sec)); err != nil {
 		return UnwrapSecretResponse{}, err
 	}
+
 	return UnwrapSecretResponse{
 		Secret: decResp.Plaintext,
 	}, nil
@@ -221,12 +202,9 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 	}
 
 	if p.internal != nil {
-		_, err = p.internal.DeleteSecret(ctx, DeleteSecretRequest{
+		return p.internal.DeleteSecret(ctx, DeleteSecretRequest{
 			Key: model.Key{TenantID: req.Key.TenantID, ID: req.Key.ID},
 		})
-		if err != nil {
-			return DeleteSecretResponse{}, err
-		}
 	}
 
 	return DeleteSecretResponse{}, nil
@@ -259,10 +237,7 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 			WrappedSecret: sec,
 			AAD:           aad,
 		})
-		if err != nil {
-			return nil, errors.Join(err, destroyAll(sec))
-		}
-		if err := destroyAll(sec); err != nil {
+		if err := errors.Join(err, destroySec(sec)); err != nil {
 			return nil, err
 		}
 		sec = resp.Secret
@@ -274,10 +249,7 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 			WrappedSecret: sec,
 			AAD:           aad,
 		})
-		if err != nil {
-			return nil, errors.Join(err, destroyAll(sec))
-		}
-		if err := destroyAll(sec); err != nil {
+		if err := errors.Join(err, destroySec(sec)); err != nil {
 			return nil, err
 		}
 		sec = resp.Secret
@@ -300,16 +272,11 @@ func lastKey(keyChain []model.Key) (model.Key, error) {
 	return keyChain[len(keyChain)-1], nil
 }
 
-func destroyAll(secrets ...*securemem.Data) error {
-	var errs []error
-	for _, s := range secrets {
-		if s != nil {
-			if err := s.Destroy(); err != nil {
-				errs = append(errs, err)
-			}
-		}
+func destroySec(sec *securemem.Data) error {
+	if sec != nil {
+		return sec.Destroy()
 	}
-	return errors.Join(errs...)
+	return nil
 }
 
 func toCryptorSecret(data *securemem.Data) *cryptor.Secret {

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -148,6 +148,9 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		AAD:        req.AAD,
 	})
 	if err := errors.Join(err, destroySec(sec)); err != nil {
+		if encResp != nil {
+			return WrapSecretResponse{}, errors.Join(err, destroySec(encResp.Ciphertext))
+		}
 		return WrapSecretResponse{}, err
 	}
 
@@ -178,6 +181,9 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		AAD:        req.AAD,
 	})
 	if err := errors.Join(err, destroySec(sec)); err != nil {
+		if decResp != nil {
+			return UnwrapSecretResponse{}, errors.Join(err, destroySec(decResp.Plaintext))
+		}
 		return UnwrapSecretResponse{}, err
 	}
 

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -16,12 +16,11 @@ var ErrEmptyKeyChain = errors.New("empty key chain")
 // Processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
 // It destroys all intermediate secrets that pass through its operations.
 type Processor struct {
-	name            string
-	vault           vault.Vault
-	cryptor         cryptor.Cryptor
-	secretGenerator cryptor.SecretGenerator
-	internal        *Processor
-	parent          *Processor
+	generator cryptor.SecretGenerator
+	wrapper   cryptor.Cryptor
+	sealer    cryptor.Cryptor
+	vault     vault.Vault
+	parent    *Processor
 }
 
 // CreateSecretRequest is the input for CreateSecret.
@@ -65,10 +64,10 @@ type DeleteSecretRequest struct {
 // DeleteSecretResponse is the output of DeleteSecret.
 type DeleteSecretResponse struct{}
 
-// CreateSecret generates a secret, wraps it through the internal and parent chain, and stores it in the vault.
-// It is a no-op when the cryptor manages its own decryption key regardless of internal or parent configuration.
+// CreateSecret generates a secret, seals it, wraps it through the parent chain, and stores it in the vault.
+// It is a no-op when the wrapper manages its own decryption key.
 func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (CreateSecretResponse, error) {
-	if !p.cryptor.Info().DecryptionSecretRequired {
+	if !p.wrapper.Info().DecryptionSecretRequired {
 		return CreateSecretResponse{}, nil
 	}
 
@@ -77,40 +76,24 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		return CreateSecretResponse{}, err
 	}
 
-	genResp, err := p.secretGenerator.GenerateSecret(ctx)
+	genResp, err := p.generator.GenerateSecret(ctx)
 	if err != nil {
 		return CreateSecretResponse{}, err
 	}
 
-	sec := genResp.Secret
-
-	if p.internal != nil {
-		resp, err := p.internal.WrapSecret(ctx, WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: key.TenantID, ID: key.ID}},
-			Secret:   sec,
-			AAD:      req.AAD,
-		})
-		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return CreateSecretResponse{}, errors.Join(err, destroySec(resp.WrappedSecret))
-		}
-		sec = resp.WrappedSecret
+	sec, err := p.seal(ctx, key, genResp.Secret, req.AAD)
+	if err != nil {
+		return CreateSecretResponse{}, err
 	}
 
-	if p.parent != nil {
-		resp, err := p.parent.WrapSecret(ctx, WrapSecretRequest{
-			KeyChain: req.KeyChain[:len(req.KeyChain)-1],
-			Secret:   sec,
-			AAD:      req.AAD,
-		})
-		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return CreateSecretResponse{}, errors.Join(err, destroySec(resp.WrappedSecret))
-		}
-		sec = resp.WrappedSecret
+	sec, err = p.parentWrap(ctx, req.KeyChain, sec, req.AAD)
+	if err != nil {
+		return CreateSecretResponse{}, err
 	}
 
 	_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    key.TenantID,
-		KeyID:       p.keyID(key.ID),
+		KeyID:       key.ID,
 		KeyVersion:  1,
 		KeyMaterial: sec,
 		AAD:         req.AAD,
@@ -118,8 +101,8 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 	return CreateSecretResponse{}, errors.Join(err, destroySec(sec))
 }
 
-// WrapSecret resolves the processor's secret from the vault and uses it to encrypt the given plaintext.
-// When the cryptor manages its own decryption key, it encrypts directly without resolving.
+// WrapSecret resolves the wrapping secret from the key chain and encrypts the given secret.
+// When the wrapper manages its own decryption key, it encrypts directly without resolving.
 func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
 	sec, err := p.resolveSecret(ctx, req.KeyChain)
 	if err != nil {
@@ -131,9 +114,9 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		return WrapSecretResponse{}, errors.Join(err, destroySec(sec))
 	}
 
-	encResp, err := p.cryptor.Encrypt(ctx, cryptor.EncryptRequest{
+	encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
 		TenantID:   key.TenantID,
-		KeyID:      p.keyID(key.ID),
+		KeyID:      key.ID,
 		KeyVersion: 1,
 		Secret:     toCryptorSecret(sec),
 		Plaintext:  req.Secret,
@@ -151,8 +134,8 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 	}, nil
 }
 
-// UnwrapSecret resolves the processor's secret from the vault and uses it to decrypt the given ciphertext.
-// When the cryptor manages its own decryption key, it decrypts directly without resolving.
+// UnwrapSecret resolves the wrapping secret from the key chain and decrypts the given wrapped secret.
+// When the wrapper manages its own decryption key, it decrypts directly without resolving.
 func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
 	sec, err := p.resolveSecret(ctx, req.KeyChain)
 	if err != nil {
@@ -164,9 +147,9 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		return UnwrapSecretResponse{}, errors.Join(err, destroySec(sec))
 	}
 
-	decResp, err := p.cryptor.Decrypt(ctx, cryptor.DecryptRequest{
+	decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
 		TenantID:   key.TenantID,
-		KeyID:      p.keyID(key.ID),
+		KeyID:      key.ID,
 		KeyVersion: 1,
 		Secret:     toCryptorSecret(sec),
 		Ciphertext: req.WrappedSecret,
@@ -184,16 +167,16 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 	}, nil
 }
 
-// DeleteSecret removes the processor's secret from the vault.
-// It is a no-op when the cryptor manages its own decryption.
+// DeleteSecret removes the wrapping secret from the vault.
+// It is a no-op when the wrapper manages its own decryption key.
 func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (DeleteSecretResponse, error) {
-	if !p.cryptor.Info().DecryptionSecretRequired {
+	if !p.wrapper.Info().DecryptionSecretRequired {
 		return DeleteSecretResponse{}, nil
 	}
 
 	_, err := p.vault.DestroyKey(ctx, vault.DestroyKeyRequest{
 		TenantID: req.Key.TenantID,
-		KeyID:    p.keyID(req.Key.ID),
+		KeyID:    req.Key.ID,
 	})
 	if err != nil {
 		return DeleteSecretResponse{}, err
@@ -203,7 +186,7 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 }
 
 func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*securemem.Data, error) {
-	if !p.cryptor.Info().DecryptionSecretRequired {
+	if !p.wrapper.Info().DecryptionSecretRequired {
 		return nil, nil //nolint:nilnil
 	}
 
@@ -214,47 +197,88 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 
 	exported, err := p.vault.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID: key.TenantID,
-		KeyID:    p.keyID(key.ID),
+		KeyID:    key.ID,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	sec := exported.KeyMaterial
-	aad := exported.AAD
-
-	if p.parent != nil {
-		resp, err := p.parent.UnwrapSecret(ctx, UnwrapSecretRequest{
-			KeyChain:      keyChain[:len(keyChain)-1],
-			WrappedSecret: sec,
-			AAD:           aad,
-		})
-		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return nil, errors.Join(err, destroySec(resp.Secret))
-		}
-		sec = resp.Secret
+	sec, err := p.parentUnwrap(ctx, keyChain, exported.KeyMaterial, exported.AAD)
+	if err != nil {
+		return nil, err
 	}
 
-	if p.internal != nil {
-		resp, err := p.internal.UnwrapSecret(ctx, UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: key.TenantID, ID: key.ID}},
-			WrappedSecret: sec,
-			AAD:           aad,
-		})
-		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return nil, errors.Join(err, destroySec(resp.Secret))
-		}
-		sec = resp.Secret
-	}
-
-	return sec, nil
+	return p.unseal(ctx, key, sec, exported.AAD)
 }
 
-func (p *Processor) keyID(id string) string {
-	if p.name == "" {
-		return id
+func (p *Processor) seal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if p.sealer == nil {
+		return sec, nil
 	}
-	return p.name + "/" + id
+	resp, err := p.sealer.Encrypt(ctx, cryptor.EncryptRequest{
+		TenantID:   key.TenantID,
+		KeyID:      key.ID,
+		KeyVersion: 1,
+		Plaintext:  sec,
+		AAD:        aad,
+	})
+	if err := errors.Join(err, destroySec(sec)); err != nil {
+		if resp.Ciphertext != nil {
+			return nil, errors.Join(err, destroySec(resp.Ciphertext))
+		}
+		return nil, err
+	}
+	return resp.Ciphertext, nil
+}
+
+func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if p.sealer == nil {
+		return sec, nil
+	}
+	resp, err := p.sealer.Decrypt(ctx, cryptor.DecryptRequest{
+		TenantID:   key.TenantID,
+		KeyID:      key.ID,
+		KeyVersion: 1,
+		Ciphertext: sec,
+		AAD:        aad,
+	})
+	if err := errors.Join(err, destroySec(sec)); err != nil {
+		if resp.Plaintext != nil {
+			return nil, errors.Join(err, destroySec(resp.Plaintext))
+		}
+		return nil, err
+	}
+	return resp.Plaintext, nil
+}
+
+func (p *Processor) parentWrap(ctx context.Context, keyChain []model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if p.parent == nil {
+		return sec, nil
+	}
+	resp, err := p.parent.WrapSecret(ctx, WrapSecretRequest{
+		KeyChain: keyChain[:len(keyChain)-1],
+		Secret:   sec,
+		AAD:      aad,
+	})
+	if err := errors.Join(err, destroySec(sec)); err != nil {
+		return nil, errors.Join(err, destroySec(resp.WrappedSecret))
+	}
+	return resp.WrappedSecret, nil
+}
+
+func (p *Processor) parentUnwrap(ctx context.Context, keyChain []model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if p.parent == nil {
+		return sec, nil
+	}
+	resp, err := p.parent.UnwrapSecret(ctx, UnwrapSecretRequest{
+		KeyChain:      keyChain[:len(keyChain)-1],
+		WrappedSecret: sec,
+		AAD:           aad,
+	})
+	if err := errors.Join(err, destroySec(sec)); err != nil {
+		return nil, errors.Join(err, destroySec(resp.Secret))
+	}
+	return resp.Secret, nil
 }
 
 func lastKey(keyChain []model.Key) (model.Key, error) {

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -85,21 +85,13 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 	sec := genResp.Secret
 
 	if p.internal != nil {
-		_, err := p.internal.CreateSecret(ctx, CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: key.TenantID, ID: key.ID}},
-			AAD:      req.AAD,
-		})
-		if err != nil {
-			return CreateSecretResponse{}, errors.Join(err, destroySec(sec))
-		}
-
 		resp, err := p.internal.WrapSecret(ctx, WrapSecretRequest{
 			KeyChain: []model.Key{{TenantID: key.TenantID, ID: key.ID}},
 			Secret:   sec,
 			AAD:      req.AAD,
 		})
 		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return CreateSecretResponse{}, err
+			return CreateSecretResponse{}, errors.Join(err, destroySec(resp.WrappedSecret))
 		}
 		sec = resp.WrappedSecret
 	}
@@ -111,7 +103,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 			AAD:      req.AAD,
 		})
 		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return CreateSecretResponse{}, err
+			return CreateSecretResponse{}, errors.Join(err, destroySec(resp.WrappedSecret))
 		}
 		sec = resp.WrappedSecret
 	}
@@ -192,8 +184,8 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 	}, nil
 }
 
-// DeleteSecret removes the processor's secret and its internal processor's secret from the vault.
-// It is a no-op when the cryptor manages its own decryption key regardless of internal or parent configuration.
+// DeleteSecret removes the processor's secret from the vault.
+// It is a no-op when the cryptor manages its own decryption.
 func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (DeleteSecretResponse, error) {
 	if !p.cryptor.Info().DecryptionSecretRequired {
 		return DeleteSecretResponse{}, nil
@@ -205,12 +197,6 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 	})
 	if err != nil {
 		return DeleteSecretResponse{}, err
-	}
-
-	if p.internal != nil {
-		return p.internal.DeleteSecret(ctx, DeleteSecretRequest{
-			Key: model.Key{TenantID: req.Key.TenantID, ID: req.Key.ID},
-		})
 	}
 
 	return DeleteSecretResponse{}, nil
@@ -244,7 +230,7 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 			AAD:           aad,
 		})
 		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return nil, err
+			return nil, errors.Join(err, destroySec(resp.Secret))
 		}
 		sec = resp.Secret
 	}
@@ -256,7 +242,7 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 			AAD:           aad,
 		})
 		if err := errors.Join(err, destroySec(sec)); err != nil {
-			return nil, err
+			return nil, errors.Join(err, destroySec(resp.Secret))
 		}
 		sec = resp.Secret
 	}

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -25,12 +25,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
 		})
 
 		// then
 		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
 	t.Run("should return error if key chain is empty", func(t *testing.T) {
@@ -38,10 +39,11 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{})
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{})
 
 		// then
 		assert.ErrorIs(t, err, keyprocessor.ErrEmptyKeyChain)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
 	t.Run("should return error if secret generation fails", func(t *testing.T) {
@@ -55,12 +57,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, nil, nil)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
 		})
 
 		// then
 		assert.ErrorIs(t, err, genErr)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
 	t.Run("should return error if internal wrap fails", func(t *testing.T) {
@@ -90,12 +93,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, internal, nil)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.ErrorContains(t, err, "internal export failed")
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 		assert.Nil(t, captured.SecureBytes())
 	})
 
@@ -127,12 +131,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, nil, parent)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.ErrorContains(t, err, "parent vault down")
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 		assert.Nil(t, captured.SecureBytes())
 	})
 
@@ -180,12 +185,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, internal, parent)
 
 		// when
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.ErrorContains(t, err, "parent vault down")
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 		assert.Nil(t, captured.SecureBytes())
 		assert.NotNil(t, internalWrapOutput)
 		assert.Nil(t, internalWrapOutput.SecureBytes())
@@ -230,12 +236,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, nil, parent)
 
 		// when
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.ErrorContains(t, err, "disk full")
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 		assert.Nil(t, captured.SecureBytes())
 	})
 
@@ -253,12 +260,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
 
 		// when
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
 	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
@@ -276,12 +284,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
 
 		// when
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
 	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
@@ -305,12 +314,13 @@ func TestCreateSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
 
 		// when
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 
 		// then
 		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 }
 
@@ -332,10 +342,11 @@ func TestResolveSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 
 		// when
-		_, err := processor.ResolveSecret(t.Context(), []model.Key{})
+		resp, err := processor.ResolveSecret(t.Context(), []model.Key{})
 
 		// then
 		assert.ErrorIs(t, err, keyprocessor.ErrEmptyKeyChain)
+		assert.Nil(t, resp)
 	})
 
 	t.Run("should return error if key is not found", func(t *testing.T) {
@@ -345,10 +356,11 @@ func TestResolveSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
 
 		// when
-		_, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
+		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+		assert.Nil(t, resp)
 	})
 
 	t.Run("should return error if vault export fails", func(t *testing.T) {
@@ -369,10 +381,11 @@ func TestResolveSecret(t *testing.T) {
 		assert.NoError(t, err)
 
 		// when
-		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
 
 		// then
 		assert.ErrorContains(t, err, "connection reset")
+		assert.Nil(t, resp)
 	})
 
 	t.Run("should return error if parent unwrap fails", func(t *testing.T) {
@@ -410,10 +423,11 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		// when
-		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
 
 		// then
 		assert.ErrorContains(t, err, "parent unavailable")
+		assert.Nil(t, resp)
 		assert.NotNil(t, exported)
 		assert.Nil(t, exported.SecureBytes())
 	})
@@ -451,10 +465,11 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		// when
-		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
 
 		// then
 		assert.ErrorContains(t, err, "internal export failed")
+		assert.Nil(t, resp)
 		assert.NotNil(t, exported)
 		assert.Nil(t, exported.SecureBytes())
 	})
@@ -554,13 +569,14 @@ func TestWrapSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
 
 		// when
-		_, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
 			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
 			Secret:   newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
 	})
 
 	t.Run("should return error if encryption fails", func(t *testing.T) {
@@ -590,13 +606,14 @@ func TestWrapSecret(t *testing.T) {
 		}
 
 		// when — nil plaintext is rejected by aes256gcm
-		_, err = processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 			Secret:   nil,
 		})
 
 		// then
 		assert.Error(t, err)
+		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
 		assert.Nil(t, exported.SecureBytes())
 	})
 
@@ -756,13 +773,14 @@ func TestUnwrapSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 
 		// when
-		_, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
 			KeyChain:      []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
 			WrappedSecret: newTestData(t, []byte("ciphertext")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
 	})
 
 	t.Run("should return error if decryption fails with tampered ciphertext", func(t *testing.T) {
@@ -788,13 +806,14 @@ func TestUnwrapSecret(t *testing.T) {
 		tampered[0] ^= 0xFF
 
 		// when
-		_, err = processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
 			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
 			WrappedSecret: newTestData(t, tampered),
 		})
 
 		// then
 		assert.Error(t, err)
+		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
 	})
 
 	t.Run("should return error if decryption fails with wrong AAD", func(t *testing.T) {
@@ -817,7 +836,7 @@ func TestUnwrapSecret(t *testing.T) {
 		assert.NoError(t, err)
 
 		// when
-		_, err = processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
 			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("wrong-aad"),
@@ -825,6 +844,7 @@ func TestUnwrapSecret(t *testing.T) {
 
 		// then
 		assert.Error(t, err)
+		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
 	})
 
 	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
@@ -957,12 +977,13 @@ func TestDeleteSecret(t *testing.T) {
 		}
 
 		// when
-		_, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
 			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
 		})
 
 		// then
 		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.DeleteSecretResponse{}, resp)
 		assert.False(t, called)
 	})
 
@@ -985,12 +1006,13 @@ func TestDeleteSecret(t *testing.T) {
 		}
 
 		// when
-		_, err = processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
 			Key: model.Key{TenantID: tenantID, ID: keyID},
 		})
 
 		// then
 		assert.ErrorContains(t, err, "vault locked")
+		assert.Equal(t, keyprocessor.DeleteSecretResponse{}, resp)
 	})
 
 	t.Run("should succeed", func(t *testing.T) {
@@ -1013,12 +1035,13 @@ func TestDeleteSecret(t *testing.T) {
 		}
 
 		// when
-		_, err = processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
 			Key: model.Key{TenantID: tenantID, ID: keyID},
 		})
 
 		// then
 		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.DeleteSecretResponse{}, resp)
 	})
 }
 
@@ -1123,13 +1146,14 @@ func TestHierarchy(t *testing.T) {
 		}
 
 		// when
-		_, err = child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+		resp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
 			Secret:   newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorContains(t, err, "parent compromised")
+		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
 	})
 }
 

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func TestCreateSecret(t *testing.T) {
-	t.Run("should not create if cryptor manages its own decryption key", func(t *testing.T) {
+	t.Run("should not create if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -36,7 +36,7 @@ func TestCreateSecret(t *testing.T) {
 
 	t.Run("should return error if key chain is empty", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{})
@@ -49,12 +49,12 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should return error if secret generation fails", func(t *testing.T) {
 		// given
 		genErr := errors.New("entropy exhausted")
-		gen := &secretGenWrapper{
-			generateSecretFn: func(context.Context) (*cryptor.GenerateSecretResponse, error) {
-				return nil, genErr
-			},
+
+		gen := &secretGenWrapper{}
+		gen.generateSecretFn = func(context.Context) (*cryptor.GenerateSecretResponse, error) {
+			return nil, genErr
 		}
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, nil, nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -66,31 +66,30 @@ func TestCreateSecret(t *testing.T) {
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
-	t.Run("should return error if internal wrap fails", func(t *testing.T) {
+	t.Run("should return error if sealing fails", func(t *testing.T) {
 		// given
+		sealErr := errors.New("sealing failed")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		var captured *securemem.Data
-		realGen := newTestSecretGen()
-		gen := &secretGenWrapper{
-			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-				resp, err := realGen.GenerateSecret(ctx)
-				if err == nil {
-					captured = resp.Secret
-				}
-				return resp, err
-			},
+		var genSec *securemem.Data
+		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
+		gen.generateSecretFn = func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+			resp, err := gen.SecretGenerator.GenerateSecret(ctx)
+			if err == nil {
+				genSec = resp.Secret
+			}
+			return resp, err
 		}
 
-		internalVault := &vaultWrapper{Vault: newTestVault(t)}
-		internalVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+		sealer := &cryptorWrapper{Cryptor: newStaticSecretCryptor(t)}
+		sealer.encryptFn = func(_ context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, "internal/"+keyID, req.KeyID)
-			return nil, errors.New("internal export failed")
+			assert.Equal(t, keyID, req.KeyID)
+			return &cryptor.EncryptResponse{}, sealErr
 		}
-		internal := keyprocessor.NewProcessor("internal", internalVault, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, internal, nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -98,37 +97,37 @@ func TestCreateSecret(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorContains(t, err, "internal export failed")
+		assert.ErrorIs(t, err, sealErr)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-		assert.Nil(t, captured.SecureBytes())
+		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should return error if parent wrap fails", func(t *testing.T) {
+	t.Run("should return error if parent wrapping fails", func(t *testing.T) {
 		// given
+		parentErr := errors.New("parent vault down")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		var captured *securemem.Data
-		realGen := newTestSecretGen()
-		gen := &secretGenWrapper{
-			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-				resp, err := realGen.GenerateSecret(ctx)
-				if err == nil {
-					captured = resp.Secret
-				}
-				return resp, err
-			},
+		var genSec *securemem.Data
+		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
+		gen.generateSecretFn = func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+			resp, err := gen.SecretGenerator.GenerateSecret(ctx)
+			if err == nil {
+				genSec = resp.Secret
+			}
+			return resp, err
 		}
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
 		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, parentID, req.KeyID)
-			return nil, errors.New("parent vault down")
+			return nil, parentErr
 		}
-		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, nil, parent)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, newTestVault(t), parent)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -136,53 +135,46 @@ func TestCreateSecret(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorContains(t, err, "parent vault down")
+		assert.ErrorIs(t, err, parentErr)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-		assert.Nil(t, captured.SecureBytes())
+		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should return error if parent wrap fails after internal wrap", func(t *testing.T) {
+	t.Run("should return error if parent wrapping fails after sealing", func(t *testing.T) {
 		// given
+		parentErr := errors.New("parent vault down")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		var captured *securemem.Data
-		realGen := newTestSecretGen()
-		gen := &secretGenWrapper{
-			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-				resp, err := realGen.GenerateSecret(ctx)
-				if err == nil {
-					captured = resp.Secret
-				}
-				return resp, err
-			},
+		var genSec *securemem.Data
+		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
+		gen.generateSecretFn = func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+			resp, err := gen.SecretGenerator.GenerateSecret(ctx)
+			if err == nil {
+				genSec = resp.Secret
+			}
+			return resp, err
 		}
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
 		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, errors.New("parent vault down")
+			return nil, parentErr
 		}
-		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
 
-		var internalWrapOutput *securemem.Data
-		internalCryptor := &cryptorWrapper{
-			Cryptor: newTestCryptor(),
-			encryptFn: func(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
-				resp, err := newTestCryptor().Encrypt(ctx, req)
-				if err == nil {
-					internalWrapOutput = resp.Ciphertext
-				}
-				return resp, err
-			},
+		realSealer := newStaticSecretCryptor(t)
+		var sealedSec *securemem.Data
+		sealer := &cryptorWrapper{Cryptor: realSealer}
+		sealer.encryptFn = func(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+			resp, err := realSealer.Encrypt(ctx, req)
+			if err == nil {
+				sealedSec = resp.Ciphertext
+			}
+			return resp, err
 		}
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, internalCryptor, newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, internal, parent)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, newTestVault(t), parent)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -190,39 +182,34 @@ func TestCreateSecret(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorContains(t, err, "parent vault down")
+		assert.ErrorIs(t, err, parentErr)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-		assert.Nil(t, captured.SecureBytes())
-		assert.NotNil(t, internalWrapOutput)
-		assert.Nil(t, internalWrapOutput.SecureBytes())
+		assert.Nil(t, genSec.SecureBytes())
+		assert.NotNil(t, sealedSec)
+		assert.Nil(t, sealedSec.SecureBytes())
 	})
 
 	t.Run("should return error if vault import fails", func(t *testing.T) {
 		// given
+		importErr := errors.New("disk full")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		var captured *securemem.Data
-		realGen := newTestSecretGen()
-		gen := &secretGenWrapper{
-			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-				resp, err := realGen.GenerateSecret(ctx)
-				if err == nil {
-					captured = resp.Secret
-				}
-				return resp, err
-			},
+		var genSec *securemem.Data
+		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
+		gen.generateSecretFn = func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+			resp, err := gen.SecretGenerator.GenerateSecret(ctx)
+			if err == nil {
+				genSec = resp.Secret
+			}
+			return resp, err
 		}
 
 		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := parentInternal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
-		_, err = parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentV, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
@@ -231,9 +218,9 @@ func TestCreateSecret(t *testing.T) {
 		v.importKeyFn = func(ctx context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, keyID, req.KeyID)
-			return nil, errors.New("disk full")
+			return nil, importErr
 		}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, nil, parent)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, v, parent)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -241,23 +228,17 @@ func TestCreateSecret(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorContains(t, err, "disk full")
+		assert.ErrorIs(t, err, importErr)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-		assert.Nil(t, captured.SecureBytes())
+		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -269,19 +250,19 @@ func TestCreateSecret(t *testing.T) {
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
-	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -293,25 +274,19 @@ func TestCreateSecret(t *testing.T) {
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
-	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -325,9 +300,9 @@ func TestCreateSecret(t *testing.T) {
 }
 
 func TestResolveSecret(t *testing.T) {
-	t.Run("should return nil if cryptor manages its own decryption key", func(t *testing.T) {
+	t.Run("should return nil if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
 
 		// when
 		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
@@ -339,7 +314,7 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should return error if key chain is empty", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.ResolveSecret(t.Context(), []model.Key{})
@@ -351,9 +326,7 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should return error if key is not found", func(t *testing.T) {
 		// given
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
@@ -365,129 +338,124 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should return error if vault export fails", func(t *testing.T) {
 		// given
+		exportErr := errors.New("connection reset")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, keyID, req.KeyID)
-			return nil, errors.New("connection reset")
-		}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
 
+		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, keyID, req.KeyID)
+			return nil, exportErr
+		}
+
 		// when
 		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
 
 		// then
-		assert.ErrorContains(t, err, "connection reset")
+		assert.ErrorIs(t, err, exportErr)
 		assert.Nil(t, resp)
 	})
 
 	t.Run("should return error if parent unwrap fails", func(t *testing.T) {
 		// given
+		parentErr := errors.New("parent unavailable")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
 
-		var exported *securemem.Data
+		var exportSec *securemem.Data
 		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			resp, err := v.Vault.ExportKey(ctx, req)
 			if err == nil {
-				exported = resp.KeyMaterial
+				exportSec = resp.KeyMaterial
 			}
 			return resp, err
 		}
 		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, parentID, req.KeyID)
-			return nil, errors.New("parent unavailable")
+			return nil, parentErr
 		}
 
 		// when
 		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
 
 		// then
-		assert.ErrorContains(t, err, "parent unavailable")
+		assert.ErrorIs(t, err, parentErr)
 		assert.Nil(t, resp)
-		assert.NotNil(t, exported)
-		assert.Nil(t, exported.SecureBytes())
+		assert.NotNil(t, exportSec)
+		assert.Nil(t, exportSec.SecureBytes())
 	})
 
-	t.Run("should return error if internal unwrap fails", func(t *testing.T) {
+	t.Run("should return error if unsealing fails", func(t *testing.T) {
 		// given
+		unsealErr := errors.New("unsealing failed")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		internalVault := &vaultWrapper{Vault: newTestVault(t)}
-		internal := keyprocessor.NewProcessor("internal", internalVault, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
+		realSealer := newStaticSecretCryptor(t)
+		sealer := &cryptorWrapper{Cryptor: realSealer}
+		sealer.decryptFn = func(_ context.Context, _ cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
+			return &cryptor.DecryptResponse{}, unsealErr
+		}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), sealer, v, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
 
-		var exported *securemem.Data
+		var exportSec *securemem.Data
 		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			resp, err := v.Vault.ExportKey(ctx, req)
 			if err == nil {
-				exported = resp.KeyMaterial
+				exportSec = resp.KeyMaterial
 			}
 			return resp, err
-		}
-		internalVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, "internal/"+keyID, req.KeyID)
-			return nil, errors.New("internal export failed")
 		}
 
 		// when
 		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
 
 		// then
-		assert.ErrorContains(t, err, "internal export failed")
+		assert.ErrorIs(t, err, unsealErr)
 		assert.Nil(t, resp)
-		assert.NotNil(t, exported)
-		assert.Nil(t, exported.SecureBytes())
+		assert.NotNil(t, exportSec)
+		assert.Nil(t, exportSec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -501,19 +469,19 @@ func TestResolveSecret(t *testing.T) {
 		assert.NotNil(t, sec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -528,25 +496,19 @@ func TestResolveSecret(t *testing.T) {
 		assert.NotNil(t, sec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -565,9 +527,7 @@ func TestResolveSecret(t *testing.T) {
 func TestWrapSecret(t *testing.T) {
 	t.Run("should return error if resolve fails", func(t *testing.T) {
 		// given
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
@@ -586,22 +546,17 @@ func TestWrapSecret(t *testing.T) {
 		keyID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
 
-		var exported *securemem.Data
+		var exportSec *securemem.Data
 		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			resp, err := v.Vault.ExportKey(ctx, req)
 			if err == nil {
-				exported = resp.KeyMaterial
+				exportSec = resp.KeyMaterial
 			}
 			return resp, err
 		}
@@ -615,12 +570,12 @@ func TestWrapSecret(t *testing.T) {
 		// then
 		assert.Error(t, err)
 		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
-		assert.Nil(t, exported.SecureBytes())
+		assert.Nil(t, exportSec.SecureBytes())
 	})
 
-	t.Run("should wrap without resolving if cryptor manages its own decryption key", func(t *testing.T) {
+	t.Run("should wrap without resolving if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
 
 		// when
 		chain := []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}}
@@ -640,28 +595,23 @@ func TestWrapSecret(t *testing.T) {
 		assert.Equal(t, []byte("data"), []byte(unwrapResp.Secret.SecureBytes()))
 	})
 
-	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), v, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
 
-		var exported *securemem.Data
+		var exportSec *securemem.Data
 		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			resp, err := v.Vault.ExportKey(ctx, req)
 			if err == nil {
-				exported = resp.KeyMaterial
+				exportSec = resp.KeyMaterial
 			}
 			return resp, err
 		}
@@ -683,23 +633,23 @@ func TestWrapSecret(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
-		assert.NotNil(t, exported)
-		assert.Nil(t, exported.SecureBytes())
+		assert.NotNil(t, exportSec)
+		assert.Nil(t, exportSec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -724,25 +674,19 @@ func TestWrapSecret(t *testing.T) {
 		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
 	})
 
-	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -771,7 +715,7 @@ func TestWrapSecret(t *testing.T) {
 func TestUnwrapSecret(t *testing.T) {
 	t.Run("should return error if resolve fails", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
@@ -789,7 +733,7 @@ func TestUnwrapSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
@@ -822,7 +766,7 @@ func TestUnwrapSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 			AAD:      []byte("create-aad"),
@@ -848,19 +792,13 @@ func TestUnwrapSecret(t *testing.T) {
 		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
 	})
 
-	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -884,19 +822,19 @@ func TestUnwrapSecret(t *testing.T) {
 		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
 	})
 
-	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -921,25 +859,19 @@ func TestUnwrapSecret(t *testing.T) {
 		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
 	})
 
-	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -966,10 +898,10 @@ func TestUnwrapSecret(t *testing.T) {
 }
 
 func TestDeleteSecret(t *testing.T) {
-	t.Run("should not delete if cryptor manages its own decryption key", func(t *testing.T) {
+	t.Run("should not delete if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor("", v, newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, v, nil)
 
 		var called bool
 		v.destroyKeyFn = func(context.Context, vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
@@ -990,11 +922,13 @@ func TestDeleteSecret(t *testing.T) {
 
 	t.Run("should return error if key destroy fails", func(t *testing.T) {
 		// given
+		destroyErr := errors.New("vault locked")
+
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
@@ -1003,7 +937,7 @@ func TestDeleteSecret(t *testing.T) {
 		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, keyID, req.KeyID)
-			return nil, errors.New("vault locked")
+			return nil, destroyErr
 		}
 
 		// when
@@ -1012,7 +946,7 @@ func TestDeleteSecret(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorContains(t, err, "vault locked")
+		assert.ErrorIs(t, err, destroyErr)
 		assert.Equal(t, keyprocessor.DeleteSecretResponse{}, resp)
 	})
 
@@ -1023,7 +957,7 @@ func TestDeleteSecret(t *testing.T) {
 		parentID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
@@ -1049,19 +983,13 @@ func TestDeleteSecret(t *testing.T) {
 func TestHierarchy(t *testing.T) {
 	t.Run("should succeed for two-level chain round trip", func(t *testing.T) {
 		// given
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err := parentInternal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
-		})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
-		_, err = parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
 		})
 		assert.NoError(t, err)
 
-		child := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
 		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
 		})
@@ -1086,25 +1014,19 @@ func TestHierarchy(t *testing.T) {
 
 	t.Run("should succeed for three-level chain round trip", func(t *testing.T) {
 		// given
-		root := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+		root := keyprocessor.NewProcessor(newTestSecretGen(), newStaticSecretCryptor(t), nil, newTestVault(t), nil)
 		_, err := root.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}},
 		})
 		assert.NoError(t, err)
 
-		midV := newTestVault(t)
-		midInternal := keyprocessor.NewProcessor("internal", midV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		_, err = midInternal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "mid-1"}},
-		})
-		assert.NoError(t, err)
-		mid := keyprocessor.NewProcessor("", midV, newTestCryptor(), newTestSecretGen(), midInternal, root)
+		mid := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), root)
 		_, err = mid.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}},
 		})
 		assert.NoError(t, err)
 
-		leaf := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, mid)
+		leaf := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), mid)
 		_, err = leaf.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
 		})
@@ -1129,21 +1051,23 @@ func TestHierarchy(t *testing.T) {
 
 	t.Run("should return error if parent vault fails during child resolve", func(t *testing.T) {
 		// given
+		parentErr := errors.New("parent compromised")
+
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
 		})
 		assert.NoError(t, err)
 
-		child := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
 		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
 		})
 		assert.NoError(t, err)
 
 		parentVault.exportKeyFn = func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, errors.New("parent compromised")
+			return nil, parentErr
 		}
 
 		// when
@@ -1153,7 +1077,7 @@ func TestHierarchy(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorContains(t, err, "parent compromised")
+		assert.ErrorIs(t, err, parentErr)
 		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
 	})
 }
@@ -1204,11 +1128,16 @@ func (w *vaultWrapper) Info() vault.Info {
 }
 
 type secretGenWrapper struct {
+	cryptor.SecretGenerator
+
 	generateSecretFn func(context.Context) (*cryptor.GenerateSecretResponse, error)
 }
 
 func (w *secretGenWrapper) GenerateSecret(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-	return w.generateSecretFn(ctx)
+	if w.generateSecretFn != nil {
+		return w.generateSecretFn(ctx)
+	}
+	return w.SecretGenerator.GenerateSecret(ctx)
 }
 
 type cryptorWrapper struct {

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -1,0 +1,1299 @@
+package keyprocessor_test
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/keyprocessor"
+	"github.com/openkcm/krypton/internal/securemem"
+	"github.com/openkcm/krypton/internal/vault"
+	"github.com/openkcm/krypton/internal/vault/sqlitevault"
+	"github.com/openkcm/krypton/pkg/model"
+)
+
+func TestCreateSecret(t *testing.T) {
+	t.Run("should not create if cryptor manages its own decryption key", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+		})
+
+		// then
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return error if key chain is empty", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrEmptyKeyChain)
+	})
+
+	t.Run("should return error if secret generation fails", func(t *testing.T) {
+		// given
+		genErr := errors.New("entropy exhausted")
+		gen := &secretGenWrapper{
+			generateSecretFn: func(context.Context) (*cryptor.GenerateSecretResponse, error) {
+				return nil, genErr
+			},
+		}
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, nil, nil)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+		})
+
+		// then
+		assert.ErrorIs(t, err, genErr)
+	})
+
+	t.Run("should return error if internal secret creation fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		var captured *securemem.Data
+		realGen := newTestSecretGen()
+		gen := &secretGenWrapper{
+			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+				resp, err := realGen.GenerateSecret(ctx)
+				if err == nil {
+					captured = resp.Secret
+				}
+				return resp, err
+			},
+		}
+
+		internalGen := &secretGenWrapper{
+			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+				return nil, errors.New("internal gen failed")
+			},
+		}
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), internalGen, nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, internal, nil)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "internal gen failed")
+		assert.Nil(t, captured.SecureBytes())
+	})
+
+	t.Run("should return error if internal wrap fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		var captured *securemem.Data
+		realGen := newTestSecretGen()
+		gen := &secretGenWrapper{
+			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+				resp, err := realGen.GenerateSecret(ctx)
+				if err == nil {
+					captured = resp.Secret
+				}
+				return resp, err
+			},
+		}
+
+		internalVault := &vaultWrapper{Vault: newTestVault(t)}
+		internalVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, "internal/"+keyID, req.KeyID)
+			return nil, errors.New("internal export failed")
+		}
+		internal := keyprocessor.NewProcessor("internal", internalVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, internal, nil)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "internal export failed")
+		assert.Nil(t, captured.SecureBytes())
+	})
+
+	t.Run("should return error if parent wrap fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		var captured *securemem.Data
+		realGen := newTestSecretGen()
+		gen := &secretGenWrapper{
+			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+				resp, err := realGen.GenerateSecret(ctx)
+				if err == nil {
+					captured = resp.Secret
+				}
+				return resp, err
+			},
+		}
+
+		parentVault := &vaultWrapper{Vault: newTestVault(t)}
+		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			return nil, errors.New("parent vault down")
+		}
+		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), gen, nil, parent)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "parent vault down")
+		assert.Nil(t, captured.SecureBytes())
+	})
+
+	t.Run("should return error if parent wrap fails after internal wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		var captured *securemem.Data
+		realGen := newTestSecretGen()
+		gen := &secretGenWrapper{
+			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+				resp, err := realGen.GenerateSecret(ctx)
+				if err == nil {
+					captured = resp.Secret
+				}
+				return resp, err
+			},
+		}
+
+		parentVault := &vaultWrapper{Vault: newTestVault(t)}
+		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			return nil, errors.New("parent vault down")
+		}
+		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+
+		var internalWrapOutput *securemem.Data
+		internalCryptor := &cryptorWrapper{
+			Cryptor: newTestCryptor(),
+			encryptFn: func(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+				resp, err := newTestCryptor().Encrypt(ctx, req)
+				if err == nil {
+					internalWrapOutput = resp.Ciphertext
+				}
+				return resp, err
+			},
+		}
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, internalCryptor, newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, internal, parent)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "parent vault down")
+		assert.Nil(t, captured.SecureBytes())
+		assert.NotNil(t, internalWrapOutput)
+		assert.Nil(t, internalWrapOutput.SecureBytes())
+	})
+
+	t.Run("should return error if vault import fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		var captured *securemem.Data
+		realGen := newTestSecretGen()
+		gen := &secretGenWrapper{
+			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+				resp, err := realGen.GenerateSecret(ctx)
+				if err == nil {
+					captured = resp.Secret
+				}
+				return resp, err
+			},
+		}
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		v.importKeyFn = func(ctx context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, keyID, req.KeyID)
+			return nil, errors.New("disk full")
+		}
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, nil, parent)
+
+		// when
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "disk full")
+		assert.Nil(t, captured.SecureBytes())
+	})
+
+	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+
+		// when
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.NoError(t, err)
+	})
+
+	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+
+		// when
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.NoError(t, err)
+	})
+
+	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+
+		// when
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+
+		// then
+		assert.NoError(t, err)
+	})
+}
+
+func TestResolveSecret(t *testing.T) {
+	t.Run("should return nil if cryptor manages its own decryption key", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+
+		// when
+		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
+
+		// then
+		assert.NoError(t, err)
+		assert.Nil(t, sec)
+	})
+
+	t.Run("should return error if key chain is empty", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
+
+		// when
+		_, err := processor.ResolveSecret(t.Context(), []model.Key{})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrEmptyKeyChain)
+	})
+
+	t.Run("should return error if key is not found", func(t *testing.T) {
+		// given
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+
+		// when
+		_, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
+
+		// then
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+	})
+
+	t.Run("should return error if vault export fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, keyID, req.KeyID)
+			return nil, errors.New("connection reset")
+		}
+
+		// when
+		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+
+		// then
+		assert.ErrorContains(t, err, "connection reset")
+	})
+
+	t.Run("should return error if parent unwrap fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentVault := &vaultWrapper{Vault: newTestVault(t)}
+		parentInternal := keyprocessor.NewProcessor("internal", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		var exported *securemem.Data
+		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			resp, err := v.Vault.ExportKey(ctx, req)
+			if err == nil {
+				exported = resp.KeyMaterial
+			}
+			return resp, err
+		}
+		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			return nil, errors.New("parent unavailable")
+		}
+
+		// when
+		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+
+		// then
+		assert.ErrorContains(t, err, "parent unavailable")
+		assert.NotNil(t, exported)
+		assert.Nil(t, exported.SecureBytes())
+	})
+
+	t.Run("should return error if internal unwrap fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		internalVault := &vaultWrapper{Vault: newTestVault(t)}
+		internal := keyprocessor.NewProcessor("internal", internalVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		var exported *securemem.Data
+		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			resp, err := v.Vault.ExportKey(ctx, req)
+			if err == nil {
+				exported = resp.KeyMaterial
+			}
+			return resp, err
+		}
+		internalVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, "internal/"+keyID, req.KeyID)
+			return nil, errors.New("internal export failed")
+		}
+
+		// when
+		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+
+		// then
+		assert.ErrorContains(t, err, "internal export failed")
+		assert.NotNil(t, exported)
+		assert.Nil(t, exported.SecureBytes())
+	})
+
+	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, sec)
+		assert.NotNil(t, sec.SecureBytes())
+	})
+
+	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, sec)
+		assert.NotNil(t, sec.SecureBytes())
+	})
+
+	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, sec)
+		assert.NotNil(t, sec.SecureBytes())
+	})
+}
+
+func TestWrapSecret(t *testing.T) {
+	t.Run("should return error if resolve fails", func(t *testing.T) {
+		// given
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+
+		// when
+		_, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+			Secret:   newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+	})
+
+	t.Run("should return error if encryption fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		var exported *securemem.Data
+		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			resp, err := v.Vault.ExportKey(ctx, req)
+			if err == nil {
+				exported = resp.KeyMaterial
+			}
+			return resp, err
+		}
+
+		// when — nil plaintext is rejected by aes256gcm
+		_, err = processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Secret:   nil,
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, exported.SecureBytes())
+	})
+
+	t.Run("should wrap without resolving if cryptor manages its own decryption key", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+
+		// when
+		chain := []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}}
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: chain,
+			Secret:   newTestData(t, []byte("data")),
+		})
+		assert.NoError(t, err)
+
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      chain,
+			WrappedSecret: wrapResp.WrappedSecret,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("data"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+
+	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		var exported *securemem.Data
+		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			resp, err := v.Vault.ExportKey(ctx, req)
+			if err == nil {
+				exported = resp.KeyMaterial
+			}
+			return resp, err
+		}
+
+		// when
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("payload")),
+			AAD:      []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+		assert.NotNil(t, exported)
+		assert.Nil(t, exported.SecureBytes())
+	})
+
+	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("payload")),
+			AAD:      []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+
+	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("payload")),
+			AAD:      []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+}
+
+func TestUnwrapSecret(t *testing.T) {
+	t.Run("should return error if resolve fails", func(t *testing.T) {
+		// given
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+
+		// when
+		_, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+			WrappedSecret: newTestData(t, []byte("ciphertext")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+	})
+
+	t.Run("should return error if decryption fails with tampered ciphertext", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("data")),
+		})
+		assert.NoError(t, err)
+
+		original := wrapResp.WrappedSecret.SecureBytes()
+		tampered := make([]byte, len(original))
+		copy(tampered, original)
+		tampered[0] ^= 0xFF
+
+		// when
+		_, err = processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			WrappedSecret: newTestData(t, tampered),
+		})
+
+		// then
+		assert.Error(t, err)
+	})
+
+	t.Run("should return error if decryption fails with wrong AAD", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			AAD:      []byte("create-aad"),
+		})
+		assert.NoError(t, err)
+
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("data")),
+			AAD:      []byte("wrap-aad"),
+		})
+		assert.NoError(t, err)
+
+		// when
+		_, err = processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("wrong-aad"),
+		})
+
+		// then
+		assert.Error(t, err)
+	})
+
+	t.Run("should succeed for processor with internal wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("payload")),
+			AAD:      []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		// when
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+
+	t.Run("should succeed for processor with parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("payload")),
+			AAD:      []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		// when
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+
+	t.Run("should succeed for processor with internal and parent wrap", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := newTestVault(t)
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Secret:   newTestData(t, []byte("payload")),
+			AAD:      []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		// when
+		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			WrappedSecret: wrapResp.WrappedSecret,
+			AAD:           []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+}
+
+func TestDeleteSecret(t *testing.T) {
+	t.Run("should not delete if cryptor manages its own decryption key", func(t *testing.T) {
+		// given
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		processor := keyprocessor.NewProcessor("", v, newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+
+		var called bool
+		v.destroyKeyFn = func(context.Context, vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
+			called = true
+			return &vault.DestroyKeyResponse{}, nil
+		}
+
+		// when
+		_, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, called)
+	})
+
+	t.Run("should return error if primary key destroy fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, keyID, req.KeyID)
+			return nil, errors.New("vault locked")
+		}
+
+		// when
+		_, err = processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+			Key: model.Key{TenantID: tenantID, ID: keyID},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "vault locked")
+	})
+
+	t.Run("should return error if internal key destroy fails", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		callCount := 0
+		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
+			callCount++
+			if callCount == 2 {
+				assert.Equal(t, "internal/"+keyID, req.KeyID)
+				return nil, errors.New("internal key stuck")
+			}
+			return v.Vault.DestroyKey(ctx, req)
+		}
+
+		// when
+		_, err = processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+			Key: model.Key{TenantID: tenantID, ID: keyID},
+		})
+
+		// then
+		assert.ErrorContains(t, err, "internal key stuck")
+	})
+
+	t.Run("should succeed for processor without internal", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+		parentID := uuid.NewString()
+
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
+
+		v := &vaultWrapper{Vault: newTestVault(t)}
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
+
+		var destroyedKeys []string
+		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
+			destroyedKeys = append(destroyedKeys, req.KeyID)
+			return v.Vault.DestroyKey(ctx, req)
+		}
+
+		// when
+		_, err = processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
+			Key: model.Key{TenantID: tenantID, ID: keyID},
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []string{keyID}, destroyedKeys)
+	})
+}
+
+func TestHierarchy(t *testing.T) {
+	t.Run("should succeed for two-level chain round trip", func(t *testing.T) {
+		// given
+		parentV := newTestVault(t)
+		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
+		})
+		assert.NoError(t, err)
+
+		child := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		wrapResp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
+			Secret:   newTestData(t, []byte("classified")),
+		})
+		assert.NoError(t, err)
+
+		unwrapResp, err := child.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
+			WrappedSecret: wrapResp.WrappedSecret,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("classified"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+
+	t.Run("should succeed for three-level chain round trip", func(t *testing.T) {
+		// given
+		root := keyprocessor.NewProcessor("", newTestVault(t), newStaticSecretCryptor(t), newTestSecretGen(), nil, nil)
+		_, err := root.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}},
+		})
+		assert.NoError(t, err)
+
+		midV := newTestVault(t)
+		midInternal := keyprocessor.NewProcessor("internal", midV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		mid := keyprocessor.NewProcessor("", midV, newTestCryptor(), newTestSecretGen(), midInternal, root)
+		_, err = mid.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}},
+		})
+		assert.NoError(t, err)
+
+		leaf := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, mid)
+		_, err = leaf.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
+		})
+		assert.NoError(t, err)
+
+		// when
+		wrapResp, err := leaf.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
+			Secret:   newTestData(t, []byte("top secret")),
+		})
+		assert.NoError(t, err)
+
+		unwrapResp, err := leaf.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			KeyChain:      []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
+			WrappedSecret: wrapResp.WrappedSecret,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("top secret"), []byte(unwrapResp.Secret.SecureBytes()))
+	})
+
+	t.Run("should return error if parent vault fails during child resolve", func(t *testing.T) {
+		// given
+		parentVault := &vaultWrapper{Vault: newTestVault(t)}
+		parentInternal := keyprocessor.NewProcessor("internal", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
+		})
+		assert.NoError(t, err)
+
+		child := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, parent)
+		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
+		})
+		assert.NoError(t, err)
+
+		parentVault.exportKeyFn = func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			return nil, errors.New("parent compromised")
+		}
+
+		// when
+		_, err = child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
+			Secret:   newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorContains(t, err, "parent compromised")
+	})
+}
+
+type vaultWrapper struct {
+	vault.Vault
+
+	importKeyFn         func(context.Context, vault.ImportKeyRequest) (*vault.ImportKeyResponse, error)
+	exportKeyFn         func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error)
+	destroyKeyFn        func(context.Context, vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error)
+	destroyKeyVersionFn func(context.Context, vault.DestroyKeyVersionRequest) (*vault.DestroyKeyVersionResponse, error)
+	infoFn              func() vault.Info
+}
+
+func (w *vaultWrapper) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
+	if w.importKeyFn != nil {
+		return w.importKeyFn(ctx, req)
+	}
+	return w.Vault.ImportKey(ctx, req)
+}
+
+func (w *vaultWrapper) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+	if w.exportKeyFn != nil {
+		return w.exportKeyFn(ctx, req)
+	}
+	return w.Vault.ExportKey(ctx, req)
+}
+
+func (w *vaultWrapper) DestroyKey(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
+	if w.destroyKeyFn != nil {
+		return w.destroyKeyFn(ctx, req)
+	}
+	return w.Vault.DestroyKey(ctx, req)
+}
+
+func (w *vaultWrapper) DestroyKeyVersion(ctx context.Context, req vault.DestroyKeyVersionRequest) (*vault.DestroyKeyVersionResponse, error) {
+	if w.destroyKeyVersionFn != nil {
+		return w.destroyKeyVersionFn(ctx, req)
+	}
+	return w.Vault.DestroyKeyVersion(ctx, req)
+}
+
+func (w *vaultWrapper) Info() vault.Info {
+	if w.infoFn != nil {
+		return w.infoFn()
+	}
+	return w.Vault.Info()
+}
+
+type secretGenWrapper struct {
+	generateSecretFn func(context.Context) (*cryptor.GenerateSecretResponse, error)
+}
+
+func (w *secretGenWrapper) GenerateSecret(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
+	return w.generateSecretFn(ctx)
+}
+
+type cryptorWrapper struct {
+	cryptor.Cryptor
+
+	encryptFn func(context.Context, cryptor.EncryptRequest) (*cryptor.EncryptResponse, error)
+	decryptFn func(context.Context, cryptor.DecryptRequest) (*cryptor.DecryptResponse, error)
+	infoFn    func() cryptor.Info
+}
+
+func (w *cryptorWrapper) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+	if w.encryptFn != nil {
+		return w.encryptFn(ctx, req)
+	}
+	return w.Cryptor.Encrypt(ctx, req)
+}
+
+func (w *cryptorWrapper) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
+	if w.decryptFn != nil {
+		return w.decryptFn(ctx, req)
+	}
+	return w.Cryptor.Decrypt(ctx, req)
+}
+
+func (w *cryptorWrapper) Info() cryptor.Info {
+	if w.infoFn != nil {
+		return w.infoFn()
+	}
+	return w.Cryptor.Info()
+}
+
+func newTestVault(t *testing.T) *sqlitevault.Unsafe {
+	t.Helper()
+	v, err := sqlitevault.NewUnsafe(t.Context(), "test", sqlitevault.MemorySource)
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = v.Close() })
+	return v
+}
+
+func newTestCryptor() *aes256gcm.AES256GCM {
+	return aes256gcm.New("test")
+}
+
+func newTestSecretGen() *cryptor.AES256SecretGenerator {
+	return cryptor.NewAES256SecretGenerator()
+}
+
+func newStaticSecretCryptor(t *testing.T) *staticsecret.StaticSecret {
+	t.Helper()
+	key, err := securemem.NewData("static-key", 32)
+	assert.NoError(t, err)
+	_, err = rand.Read(key.SecureBytes())
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = key.Destroy() })
+	c, err := staticsecret.New("test-static", key)
+	assert.NoError(t, err)
+	return c
+}
+
+func newTestData(t *testing.T, content []byte) *securemem.Data {
+	t.Helper()
+	d, err := securemem.NewData("test", len(content))
+	assert.NoError(t, err)
+	copy(d.SecureBytes(), content)
+	return d
+}

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -63,42 +63,6 @@ func TestCreateSecret(t *testing.T) {
 		assert.ErrorIs(t, err, genErr)
 	})
 
-	t.Run("should return error if internal secret creation fails", func(t *testing.T) {
-		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-
-		var captured *securemem.Data
-		realGen := newTestSecretGen()
-		gen := &secretGenWrapper{
-			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-				resp, err := realGen.GenerateSecret(ctx)
-				if err == nil {
-					captured = resp.Secret
-				}
-				return resp, err
-			},
-		}
-
-		internalGen := &secretGenWrapper{
-			generateSecretFn: func(ctx context.Context) (*cryptor.GenerateSecretResponse, error) {
-				return nil, errors.New("internal gen failed")
-			},
-		}
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), internalGen, nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, internal, nil)
-
-		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-
-		// then
-		assert.ErrorContains(t, err, "internal gen failed")
-		assert.Nil(t, captured.SecureBytes())
-	})
-
 	t.Run("should return error if internal wrap fails", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
@@ -156,6 +120,7 @@ func TestCreateSecret(t *testing.T) {
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
 		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, parentID, req.KeyID)
 			return nil, errors.New("parent vault down")
 		}
 		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
@@ -208,10 +173,14 @@ func TestCreateSecret(t *testing.T) {
 		}
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, internalCryptor, newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), gen, internal, parent)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 
@@ -242,8 +211,12 @@ func TestCreateSecret(t *testing.T) {
 
 		parentV := newTestVault(t)
 		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := parentInternal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
+		})
+		assert.NoError(t, err)
 		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
 		assert.NoError(t, err)
@@ -273,10 +246,14 @@ func TestCreateSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
 
 		// when
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 
@@ -290,9 +267,7 @@ func TestCreateSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -315,9 +290,7 @@ func TestCreateSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -325,6 +298,10 @@ func TestCreateSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
 
 		// when
@@ -380,18 +357,16 @@ func TestResolveSecret(t *testing.T) {
 		keyID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-
 		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, keyID, req.KeyID)
 			return nil, errors.New("connection reset")
 		}
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 
 		// when
 		_, err = processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
@@ -407,8 +382,7 @@ func TestResolveSecret(t *testing.T) {
 		parentID := uuid.NewString()
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentInternal := keyprocessor.NewProcessor("internal", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -431,6 +405,7 @@ func TestResolveSecret(t *testing.T) {
 		}
 		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, parentID, req.KeyID)
 			return nil, errors.New("parent unavailable")
 		}
 
@@ -450,10 +425,13 @@ func TestResolveSecret(t *testing.T) {
 
 		internalVault := &vaultWrapper{Vault: newTestVault(t)}
 		internal := keyprocessor.NewProcessor("internal", internalVault, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -488,8 +466,12 @@ func TestResolveSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -509,9 +491,7 @@ func TestResolveSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -538,9 +518,7 @@ func TestResolveSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -548,6 +526,10 @@ func TestResolveSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
@@ -588,8 +570,12 @@ func TestWrapSecret(t *testing.T) {
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -643,8 +629,12 @@ func TestWrapSecret(t *testing.T) {
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -685,9 +675,7 @@ func TestWrapSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -724,9 +712,7 @@ func TestWrapSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -734,6 +720,10 @@ func TestWrapSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
@@ -763,9 +753,7 @@ func TestWrapSecret(t *testing.T) {
 func TestUnwrapSecret(t *testing.T) {
 	t.Run("should return error if resolve fails", func(t *testing.T) {
 		// given
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 
 		// when
 		_, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
@@ -782,9 +770,7 @@ func TestUnwrapSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
@@ -816,9 +802,7 @@ func TestUnwrapSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
-		v := newTestVault(t)
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 			AAD:      []byte("create-aad"),
@@ -850,8 +834,12 @@ func TestUnwrapSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
@@ -881,9 +869,7 @@ func TestUnwrapSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -920,9 +906,7 @@ func TestUnwrapSecret(t *testing.T) {
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", newTestVault(t), newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
 		})
@@ -930,6 +914,10 @@ func TestUnwrapSecret(t *testing.T) {
 
 		v := newTestVault(t)
 		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err = internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+		})
+		assert.NoError(t, err)
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, parent)
 		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
@@ -978,14 +966,13 @@ func TestDeleteSecret(t *testing.T) {
 		assert.False(t, called)
 	})
 
-	t.Run("should return error if primary key destroy fails", func(t *testing.T) {
+	t.Run("should return error if key destroy fails", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
@@ -1006,62 +993,22 @@ func TestDeleteSecret(t *testing.T) {
 		assert.ErrorContains(t, err, "vault locked")
 	})
 
-	t.Run("should return error if internal key destroy fails", func(t *testing.T) {
-		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-
-		v := &vaultWrapper{Vault: newTestVault(t)}
-		internal := keyprocessor.NewProcessor("internal", v, newTestCryptor(), newTestSecretGen(), nil, nil)
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
-		assert.NoError(t, err)
-
-		callCount := 0
-		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
-			callCount++
-			if callCount == 2 {
-				assert.Equal(t, "internal/"+keyID, req.KeyID)
-				return nil, errors.New("internal key stuck")
-			}
-			return v.Vault.DestroyKey(ctx, req)
-		}
-
-		// when
-		_, err = processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
-			Key: model.Key{TenantID: tenantID, ID: keyID},
-		})
-
-		// then
-		assert.ErrorContains(t, err, "internal key stuck")
-	})
-
-	t.Run("should succeed for processor without internal", func(t *testing.T) {
+	t.Run("should succeed", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentID := uuid.NewString()
 
-		parentV := newTestVault(t)
-		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
-		assert.NoError(t, err)
-
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
 		})
 		assert.NoError(t, err)
 
-		var destroyedKeys []string
 		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
-			destroyedKeys = append(destroyedKeys, req.KeyID)
+			assert.Equal(t, tenantID, req.TenantID)
+			assert.Equal(t, keyID, req.KeyID)
 			return v.Vault.DestroyKey(ctx, req)
 		}
 
@@ -1072,7 +1019,6 @@ func TestDeleteSecret(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, []string{keyID}, destroyedKeys)
 	})
 }
 
@@ -1081,8 +1027,12 @@ func TestHierarchy(t *testing.T) {
 		// given
 		parentV := newTestVault(t)
 		parentInternal := keyprocessor.NewProcessor("internal", parentV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err := parentInternal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
+		})
+		assert.NoError(t, err)
 		parent := keyprocessor.NewProcessor("", parentV, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+		_, err = parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
 		})
 		assert.NoError(t, err)
@@ -1120,6 +1070,10 @@ func TestHierarchy(t *testing.T) {
 
 		midV := newTestVault(t)
 		midInternal := keyprocessor.NewProcessor("internal", midV, newTestCryptor(), newTestSecretGen(), nil, nil)
+		_, err = midInternal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			KeyChain: []model.Key{{TenantID: "t1", ID: "mid-1"}},
+		})
+		assert.NoError(t, err)
 		mid := keyprocessor.NewProcessor("", midV, newTestCryptor(), newTestSecretGen(), midInternal, root)
 		_, err = mid.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}},
@@ -1152,8 +1106,7 @@ func TestHierarchy(t *testing.T) {
 	t.Run("should return error if parent vault fails during child resolve", func(t *testing.T) {
 		// given
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentInternal := keyprocessor.NewProcessor("internal", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
-		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), parentInternal, nil)
+		parent := keyprocessor.NewProcessor("", parentVault, newTestCryptor(), newTestSecretGen(), nil, nil)
 		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
 		})

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -442,6 +442,7 @@ func TestResolveSecret(t *testing.T) {
 		_, err := internal.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
 			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
 		})
+		assert.NoError(t, err)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor("", v, newTestCryptor(), newTestSecretGen(), internal, nil)


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add key processor

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Adds `keyprocessor.Processor` which manages secret lifecycle (create, wrap, unwrap, delete) within a composable key hierarchy, handling layered encryption/decryption and secure memory cleanup.
