### PR TITLE
feat: add key processor manager

### DIFF
--- a/internal/keyprocessor/export_test.go
+++ b/internal/keyprocessor/export_test.go
@@ -7,18 +7,23 @@ import (
 	"github.com/openkcm/krypton/internal/securemem"
 	"github.com/openkcm/krypton/internal/vault"
 	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
 )
 
-func NewProcessor(generator cryptor.SecretGenerator, wrapper, sealer cryptor.Cryptor, v vault.Vault, parent *Processor) *Processor {
+func NewProcessor(generator cryptor.SecretGenerator, wrapper, transportSealer, parent cryptor.Cryptor, v vault.Vault) *Processor {
 	return &Processor{
-		generator: generator,
-		wrapper:   wrapper,
-		sealer:    sealer,
-		vault:     v,
-		parent:    parent,
+		generator:       generator,
+		wrapper:         wrapper,
+		transportSealer: transportSealer,
+		parent:          parent,
+		vault:           v,
 	}
 }
 
-func (p *Processor) ResolveSecret(ctx context.Context, keyChain []model.Key) (*securemem.Data, error) {
-	return p.resolveSecret(ctx, keyChain)
+func NewManager(s store.Key, processors map[model.KeyKind]Processor) *Manager {
+	return &Manager{store: s, processors: processors}
+}
+
+func (p *Processor) ResolveSecret(ctx context.Context, key model.Key) (*securemem.Data, error) {
+	return p.resolveSecret(ctx, key)
 }

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -1,0 +1,85 @@
+package keyprocessor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+)
+
+// ErrProcessorNotFound is returned when no processor is registered for a key's kind.
+var ErrProcessorNotFound = errors.New("key processor could not be found")
+
+// TypeManager identifies the Manager cryptor type.
+const TypeManager cryptor.Type = "manager"
+
+// Manager encrypts and decrypts secrets by looking up the key and delegating
+// to the Processor registered for that key's kind.
+type Manager struct {
+	store      store.Key
+	processors map[model.KeyKind]Processor
+}
+
+var _ cryptor.Cryptor = &Manager{}
+
+// Encrypt looks up the key and delegates to the matching processor.
+func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	proc, ok := km.processors[key.Kind]
+	if !ok {
+		return nil, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
+	}
+
+	resp, err := proc.WrapSecret(ctx, WrapSecretRequest{
+		Key:    *key,
+		Secret: req.Plaintext,
+		AAD:    req.AAD,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &cryptor.EncryptResponse{
+		Ciphertext: resp.WrappedSecret,
+	}, nil
+}
+
+// Decrypt looks up the key and delegates to the matching processor.
+func (km *Manager) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
+	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	proc, ok := km.processors[key.Kind]
+	if !ok {
+		return nil, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
+	}
+
+	resp, err := proc.UnwrapSecret(ctx, UnwrapSecretRequest{
+		Key:           *key,
+		WrappedSecret: req.Ciphertext,
+		AAD:           req.AAD,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &cryptor.DecryptResponse{
+		Plaintext: resp.Secret,
+	}, nil
+}
+
+// Info returns the Manager's cryptor metadata.
+func (km *Manager) Info() cryptor.Info {
+	return cryptor.Info{
+		Name:                     "keyprocessor-manager",
+		Type:                     TypeManager,
+		DecryptionSecretRequired: true,
+	}
+}

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -1,0 +1,226 @@
+package keyprocessor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/keyprocessor"
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+	storesql "github.com/openkcm/krypton/pkg/store/sql"
+)
+
+func TestManagerEncrypt(t *testing.T) {
+	t.Run("should return error if store lookup fails", func(t *testing.T) {
+		// given
+		storeErr := errors.New("database unavailable")
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
+			assert.Equal(t, keyID, id)
+			assert.Equal(t, tenantID, tid)
+			return nil, storeErr
+		}
+		c := keyprocessor.NewManager(ks, nil)
+
+		// when
+		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+			TenantID:  tenantID,
+			KeyID:     keyID,
+			Plaintext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, storeErr)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should return error if processor not found for key kind", func(t *testing.T) {
+		// given
+		key := &model.Key{
+			ID:       uuid.NewString(),
+			TenantID: uuid.NewString(),
+			Kind:     "UNKNOWN_KIND",
+		}
+
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
+			assert.Equal(t, key.ID, id)
+			assert.Equal(t, key.TenantID, tid)
+			return key, nil
+		}
+		c := keyprocessor.NewManager(ks, map[model.KeyKind]keyprocessor.Processor{})
+
+		// when
+		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+			TenantID:  key.TenantID,
+			KeyID:     key.ID,
+			Plaintext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrProcessorNotFound)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should succeed", func(t *testing.T) {
+		// given
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		key := model.NewKey(tenantID, "enc-key-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+
+		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		assert.NoError(t, err)
+
+		c := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
+
+		// when
+		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+			TenantID:  tenantID,
+			KeyID:     key.ID,
+			Plaintext: newTestData(t, []byte("secret payload")),
+			AAD:       []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.Ciphertext)
+		assert.NotEmpty(t, resp.Ciphertext.SecureBytes())
+	})
+}
+
+func TestManagerDecrypt(t *testing.T) {
+	t.Run("should return error if store lookup fails", func(t *testing.T) {
+		// given
+		storeErr := errors.New("database unavailable")
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
+			assert.Equal(t, keyID, id)
+			assert.Equal(t, tenantID, tid)
+			return nil, storeErr
+		}
+		c := keyprocessor.NewManager(ks, nil)
+
+		// when
+		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+			TenantID:   tenantID,
+			KeyID:      keyID,
+			Ciphertext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, storeErr)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should return error if processor not found for key kind", func(t *testing.T) {
+		// given
+		key := &model.Key{
+			ID:       uuid.NewString(),
+			TenantID: uuid.NewString(),
+			Kind:     "UNKNOWN_KIND",
+		}
+
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
+			assert.Equal(t, key.ID, id)
+			assert.Equal(t, key.TenantID, tid)
+			return key, nil
+		}
+		c := keyprocessor.NewManager(ks, map[model.KeyKind]keyprocessor.Processor{})
+
+		// when
+		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+			TenantID:   key.TenantID,
+			KeyID:      key.ID,
+			Ciphertext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrProcessorNotFound)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should succeed with round trip", func(t *testing.T) {
+		// given
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		key := model.NewKey(tenantID, "dec-key-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+
+		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		assert.NoError(t, err)
+
+		c := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
+
+		encResp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+			TenantID:  tenantID,
+			KeyID:     key.ID,
+			Plaintext: newTestData(t, []byte("round trip data")),
+			AAD:       []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		// when
+		decResp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+			TenantID:   tenantID,
+			KeyID:      key.ID,
+			Ciphertext: encResp.Ciphertext,
+			AAD:        []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, decResp)
+		assert.Equal(t, []byte("round trip data"), []byte(decResp.Plaintext.SecureBytes()))
+	})
+}
+
+func TestManagerInfo(t *testing.T) {
+	t.Run("should return manager info with decryption secret required", func(t *testing.T) {
+		// given
+		c := keyprocessor.NewManager(nil, nil)
+
+		// when
+		info := c.Info()
+
+		// then
+		assert.Equal(t, cryptor.Info{
+			Name:                     "keyprocessor-manager",
+			Type:                     keyprocessor.TypeManager,
+			DecryptionSecretRequired: true,
+		}, info)
+	})
+}
+
+type keyStoreWrapper struct {
+	store.Key
+
+	getKeyByIDFn func(context.Context, string, string) (*model.Key, error)
+}
+
+func (w *keyStoreWrapper) GetKeyByID(ctx context.Context, id, tenantID string) (*model.Key, error) {
+	if w.getKeyByIDFn != nil {
+		return w.getKeyByIDFn(ctx, id, tenantID)
+	}
+	return w.Key.GetKeyByID(ctx, id, tenantID)
+}

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -14,8 +14,9 @@ import (
 const persistSecName = "persistedSec"
 
 var (
-	// ErrEmptyKeyChain is returned when an operation receives an empty key chain.
-	ErrEmptyKeyChain = errors.New("empty key chain")
+	// ErrMissingParentID is returned when a processor has a parent cryptor set
+	// but the key does not specify a parent ID.
+	ErrMissingParentID = errors.New("parent set but key has no parent ID")
 	// ErrSecNotPersisted is returned when a handler completes successfully
 	// but the secret is missing from the persistent vault, indicating a bug
 	ErrSecNotPersisted = errors.New("persisted secret missing from handler response")
@@ -24,17 +25,17 @@ var (
 // Processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
 // It destroys all intermediate secrets that pass through its operations.
 type Processor struct {
-	generator cryptor.SecretGenerator
-	wrapper   cryptor.Cryptor
-	sealer    cryptor.Cryptor
-	vault     vault.Vault
-	parent    *Processor
+	generator       cryptor.SecretGenerator
+	wrapper         cryptor.Cryptor
+	transportSealer cryptor.Cryptor
+	parent          cryptor.Cryptor
+	vault           vault.Vault
 }
 
 // CreateSecretRequest is the input for CreateSecret.
 type CreateSecretRequest struct {
-	KeyChain []model.Key
-	AAD      []byte
+	Key model.Key
+	AAD []byte
 }
 
 // CreateSecretResponse is the output of CreateSecret.
@@ -42,9 +43,9 @@ type CreateSecretResponse struct{}
 
 // WrapSecretRequest is the input for WrapSecret.
 type WrapSecretRequest struct {
-	KeyChain []model.Key
-	Secret   *securemem.Data
-	AAD      []byte
+	Key    model.Key
+	Secret *securemem.Data
+	AAD    []byte
 }
 
 // WrapSecretResponse is the output of WrapSecret.
@@ -54,7 +55,7 @@ type WrapSecretResponse struct {
 
 // UnwrapSecretRequest is the input for UnwrapSecret.
 type UnwrapSecretRequest struct {
-	KeyChain      []model.Key
+	Key           model.Key
 	WrappedSecret *securemem.Data
 	AAD           []byte
 }
@@ -79,33 +80,28 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		return CreateSecretResponse{}, nil
 	}
 
-	key, err := lastKey(req.KeyChain)
-	if err != nil {
-		return CreateSecretResponse{}, err
-	}
-
-	_, err = securemem.Run(ctx, func(ctx context.Context, _ *securemem.HandlerRequest) error {
+	_, err := securemem.Run(ctx, func(ctx context.Context, _ *securemem.HandlerRequest) error {
 		resp, err := p.generator.GenerateSecret(ctx)
 		if err != nil {
 			return err
 		}
 		defer destroySec(resp.Secret)
 
-		sealSec, err := p.seal(ctx, key, resp.Secret, req.AAD)
+		sealSec, err := p.transportSeal(ctx, req.Key, resp.Secret, req.AAD)
 		if err != nil {
 			return err
 		}
 		defer destroySec(sealSec)
 
-		wrapSec, err := p.parentWrap(ctx, req.KeyChain, sealSec, req.AAD)
+		wrapSec, err := p.parentWrap(ctx, req.Key, sealSec, req.AAD)
 		if err != nil {
 			return err
 		}
 		defer destroySec(wrapSec)
 
 		_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
-			TenantID:    key.TenantID,
-			KeyID:       key.ID,
+			TenantID:    req.Key.TenantID,
+			KeyID:       req.Key.ID,
 			KeyVersion:  1,
 			KeyMaterial: wrapSec,
 			AAD:         req.AAD,
@@ -120,20 +116,15 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 // When the wrapper manages its own decryption key, it encrypts directly without resolving.
 func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
-		sec, err := p.resolveSecret(ctx, req.KeyChain)
+		sec, err := p.resolveSecret(ctx, req.Key)
 		if err != nil {
 			return err
 		}
 		defer destroySec(sec)
 
-		key, err := lastKey(req.KeyChain)
-		if err != nil {
-			return err
-		}
-
 		encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   key.TenantID,
-			KeyID:      key.ID,
+			TenantID:   req.Key.TenantID,
+			KeyID:      req.Key.ID,
 			KeyVersion: 1,
 			Secret:     toCryptorSecret(sec),
 			Plaintext:  req.Secret,
@@ -159,20 +150,15 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 // When the wrapper manages its own decryption key, it decrypts directly without resolving.
 func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
-		sec, err := p.resolveSecret(ctx, req.KeyChain)
+		sec, err := p.resolveSecret(ctx, req.Key)
 		if err != nil {
 			return err
 		}
 		defer destroySec(sec)
 
-		key, err := lastKey(req.KeyChain)
-		if err != nil {
-			return err
-		}
-
 		decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   key.TenantID,
-			KeyID:      key.ID,
+			TenantID:   req.Key.TenantID,
+			KeyID:      req.Key.ID,
 			KeyVersion: 1,
 			Secret:     toCryptorSecret(sec),
 			Ciphertext: req.WrappedSecret,
@@ -212,14 +198,9 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 	return DeleteSecretResponse{}, nil
 }
 
-func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*securemem.Data, error) {
+func (p *Processor) resolveSecret(ctx context.Context, key model.Key) (*securemem.Data, error) {
 	if !p.wrapper.Info().DecryptionSecretRequired {
 		return nil, nil //nolint:nilnil
-	}
-
-	key, err := lastKey(keyChain)
-	if err != nil {
-		return nil, err
 	}
 
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
@@ -232,7 +213,7 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 		}
 		defer destroySec(exported.KeyMaterial)
 
-		unwrapSec, err := p.parentUnwrap(ctx, keyChain, exported.KeyMaterial, exported.AAD)
+		unwrapSec, err := p.parentUnwrap(ctx, key, exported.KeyMaterial, exported.AAD)
 		if err != nil {
 			return err
 		}
@@ -259,11 +240,11 @@ func (p *Processor) resolveSecret(ctx context.Context, keyChain []model.Key) (*s
 	return getPersistedSec(resp)
 }
 
-func (p *Processor) seal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
-	if p.sealer == nil {
+func (p *Processor) transportSeal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if p.transportSealer == nil {
 		return sec, nil
 	}
-	resp, err := p.sealer.Encrypt(ctx, cryptor.EncryptRequest{
+	resp, err := p.transportSealer.Encrypt(ctx, cryptor.EncryptRequest{
 		TenantID:   key.TenantID,
 		KeyID:      key.ID,
 		KeyVersion: 1,
@@ -277,10 +258,10 @@ func (p *Processor) seal(ctx context.Context, key model.Key, sec *securemem.Data
 }
 
 func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
-	if p.sealer == nil {
+	if p.transportSealer == nil {
 		return sec, nil
 	}
-	resp, err := p.sealer.Decrypt(ctx, cryptor.DecryptRequest{
+	resp, err := p.transportSealer.Decrypt(ctx, cryptor.DecryptRequest{
 		TenantID:   key.TenantID,
 		KeyID:      key.ID,
 		KeyVersion: 1,
@@ -293,41 +274,42 @@ func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Da
 	return resp.Plaintext, nil
 }
 
-func (p *Processor) parentWrap(ctx context.Context, keyChain []model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) parentWrap(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.parent == nil {
 		return sec, nil
 	}
-	resp, err := p.parent.WrapSecret(ctx, WrapSecretRequest{
-		KeyChain: keyChain[:len(keyChain)-1],
-		Secret:   sec,
-		AAD:      aad,
+	if key.ParentID == nil {
+		return nil, ErrMissingParentID
+	}
+	resp, err := p.parent.Encrypt(ctx, cryptor.EncryptRequest{
+		TenantID:  key.TenantID,
+		KeyID:     *key.ParentID,
+		Plaintext: sec,
+		AAD:       aad,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return resp.WrappedSecret, nil
+	return resp.Ciphertext, nil
 }
 
-func (p *Processor) parentUnwrap(ctx context.Context, keyChain []model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) parentUnwrap(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.parent == nil {
 		return sec, nil
 	}
-	resp, err := p.parent.UnwrapSecret(ctx, UnwrapSecretRequest{
-		KeyChain:      keyChain[:len(keyChain)-1],
-		WrappedSecret: sec,
-		AAD:           aad,
+	if key.ParentID == nil {
+		return nil, ErrMissingParentID
+	}
+	resp, err := p.parent.Decrypt(ctx, cryptor.DecryptRequest{
+		TenantID:   key.TenantID,
+		KeyID:      *key.ParentID,
+		Ciphertext: sec,
+		AAD:        aad,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return resp.Secret, nil
-}
-
-func lastKey(keyChain []model.Key) (model.Key, error) {
-	if len(keyChain) == 0 {
-		return model.Key{}, ErrEmptyKeyChain
-	}
-	return keyChain[len(keyChain)-1], nil
+	return resp.Plaintext, nil
 }
 
 func destroySec(sec *securemem.Data) {

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
@@ -17,6 +18,7 @@ import (
 	"github.com/openkcm/krypton/internal/vault"
 	"github.com/openkcm/krypton/internal/vault/sqlitevault"
 	"github.com/openkcm/krypton/pkg/model"
+	storesql "github.com/openkcm/krypton/pkg/store/sql"
 )
 
 func TestCreateSecret(t *testing.T) {
@@ -26,23 +28,11 @@ func TestCreateSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
 		})
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-	})
-
-	t.Run("should return error if key chain is empty", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-
-		// when
-		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{})
-
-		// then
-		assert.ErrorIs(t, err, keyprocessor.ErrEmptyKeyChain)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
@@ -54,11 +44,11 @@ func TestCreateSecret(t *testing.T) {
 		gen.generateSecretFn = func(context.Context) (*cryptor.GenerateSecretResponse, error) {
 			return nil, genErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, newTestVault(t), nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, nil, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
 		})
 
 		// then
@@ -89,11 +79,11 @@ func TestCreateSecret(t *testing.T) {
 			assert.Equal(t, keyID, req.KeyID)
 			return &cryptor.EncryptResponse{}, sealErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, newTestVault(t), nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, nil, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Key: model.Key{TenantID: tenantID, ID: keyID},
 		})
 
 		// then
@@ -106,9 +96,12 @@ func TestCreateSecret(t *testing.T) {
 		// given
 		parentErr := errors.New("parent vault down")
 
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
 
 		var genSec *securemem.Data
 		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
@@ -121,17 +114,20 @@ func TestCreateSecret(t *testing.T) {
 		}
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+		parentVault.exportKeyFn = func(_ context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, parentID, req.KeyID)
+			assert.Equal(t, parentKey.ID, req.KeyID)
 			return nil, parentErr
 		}
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, newTestVault(t), parent)
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
+
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, parent, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key: childKey,
 		})
 
 		// then
@@ -144,9 +140,12 @@ func TestCreateSecret(t *testing.T) {
 		// given
 		parentErr := errors.New("parent vault down")
 
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
 
 		var genSec *securemem.Data
 		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
@@ -159,10 +158,11 @@ func TestCreateSecret(t *testing.T) {
 		}
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+		parentVault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			return nil, parentErr
 		}
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
 		realSealer := newStaticSecretCryptor(t)
 		var sealedSec *securemem.Data
@@ -174,11 +174,13 @@ func TestCreateSecret(t *testing.T) {
 			}
 			return resp, err
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, newTestVault(t), parent)
+
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, parent, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key: childKey,
 		})
 
 		// then
@@ -193,9 +195,12 @@ func TestCreateSecret(t *testing.T) {
 		// given
 		importErr := errors.New("disk full")
 
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
 
 		var genSec *securemem.Data
 		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
@@ -207,24 +212,23 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		parentV := newTestVault(t)
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentV, nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		v.importKeyFn = func(ctx context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
+		v.importKeyFn = func(_ context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, keyID, req.KeyID)
+			assert.Equal(t, childKey.ID, req.KeyID)
 			return nil, importErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, v, parent)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, parent, v)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key: childKey,
 		})
 
 		// then
@@ -233,16 +237,41 @@ func TestCreateSecret(t *testing.T) {
 		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with sealer", func(t *testing.T) {
+	t.Run("should return error if parent set but key has no parent ID", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
+		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
+
+		// Key without ParentID but processor has a parent
+		orphanKey := model.Key{TenantID: tenantID, ID: uuid.NewString()}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
+			Key: orphanKey,
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrMissingParentID)
+		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
+	})
+
+	t.Run("should succeed for processor with sealer", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
+
+		// when
+		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
+			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
 		})
 
 		// then
@@ -252,21 +281,24 @@ func TestCreateSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key: childKey,
 		})
 
 		// then
@@ -276,21 +308,24 @@ func TestCreateSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key: childKey,
 		})
 
 		// then
@@ -305,31 +340,19 @@ func TestResolveSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
+		sec, err := processor.ResolveSecret(t.Context(), model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()})
 
 		// then
 		assert.NoError(t, err)
 		assert.Nil(t, sec)
 	})
 
-	t.Run("should return error if key chain is empty", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-
-		// when
-		resp, err := processor.ResolveSecret(t.Context(), []model.Key{})
-
-		// then
-		assert.ErrorIs(t, err, keyprocessor.ErrEmptyKeyChain)
-		assert.Nil(t, resp)
-	})
-
 	t.Run("should return error if key is not found", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}})
