### PR TITLE
feat: add  CLI command to retrieve a single key by tenant and key ID

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -12,6 +12,7 @@ func getCmd() *cobra.Command {
 
 	cmd.AddCommand(getTenantCmd())
 	cmd.AddCommand(getTenantsCmd())
+	cmd.AddCommand(getKeyCmd())
 	cmd.AddCommand(getKeyParentsCmd())
 	cmd.AddCommand(getKeyDescendantsCmd())
 	cmd.AddCommand(getKeysCmd())

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/openkcm/krypton/cli/output"
+	"github.com/openkcm/krypton/internal/clock"
 	"github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
 	"github.com/openkcm/krypton/pkg/model"
 )
@@ -17,6 +18,20 @@ import (
 type keyRows struct {
 	Keys   []keyRow
 	Cursor string
+}
+
+type key struct {
+	ID                 string
+	Name               string
+	TenantID           string
+	Kind               model.KeyKind
+	ParentID           *string
+	ManagedBy          string
+	Labels             model.Labels
+	LifeCycleState     model.KeyLifeCycleState
+	KeyProcessingState model.KeyProcessingState
+	CreatedAt          clock.UnixNano
+	UpdatedAt          clock.UnixNano
 }
 
 type keyRow struct {
@@ -41,6 +56,80 @@ func newKeyRow(k *keys.Key) keyRow {
 		ManagedBy:      k.GetManagedBy(),
 		Status:         model.KeyProcessingStatus(k.GetKeyProcessingState().GetStatus()),
 	}
+}
+
+func newKey(k *keys.Key) key {
+	mk := keys.KeyFromProto(k)
+	return key{
+		ID:                 mk.ID,
+		Name:               mk.Name,
+		TenantID:           mk.TenantID,
+		Kind:               mk.Kind,
+		ParentID:           mk.ParentID,
+		ManagedBy:          mk.ManagedBy,
+		Labels:             mk.Labels,
+		LifeCycleState:     mk.LifeCycleState,
+		KeyProcessingState: mk.KeyProcessingState,
+		CreatedAt:          mk.CreatedAt,
+		UpdatedAt:          mk.UpdatedAt,
+	}
+}
+
+func getKeyCmd() *cobra.Command {
+	var keyID, tenantID string
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "key",
+		Short: "Get a single key by its tenant ID and key ID",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if tenantID == "" {
+				tID, err := selectedTenantID()
+				if err != nil {
+					return fmt.Errorf("failed to get selected tenant: %w", err)
+				}
+				tenantID = tID
+			}
+
+			// TODO: insecure.NewCredentials is a temporary workaround until TLS is configured
+			conn, err := grpc.NewClient(
+				serverAddr,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to connect: %w", err)
+			}
+			defer conn.Close()
+
+			client := keys.NewKeyServiceClient(conn)
+
+			resp, err := client.GetKey(cmd.Context(), &keys.GetKeyRequest{
+				Id:       keyID,
+				TenantId: tenantID,
+			})
+			if err != nil {
+				if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+					return fmt.Errorf("key for tenant:[%s] and key:[%s] not found", tenantID, keyID)
+				}
+				return fmt.Errorf("failed to get key: %w", err)
+			}
+
+			builder, err := output.From(newKey(resp.GetKey()))
+			if err != nil {
+				return fmt.Errorf("failed to format output: %w", err)
+			}
+
+			return formatOutput(builder, asJSON).To(cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVar(&keyID, "key-id", "", "id of the key")
+	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "id of the tenant")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output in JSON format")
+	_ = cmd.MarkFlagRequired("key-id")
+
+	return cmd
 }
 
 func getKeyParentsCmd() *cobra.Command {

--- a/integration/key_test.go
+++ b/integration/key_test.go
@@ -39,7 +39,6 @@ func TestGetKeys(t *testing.T) {
 	})
 
 	// create tenant
