### PR TITLE
feat: add cleanup for data

### DIFF
--- a/internal/securemem/data.go
+++ b/internal/securemem/data.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"sync"
 )
 
@@ -26,6 +27,12 @@ type Data struct {
 	data       SecureBytes
 	isReadOnly bool
 	mux        sync.RWMutex
+	cleanup    runtime.Cleanup
+}
+
+type dataCleanupRef struct {
+	name string
+	data SecureBytes
 }
 
 var (
@@ -65,10 +72,21 @@ func NewData(name string, size int) (*Data, error) {
 		return nil, err
 	}
 
-	return &Data{
+	d := &Data{
 		name: name,
 		data: b,
-	}, nil
+	}
+
+	d.cleanup = runtime.AddCleanup(d, func(m *dataCleanupRef) {
+		slog.Debug("securemem: cleanup started")
+		err := m.Destroy()
+		if err != nil {
+			slog.Error("securemem: failed to destroy secure memory region", "error", err)
+		}
+		slog.Debug("securemem: cleanup finished")
+	}, &dataCleanupRef{name: d.name, data: d.data})
+
+	return d, nil
 }
 
 // SecureBytes returns the underlying byte slice of the secure memory region. If the
@@ -93,13 +111,17 @@ func (m *Data) Destroy() error {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
+	slog.Debug("securemem: destroy started", "name", m.name)
+
 	if m.data == nil {
+		slog.Debug("securemem: destroy skipped, already destroyed", "name", m.name)
 		return nil
 	}
 
 	if m.isReadOnly {
 		err := readwrite(m.data)
 		if err != nil {
+			slog.Error("securemem: destroy marking readwrite failed", "name", m.name, "error", err)
 			return err
 		}
 		m.isReadOnly = false
@@ -107,9 +129,17 @@ func (m *Data) Destroy() error {
 
 	defer func() {
 		m.data = nil
+		m.cleanup.Stop()
 	}()
 
-	return unalloc(m.data)
+	err := unalloc(m.data)
+	if err != nil {
+		slog.Error("securemem: destroy failed", "name", m.name, "error", err)
+	} else {
+		slog.Debug("securemem: destroy finished", "name", m.name)
+	}
+
+	return err
 }
 
 // MarkReadOnly sets the memory protection of the underlying buffer to read-only,
@@ -196,4 +226,14 @@ func (s SecureBytes) MarshalText() (text []byte, err error) {
 // MarshalJSON implements [json.Marshaler].
 func (s SecureBytes) MarshalJSON() ([]byte, error) {
 	return json.Marshal(Redacted)
+}
+
+// Destroy securely wipes and unmaps the memory region referenced by this cleanup ref.
+// It creates a temporary Data with isReadOnly=true so that Destroy() always calls
+// readwrite() (mprotect) first — this acts as a safe guard that returns ENOMEM if the
+// memory was already unmapped by a prior Destroy() call, preventing Zero() from writing
+// to invalid memory (which would SIGSEGV).
+func (m *dataCleanupRef) Destroy() error {
+	data := &Data{data: m.data, isReadOnly: true, name: m.name}
+	return data.Destroy()
 }

--- a/internal/securemem/data_test.go
+++ b/internal/securemem/data_test.go
@@ -456,6 +456,11 @@ func TestSubSlicingRetainstheUnderlyingdatastructure(t *testing.T) {
 		data, err := securemem.NewData("test-data", 10)
 		require.NoError(t, err)
 
+		t.Cleanup(func() {
+			err := data.Destroy()
+			assert.NoError(t, err)
+		})
+
 		dataByteA := data.SecureBytes()
 		for i := range dataByteA {
 			dataByteA[i] = byte(i)
@@ -504,5 +509,64 @@ func TestSubSlicingRetainstheUnderlyingdatastructure(t *testing.T) {
 		assert.True(t, sameUnderLying(dataByteA[2:][:3], dataByteA))
 		assert.True(t, sameUnderLying(dataByteA[2:5], dataByteA))
 		assert.True(t, sameUnderLying(dataByteA[2:5][:1], dataByteA))
+	})
+}
+
+func TestDataCleanup(t *testing.T) {
+	t.Run("should destroy data if cleanupref destroy is executed", func(t *testing.T) {
+		// given
+		subj, err := securemem.NewData("test-cleanup", 1)
+		require.NoError(t, err)
+
+		// ref captures a copy of the slice header (pointer+len+cap) pointing to
+		// the same mmap'd memory as subj.data. It does NOT hold a *Data reference.
+		ref := securemem.NewDataCleanupRef(subj.Name(), subj.SecureBytes())
+
+		// ref.Destroy() creates a temporary Data{isReadOnly: true}, which triggers:
+		//   1. readwrite() — mprotect(RW) succeeds (memory still mapped)
+		//   2. unalloc()   — Zero() + Munlock() + Munmap()
+		// After this, the underlying page is unmapped from the process address space.
+		// However, subj.data still holds the old (now-dangling) slice header because
+		// ref has no way to set subj.data = nil.
+		err = ref.Destroy()
+		require.NoError(t, err)
+
+		// when
+		// We cannot safely dereference subj.SecureBytes()[0] — that would SIGSEGV
+		// because the page is munmapped. Instead, we use MarkReadOnly() which calls
+		// mprotect() — a syscall that safely returns ENOMEM on unmapped addresses
+		// rather than crashing. This proves the memory was successfully destroyed.
+		err = subj.MarkReadOnly()
+
+		// then
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "cannot allocate memory")
+	})
+
+	t.Run("should fail if cleanup ref destroys already-unmapped memory", func(t *testing.T) {
+		// given
+		subj, err := securemem.NewData("test-cleanup", 1)
+		require.NoError(t, err)
+
+		// ref captures the slice header before subj is destroyed.
+		ref := securemem.NewDataCleanupRef(subj.Name(), subj.SecureBytes())
+
+		// subj.Destroy() properly zeroes + munmaps the memory AND sets subj.data = nil.
+		err = subj.Destroy()
+		assert.NoError(t, err)
+		assert.Nil(t, subj.SecureBytes())
+
+		// when
+		// ref.Destroy() still holds the old (now-invalid) slice header. It creates a
+		// temporary Data{isReadOnly: true} and calls Destroy() on it. Because
+		// isReadOnly=true, it first calls readwrite() (mprotect RW) as a safety
+		// canary. Since the page is already munmapped, mprotect returns ENOMEM —
+		// this prevents unalloc()/Zero() from writing to unmapped memory (which
+		// would SIGSEGV).
+		err = ref.Destroy()
+
+		// then
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "cannot allocate memory")
 	})
 }

--- a/internal/securemem/export_test.go
+++ b/internal/securemem/export_test.go
@@ -1,3 +1,7 @@
 package securemem
 
 var NewHandlerRequest = newHandlerRequest
+
+func NewDataCleanupRef(name string, data SecureBytes) *dataCleanupRef {
+	return &dataCleanupRef{name: name, data: data}
+}

--- a/internal/securemem/test/cleanup/cleanup_test.go
+++ b/internal/securemem/test/cleanup/cleanup_test.go
@@ -1,0 +1,59 @@
+package main_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDestroyCleanup verifies that explicit Destroy() prevents the GC cleanup
+// from firing (cleanup.Stop() deregisters it). Runs in a subprocess because
+// SIGSEGV from double-destroy cannot be caught by recover().
+func TestDestroyCleanup(t *testing.T) {
+	// given
+	cmd := exec.CommandContext(t.Context(), "go", "run", "main.go", "destroy-cleanup")
+
+	// when
+	out, err := cmd.CombinedOutput()
+
+	// then
+	assert.NoError(t, err)
+	outStr := string(out)
+
+	assert.Contains(t, outStr, "start destroy-cleanup")
+	// GC cleanup must NOT fire — Destroy() already called cleanup.Stop()
+	assert.NotContains(t, outStr, "securemem: cleanup started")
+	assert.NotContains(t, outStr, "securemem: failed to destroy secure memory region")
+	assert.NotContains(t, outStr, "securemem: cleanup finished")
+	// Explicit Destroy() ran successfully
+	assert.Contains(t, outStr, "securemem: destroy started")
+	assert.Contains(t, outStr, "securemem: destroy finished")
+	assert.Contains(t, outStr, "finish destroy-cleanup")
+	assert.NotContains(t, outStr, "PANIC RECOVERED")
+}
+
+// TestCleanupOnly verifies that without explicit Destroy(), the GC cleanup
+// fires and securely destroys the memory. Runs in a subprocess because
+// runtime.AddCleanup requires the object to be truly unreachable.
+func TestCleanupOnly(t *testing.T) {
+	// given
+	cmd := exec.CommandContext(t.Context(), "go", "run", "main.go", "cleanup-only")
+
+	// when
+	out, err := cmd.CombinedOutput()
+
+	// then
+	assert.NoError(t, err)
+	outStr := string(out)
+
+	assert.Contains(t, outStr, "start cleanup-only")
+	// GC cleanup MUST fire — no explicit Destroy() was called
+	assert.Contains(t, outStr, "securemem: cleanup started")
+	assert.NotContains(t, outStr, "securemem: failed to destroy secure memory region")
+	assert.Contains(t, outStr, "securemem: destroy started")
+	assert.Contains(t, outStr, "securemem: destroy finished")
+	assert.Contains(t, outStr, "securemem: cleanup finished")
+	assert.Contains(t, outStr, "finish cleanup-only")
+	assert.NotContains(t, outStr, "PANIC RECOVERED")
+}

--- a/internal/securemem/test/cleanup/main.go
+++ b/internal/securemem/test/cleanup/main.go
@@ -1,0 +1,100 @@
+// Test helper binary for cleanup_test.go. Runs as a subprocess because
+// runtime.AddCleanup requires true unreachability, and accessing munmapped
+// memory causes fatal SIGSEGV that recover() cannot catch.
+package main
+
+import (
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("PANIC RECOVERED:", "recover", r)
+		}
+	}()
+
+	tc := os.Args[1]
+
+	switch tc {
+	case "cleanup-only":
+		cleanupOnly()
+	case "destroy-cleanup":
+		destroyCleanupOnly()
+	}
+}
+
+// destroyCleanupOnly verifies that explicit Destroy() prevents the GC cleanup
+// from firing. Destroy() calls cleanup.Stop(), so no cleanup logs should appear.
+func destroyCleanupOnly() {
+	slog.Info("start destroy-cleanup")
+
+	// Allocate in a separate function so the *Data is guaranteed off the stack
+	// when it returns — making it truly unreachable for GC.
+	allocateAndDestroy()
+
+	awaitGC()
+
+	slog.Info("finish destroy-cleanup")
+}
+
+// cleanupOnly verifies that without explicit Destroy(), the GC cleanup fires
+// and securely destroys the memory via dataCleanupRef.Destroy().
+func cleanupOnly() {
+	slog.Info("start cleanup-only")
+
+	// Allocate in a separate function so the *Data is guaranteed off the stack
+	// when it returns — making it truly unreachable for GC.
+	allocateData()
+
+	awaitGC()
+
+	slog.Info("finish cleanup-only")
+}
+
+// allocateAndDestroy creates a *Data, calls Destroy() twice (proving idempotency),
+// and drops the reference. Once this returns, the *Data is off the stack and eligible
+// for GC — but cleanup.Stop() was already called, so no cleanup callback should fire.
+func allocateAndDestroy() {
+	subj, err := securemem.NewData("destroy-cleanup", 3)
+	if err != nil {
+		panic(err)
+	}
+
+	// First Destroy: zeroes + munmaps, sets data=nil, calls cleanup.Stop()
+	err = subj.Destroy()
+	if err != nil {
+		panic(err)
+	}
+
+	// Second Destroy: idempotent (data is nil)
+	err = subj.Destroy()
+	if err != nil {
+		panic(err)
+	}
+}
+
+// allocateData creates a *Data without holding a reference in the caller's frame.
+// Once this function returns, the *Data is unreachable and eligible for GC collection.
+func allocateData() {
+	_, err := securemem.NewData("cleanup-only", 3)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// awaitGC forces garbage collection and waits for async cleanup callbacks to execute.
+// runtime.GC() is synchronous (completes the collection), but cleanup callbacks run
+// on a background goroutine — the sleep gives that goroutine time to execute.
+func awaitGC() {
+	runtime.GC()
+	time.Sleep(1 * time.Second)
+}


### PR DESCRIPTION
Description
Add a runtime.AddCleanup safety net to securemem.Data that automatically destroys mmap'd memory regions when the GC collects an unreachable *Data instance — preventing memory leaks if a caller forgets to call Destroy().
Key design points:
- A dataCleanupRef struct captures only the slice header and name (not *Data), so it doesn't prevent GC collection of the parent object.
- The cleanup callback sets isReadOnly: true on a temporary Data, forcing Destroy() to call readwrite() (mprotect) first. This safely returns ENOMEM on already-unmapped memory instead of SIGSEGV from writing to invalid addresses.
- Explicit Destroy() calls cleanup.Stop() to deregister the callback, preventing double-destroy.
- Adds structured logging to the destroy lifecycle for observability.
- Subprocess-based integration tests verify both paths: cleanup fires when Destroy() is not called, and cleanup is suppressed when Destroy() is called explicitly.