+		resp, err := processor.ResolveSecret(t.Context(), model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()})
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -342,22 +365,21 @@ func TestResolveSecret(t *testing.T) {
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
+		key := model.Key{TenantID: tenantID, ID: keyID}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
-		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+		v.exportKeyFn = func(_ context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, keyID, req.KeyID)
 			return nil, exportErr
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+		resp, err := processor.ResolveSecret(t.Context(), key)
 
 		// then
 		assert.ErrorIs(t, err, exportErr)
@@ -368,22 +390,23 @@ func TestResolveSecret(t *testing.T) {
 		// given
 		parentErr := errors.New("parent unavailable")
 
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
 
 		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, v)
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -394,14 +417,14 @@ func TestResolveSecret(t *testing.T) {
 			}
 			return resp, err
 		}
-		parentVault.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+		parentVault.exportKeyFn = func(_ context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, parentID, req.KeyID)
+			assert.Equal(t, parentKey.ID, req.KeyID)
 			return nil, parentErr
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+		resp, err := processor.ResolveSecret(t.Context(), childKey)
 
 		// then
 		assert.ErrorIs(t, err, parentErr)
@@ -416,6 +439,7 @@ func TestResolveSecret(t *testing.T) {
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
+		key := model.Key{TenantID: tenantID, ID: keyID}
 
 		realSealer := newStaticSecretCryptor(t)
 		sealer := &cryptorWrapper{Cryptor: realSealer}
@@ -424,10 +448,8 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), sealer, v, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), sealer, nil, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -440,7 +462,7 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+		resp, err := processor.ResolveSecret(t.Context(), key)
 
 		// then
 		assert.ErrorIs(t, err, unsealErr)