-	// `kr create tenant --name <name> --json --server <server-addr>`
 	expTenantName := "tenant-" + uuid.NewString()
 	cmd := newCLICommand(
 		t.Context(),
@@ -61,6 +60,140 @@ func TestGetKeys(t *testing.T) {
 
 	// create hierarchy
 	hierarchy := createKeyHierarchy(t, keyStore, tenantID)
+
+	t.Run("key", func(t *testing.T) {
+		t.Run("should get key for tenant and a key ID", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"key",
+				"--tenant-id", tenantID,
+				"--key-id", hierarchy.e.ID,
+				"--json",
+				"--server", serverAddr)
+
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeys := decodeKeys(t, output)
+			require.Len(t, actKeys, 1)
+			assert.Equal(t, hierarchy.e.Name, actKeys[0].Name)
+			assert.Equal(t, tenantID, actKeys[0].TenantID)
+			assert.Equal(t, hierarchy.e.Kind, actKeys[0].Kind)
+			assert.Equal(t, hierarchy.e.ParentID, actKeys[0].ParentID)
+			assert.Equal(t, "agent-azure", actKeys[0].ManagedBy)
+			assert.Nil(t, actKeys[0].Labels)
+			assert.Equal(t, model.KeyLifeCycleActive, actKeys[0].LifeCycleState)
+			assert.Equal(t, model.KeyProcessingPending, actKeys[0].KeyProcessingState.Status)
+			assert.Empty(t, actKeys[0].KeyProcessingState.JobID)
+			assert.NotEmpty(t, actKeys[0].UpdatedAt)
+			assert.NotEmpty(t, actKeys[0].CreatedAt)
+		})
+
+		t.Run("should fail if key does not exist", func(t *testing.T) {
+			// when
+			unknownKeyID := uuid.NewString()
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"key",
+				"--tenant-id", tenantID,
+				"--key-id", unknownKeyID,
+				"--json",
+				"--server", serverAddr)
+
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.Error(t, err, "command should fail, output: %s", string(output))
+			assert.Contains(t, string(output), "not found")
+		})
+
+		t.Run("should fail if key ID parameter is not provided", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"key",
+				"--tenant-id", tenantID,
+				"--json",
+				"--server", serverAddr)
+
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.Error(t, err, "command should fail, output: %s", string(output))
+			assert.Contains(t, string(output), "required flag(s) \"key-id\" not set")
+		})
+
+		t.Run("should fail if tenant does not exist", func(t *testing.T) {
+			// when
+			unknownTenantID := uuid.NewString()
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"key",
+				"--tenant-id", unknownTenantID,
+				"--key-id", hierarchy.e.ID,
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.Error(t, err)
+			assert.Contains(t, string(output), "not found")
+		})
+
+		t.Run("should fall back to selected tenant when tenant-id is not provided", func(t *testing.T) {
+			//given
+			// create selected tenant in store to test fetching tenant id from store when not provided as parameter
+			tmpDir := t.TempDir()
+			seedSelectedTenant(t, tmpDir, tenantID, expTenantName)
+
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				tmpDir,
+				"get",
+				"key",
+				"--key-id", hierarchy.h.ID,
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.NoError(t, err, "command should succeed, output: %s", string(output))
+
+			actKeys := decodeKeys(t, output)
+			require.Len(t, actKeys, 1)
+			assert.Equal(t, hierarchy.h.Name, actKeys[0].Name)
+			assert.Equal(t, tenantID, actKeys[0].TenantID)
+		})
+
+		t.Run("should fail if tenant id parameter is not provided", func(t *testing.T) {
+			// when
+			cmd = newCLICommand(
+				t.Context(),
+				t.TempDir(),
+				"get",
+				"key",
+				"--key-id", hierarchy.e.ID,
+				"--json",
+				"--server", serverAddr)
+			output, err = cmd.CombinedOutput()
+
+			// then
+			assert.Error(t, err)
+			assert.Contains(t, string(output), "no tenant selected")
+		})
+	})
 
 	t.Run("parent-keys", func(t *testing.T) {
 		t.Run("should get all parent keys", func(t *testing.T) {
@@ -731,6 +864,20 @@ func TestGetKeys(t *testing.T) {
 	})
 }
 
+type key struct {
+	ID                 string
+	Name               string
+	TenantID           string
+	Kind               model.KeyKind
+	ParentID           *string
+	ManagedBy          string
+	Labels             model.Labels
+	LifeCycleState     model.KeyLifeCycleState
+	KeyProcessingState model.KeyProcessingState
+	CreatedAt          string
+	UpdatedAt          string
+}
+
 type keyRow struct {
 	Kind           model.KeyKind
 	ID             string
@@ -828,6 +975,16 @@ func createKeyHierarchy(t *testing.T, keyStore store.Key, tenantID string) keyHi
 func decodeKeyRow(t *testing.T, output []byte) []keyRow {
 	t.Helper()
 	var ts []keyRow
+	err := json.Unmarshal(output, &ts)
+	if err != nil {
+		assert.FailNowf(t, "failed to decode response", "output: %s, error: %v", string(output), err)
+	}
+	return ts
+}
+
+func decodeKeys(t *testing.T, output []byte) []key {
+	t.Helper()
+	var ts []key
 	err := json.Unmarshal(output, &ts)
 	if err != nil {
 		assert.FailNowf(t, "failed to decode response", "output: %s, error: %v", string(output), err)


### PR DESCRIPTION
Adds a new get key subcommand that fetches a single key's full details (including timestamps, labels, processing state) given a tenant ID and key ID. Falls back to the selected tenant when --tenant-id is not provided. Outputs in tabular or JSON format.

| ID | Name | TenantID | Kind | ParentID | ManagedBy | Labels | LifeCycleState | KeyProcessingState | CreatedAt | UpdatedAt |
|---|---|---|---|---|---|---|---|---|---|---|
| b3645297-b9ad-464a-9b0d-cd8d8d8ef9f9 | B | 92f3e815-c6b1-4a62-bd7d-8205fd723866 | K1 | 0x6e51b7952340 | root | | pre-activation | {pending } | 2026-06-30T15:21:16+02:00 | 2026-06-30T15:21:16+02:00 |

**Please note** here the `KeyProcessingState` output is `{pending}` but if we have jobId in the future it might be something like this `{pending b3645297-b9ad-464a-9b0d-cd8d8d8ef123}`do we want to print it like this any suggestions are welcome.