@@ -451,17 +473,14 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: keyID}})
+		sec, err := processor.ResolveSecret(t.Context(), key)
 
 		// then
 		assert.NoError(t, err)
@@ -471,24 +490,25 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+		sec, err := processor.ResolveSecret(t.Context(), childKey)
 
 		// then
 		assert.NoError(t, err)
@@ -498,24 +518,25 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}})
+		sec, err := processor.ResolveSecret(t.Context(), childKey)
 
 		// then
 		assert.NoError(t, err)
@@ -527,12 +548,12 @@ func TestResolveSecret(t *testing.T) {
 func TestWrapSecret(t *testing.T) {
 	t.Run("should return error if resolve fails", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
 
 		// when
 		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
-			Secret:   newTestData(t, []byte("data")),
+			Key:    model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+			Secret: newTestData(t, []byte("data")),
 		})
 
 		// then
@@ -542,14 +563,11 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should return error if encryption fails", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -563,8 +581,8 @@ func TestWrapSecret(t *testing.T) {
 
 		// when — nil plaintext is rejected by aes256gcm
 		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-			Secret:   nil,
+			Key:    key,
+			Secret: nil,
 		})
 
 		// then
@@ -576,17 +594,17 @@ func TestWrapSecret(t *testing.T) {
 	t.Run("should wrap without resolving if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
 		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
 		// when
-		chain := []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}}
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: chain,
-			Secret:   newTestData(t, []byte("data")),
+			Key:    key,
+			Secret: newTestData(t, []byte("data")),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      chain,
+			Key:           key,
 			WrappedSecret: wrapResp.WrappedSecret,
 		})
 
@@ -597,14 +615,11 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), v, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -618,14 +633,14 @@ func TestWrapSecret(t *testing.T) {
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("payload")),
-			AAD:      []byte("aad"),
+			Key:    key,
+			Secret: newTestData(t, []byte("payload")),
+			AAD:    []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			Key:           key,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -639,32 +654,33 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("payload")),
-			AAD:      []byte("aad"),
+			Key:    childKey,
+			Secret: newTestData(t, []byte("payload")),
+			AAD:    []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key:           childKey,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -676,32 +692,33 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("payload")),
-			AAD:      []byte("aad"),
+			Key:    childKey,
+			Secret: newTestData(t, []byte("payload")),
+			AAD:    []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key:           childKey,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -715,11 +732,11 @@ func TestWrapSecret(t *testing.T) {
 func TestUnwrapSecret(t *testing.T) {
 	t.Run("should return error if resolve fails", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: uuid.NewString(), ID: uuid.NewString()}},
+			Key:           model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
 			WrappedSecret: newTestData(t, []byte("ciphertext")),
 		})
 
@@ -730,18 +747,15 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should return error if decryption fails with tampered ciphertext", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("data")),
+			Key:    key,
+			Secret: newTestData(t, []byte("data")),
 		})
 		assert.NoError(t, err)
 
@@ -752,7 +766,7 @@ func TestUnwrapSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			Key:           key,
 			WrappedSecret: newTestData(t, tampered),
 		})
 
@@ -763,26 +777,25 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should return error if decryption fails with wrong AAD", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-			AAD:      []byte("create-aad"),
+			Key: key,
+			AAD: []byte("create-aad"),
 		})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("data")),
-			AAD:      []byte("wrap-aad"),
+			Key:    key,
+			Secret: newTestData(t, []byte("data")),
+			AAD:    []byte("wrap-aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			Key:           key,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("wrong-aad"),
 		})
@@ -794,25 +807,22 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
+		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("payload")),
-			AAD:      []byte("aad"),
+			Key:    key,
+			Secret: newTestData(t, []byte("payload")),
+			AAD:    []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: keyID}},
+			Key:           key,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -824,32 +834,33 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("payload")),
-			AAD:      []byte("aad"),
+			Key:    childKey,
+			Secret: newTestData(t, []byte("payload")),
+			AAD:    []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key:           childKey,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -861,32 +872,33 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
 		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), parent)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
+		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-			Secret:   newTestData(t, []byte("payload")),
-			AAD:      []byte("aad"),
+			Key:    childKey,
+			Secret: newTestData(t, []byte("payload")),
+			AAD:    []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
+			Key:           childKey,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -901,7 +913,7 @@ func TestDeleteSecret(t *testing.T) {
 	t.Run("should not delete if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, v, nil)
+		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, v)
 
 		var called bool
 		v.destroyKeyFn = func(context.Context, vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
@@ -926,24 +938,21 @@ func TestDeleteSecret(t *testing.T) {
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
+		key := model.Key{TenantID: tenantID, ID: keyID}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
-		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
+		v.destroyKeyFn = func(_ context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, keyID, req.KeyID)
 			return nil, destroyErr
 		}
 
 		// when
-		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
-			Key: model.Key{TenantID: tenantID, ID: keyID},
-		})
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{Key: key})
 
 		// then
 		assert.ErrorIs(t, err, destroyErr)
@@ -954,13 +963,11 @@ func TestDeleteSecret(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		parentID := uuid.NewString()
+		key := model.Key{TenantID: tenantID, ID: keyID}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, v, nil)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: tenantID, ID: parentID}, {TenantID: tenantID, ID: keyID}},
-		})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
 		assert.NoError(t, err)
 
 		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
@@ -970,9 +977,7 @@ func TestDeleteSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
-			Key: model.Key{TenantID: tenantID, ID: keyID},
-		})
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{Key: key})
 
 		// then
 		assert.NoError(t, err)
@@ -983,27 +988,32 @@ func TestDeleteSecret(t *testing.T) {
 func TestHierarchy(t *testing.T) {
 	t.Run("should succeed for two-level chain round trip", func(t *testing.T) {
 		// given
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
-		})
-		assert.NoError(t, err)
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
-		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
+		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
+
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
-			Secret:   newTestData(t, []byte("classified")),
+			Key:    childKey,
+			Secret: newTestData(t, []byte("classified")),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := child.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
+			Key:           childKey,
 			WrappedSecret: wrapResp.WrappedSecret,
 		})
 
@@ -1014,33 +1024,39 @@ func TestHierarchy(t *testing.T) {
 
 	t.Run("should succeed for three-level chain round trip", func(t *testing.T) {
 		// given
-		root := keyprocessor.NewProcessor(newTestSecretGen(), newStaticSecretCryptor(t), nil, newTestVault(t), nil)
-		_, err := root.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}},
-		})
-		assert.NoError(t, err)
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		mid := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), newTestVault(t), root)
-		_, err = mid.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}},
-		})
-		assert.NoError(t, err)
+		rootKey := model.NewKey(tenantID, "root-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), rootKey))
 
-		leaf := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), mid)
-		_, err = leaf.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
-		})
+		rootProc := keyprocessor.NewProcessor(newTestSecretGen(), newStaticSecretCryptor(t), nil, nil, newTestVault(t))
+		_, err := rootProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: rootKey})
+		assert.NoError(t, err)
+		rootCryptor := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{rootKey.Kind: *rootProc})
+
+		midKey := model.NewKey(tenantID, "mid-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), midKey))
+		midProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), rootCryptor, newTestVault(t))
+		_, err = midProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: midKey})
+		assert.NoError(t, err)
+		midCryptor := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{midKey.Kind: *midProc})
+
+		leafKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &midKey.ID, Kind: "K2"}
+		leafProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, midCryptor, newTestVault(t))
+		_, err = leafProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: leafKey})
 		assert.NoError(t, err)
 
 		// when
-		wrapResp, err := leaf.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
-			Secret:   newTestData(t, []byte("top secret")),
+		wrapResp, err := leafProc.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
+			Key:    leafKey,
+			Secret: newTestData(t, []byte("top secret")),
 		})
 		assert.NoError(t, err)
 
-		unwrapResp, err := leaf.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyChain:      []model.Key{{TenantID: "t1", ID: "root-1"}, {TenantID: "t1", ID: "mid-1"}, {TenantID: "t1", ID: "leaf-1"}},
+		unwrapResp, err := leafProc.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
+			Key:           leafKey,
 			WrappedSecret: wrapResp.WrappedSecret,
 		})
 
@@ -1053,17 +1069,22 @@ func TestHierarchy(t *testing.T) {
 		// given
 		parentErr := errors.New("parent compromised")
 
-		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parent := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parentVault, nil)
-		_, err := parent.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}},
-		})
-		assert.NoError(t, err)
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
 
-		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestVault(t), parent)
-		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
-		})
+		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+		parentVault := &vaultWrapper{Vault: newTestVault(t)}
+		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
+		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
+		assert.NoError(t, err)
+		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
+
+		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
 		assert.NoError(t, err)
 
 		parentVault.exportKeyFn = func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
@@ -1072,8 +1093,8 @@ func TestHierarchy(t *testing.T) {
 
 		// when
 		resp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyChain: []model.Key{{TenantID: "t1", ID: "parent-1"}, {TenantID: "t1", ID: "child-1"}},
-			Secret:   newTestData(t, []byte("data")),
+			Key:    childKey,
+			Secret: newTestData(t, []byte("data")),
 		})
 
 		// then

--- a/internal/keyprocessor/setup_test.go
+++ b/internal/keyprocessor/setup_test.go
@@ -1,0 +1,101 @@
+package keyprocessor_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	_ "github.com/lib/pq"
+
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+	storesql "github.com/openkcm/krypton/pkg/store/sql"
+)
+
+var pgConnStr string
+
+func TestMain(m *testing.M) {
+	pgCleanup, err := setupPostgres()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+	pgCleanup()
+	os.Exit(exitCode)
+}
+
+func setupPostgres() (func(), error) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:18-alpine",
+		postgres.WithDatabase("postgres"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	cleanUp := func() { _ = pgContainer.Terminate(ctx) }
+
+	pgConnStr, err = pgContainer.ConnectionString(ctx, "sslmode=disable")
+
+	return cleanUp, err
+}
+
+func createDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+	ctx := t.Context()
+
+	db, err := sql.Open("postgres", pgConnStr)
+	if err != nil {
+		assert.FailNowf(t, "failed to connect to PostgreSQL", "error: %v", err)
+	}
+
+	dbName := "test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+
+	_, err = db.ExecContext(ctx, "CREATE DATABASE "+dbName)
+	if err != nil {
+		db.Close()
+		assert.FailNowf(t, "failed to create test database", "error: %v", err)
+	}
+	db.Close()
+
+	pgConStr := strings.Replace(pgConnStr, "/postgres?", "/"+dbName+"?", 1)
+	sqlDB, err := sql.Open("postgres", pgConStr)
+	if err != nil {
+		assert.FailNowf(t, "failed to connect to test database", "error: %v", err)
+	}
+
+	t.Cleanup(func() {
+		sqlDB.Close()
+
+		db, err := sql.Open("postgres", pgConnStr)
+		if err == nil {
+			_, _ = db.ExecContext(context.Background(), "DROP DATABASE "+dbName)
+			db.Close()
+		}
+	})
+
+	require.NoError(t, storesql.Migrate(ctx, sqlDB))
+
+	return sqlDB
+}
+
+func createTenant(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	tenantStore := storesql.NewTenantStore(db)
+	tenant := model.NewTenant("test-tenant-"+uuid.NewString(), nil)
+	result, err := tenantStore.CreateTenant(t.Context(), store.CreateTenantQuery{Tenant: tenant})
+	require.NoError(t, err)
+	return result.Tenant.ID
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add key processor manager

Following the conventional commits: https://www.conventionalcommits.org
-->
This replaces the key chain snapshot with runtime hierarchy traversal via a `keyprocessor.Manager` that looks up keys and routes to the matching processor.

**Old: Key Chain**
```
caller: chain=[root, mid, leaf]
        │
        ▼
┌─────────────────┐
│  Leaf Proc      │
│  picks chain[2] │
└────────┬────────┘
         │ chain[0:1]
         ▼
┌─────────────────┐
│  Mid Proc       │
│  picks chain[1] │
└────────┬────────┘
         │ chain[0:0]
         ▼
┌─────────────────┐
│  Root Proc      │
│  picks chain[0] │
└─────────────────┘
```

**New: Single Key + Manager**

```
caller: Encrypt(id="leaf")
        │
        ▼
┌─────────────────┐
│    Manager      │  store.GetKey("leaf") → kind=K2
└────────┬────────┘
         │ Wrap(key=leaf)
         ▼
┌─────────────────┐
│  Leaf Proc      │  leaf.ParentID="mid"
└────────┬────────┘
         │ Decrypt(id="mid")
         ▼
┌─────────────────┐
│    Manager      │  store.GetKey("mid") → kind=K1
└────────┬────────┘
         │ Unwrap(key=mid)
         ▼
┌─────────────────┐
│  Mid Proc       │  mid.ParentID="root"
└────────┬────────┘
         │ Decrypt(id="root")
         ▼
┌─────────────────┐
│    Manager      │  store.GetKey("root") → kind=K0
└────────┬────────┘
         │ Unwrap(key=root)
         ▼
┌─────────────────┐
│  Root Proc      │  no parent, terminates
└─────────────────┘
```

Benefits:
- Caller only needs its own key, not a snapshot of the full chain
- Hierarchy is discovered at runtime via ParentID + store lookup
- Manager centralizes routing and can enforce validation later