### PR TITLE
feat: add key version store and sql implementation

### DIFF
--- a/pkg/api/v1/proto/admin/keys/key_service_test.go
+++ b/pkg/api/v1/proto/admin/keys/key_service_test.go
@@ -482,7 +482,7 @@ func TestAnnounceKey(t *testing.T) {
 		// Seed a tenant in the temp DB so tenant-existence passes; then drop
 		// the keys table so the downstream lookup fails.
 		tmpTenant := createTenant(t, tmpDB)
-		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys")
+		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
 		cli := setupKeyServerAndClient(t, tmpDB)
@@ -599,7 +599,7 @@ func TestGetKeyService(t *testing.T) {
 
 		require.NoError(t, storesql.Migrate(ctx, tmpDB))
 
-		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys")
+		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
 		cli := setupKeyServerAndClient(t, tmpDB)
@@ -683,7 +683,7 @@ func TestGetParentKeys(t *testing.T) {
 
 		require.NoError(t, storesql.Migrate(ctx, tmpDB))
 
-		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys")
+		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
 		cli := setupKeyServerAndClient(t, tmpDB)
@@ -800,7 +800,7 @@ func TestGetDescendantKeys(t *testing.T) {
 
 		require.NoError(t, storesql.Migrate(ctx, tmpDB))
 
-		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys")
+		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
 		cli := setupKeyServerAndClient(t, tmpDB)
@@ -977,7 +977,7 @@ func TestListKeys(t *testing.T) {
 
 		require.NoError(t, storesql.Migrate(ctx, tmpDB))
 
-		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys")
+		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
 		cli := setupKeyServerAndClient(t, tmpDB)

--- a/pkg/store/keyversion.go
+++ b/pkg/store/keyversion.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkcm/krypton/pkg/model"
+)
+
+var ErrKeyVersionNotFound = errors.New("key version not found")
+
+type KeyVersion interface {
+	CreateKeyVersion(ctx context.Context, query CreateKeyVersionQuery) (CreateKeyVersionResult, error)
+	ListKeyVersions(ctx context.Context, query ListKeyVersionsQuery) (ListKeyVersionsResult, error)
+}
+
+type CreateKeyVersionQuery struct {
+	KeyVersion model.KeyVersion
+}
+
+type CreateKeyVersionResult struct {
+	KeyVersion model.KeyVersion
+}
+
+type ListKeyVersionsQuery struct {
+	TenantID              string
+	KeyID                 string
+	Version               string
+	ProcessingState       model.KeyVersionProcessingState
+	IsOrderByRevisionDesc bool
+	Limit                 int
+}
+
+type ListKeyVersionsResult struct {
+	KeyVersions []model.KeyVersion
+}

--- a/pkg/store/sql/keyversion.go
+++ b/pkg/store/sql/keyversion.go
@@ -1,0 +1,109 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+)
+
+type KeyVersionStore struct {
+	db *sql.DB
+}
+
+var _ store.KeyVersion = &KeyVersionStore{}
+
+func NewKeyVersionStore(db *sql.DB) *KeyVersionStore {
+	return &KeyVersionStore{db: db}
+}
+
+func (s *KeyVersionStore) CreateKeyVersion(ctx context.Context, query store.CreateKeyVersionQuery) (store.CreateKeyVersionResult, error) {
+	stmt := `
+		INSERT INTO key_versions (tenant_id, key_id, version, revision, parent_key_id, parent_key_version, life_cycle_state, processing_state, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`
+
+	kv := query.KeyVersion
+	_, err := s.db.ExecContext(ctx, stmt,
+		kv.TenantID,
+		kv.KeyID,
+		kv.Version,
+		kv.Revision,
+		kv.ParentKeyID,
+		kv.ParentKeyVersion,
+		kv.LifeCycleState,
+		kv.ProcessingState,
+		kv.CreatedAt,
+		kv.UpdatedAt,
+	)
+	if err != nil {
+		return store.CreateKeyVersionResult{}, err
+	}
+
+	return store.CreateKeyVersionResult{KeyVersion: kv}, nil
+}
+
+func (s *KeyVersionStore) ListKeyVersions(ctx context.Context, query store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+	params := make([]any, 0, 6)
+	nextParam := func(v any) string {
+		params = append(params, v)
+		return fmt.Sprintf("$%d", len(params))
+	}
+
+	var q strings.Builder
+	fmt.Fprintf(&q, `SELECT tenant_id, key_id, version, revision, parent_key_id, parent_key_version, life_cycle_state, processing_state, created_at, updated_at
+		FROM key_versions WHERE tenant_id = %s `, nextParam(query.TenantID))
+
+	if query.KeyID != "" {
+		fmt.Fprintf(&q, "AND key_id = %s ", nextParam(query.KeyID))
+	}
+	if query.Version != "" {
+		fmt.Fprintf(&q, "AND version = %s ", nextParam(query.Version))
+	}
+	if query.ProcessingState != "" {
+		fmt.Fprintf(&q, "AND processing_state = %s ", nextParam(query.ProcessingState))
+	}
+
+	if query.IsOrderByRevisionDesc {
+		q.WriteString("ORDER BY revision DESC ")
+	}
+
+	if query.Limit > 0 {
+		fmt.Fprintf(&q, "LIMIT %s ", nextParam(query.Limit))
+	}
+
+	rows, err := s.db.QueryContext(ctx, q.String(), params...)
+	if err != nil {
+		return store.ListKeyVersionsResult{}, err
+	}
+	defer rows.Close()
+
+	var keyVersions []model.KeyVersion
+	for rows.Next() {
+		var kv model.KeyVersion
+		err := rows.Scan(
+			&kv.TenantID,
+			&kv.KeyID,
+			&kv.Version,
+			&kv.Revision,
+			&kv.ParentKeyID,
+			&kv.ParentKeyVersion,
+			&kv.LifeCycleState,
+			&kv.ProcessingState,
+			&kv.CreatedAt,
+			&kv.UpdatedAt,
+		)
+		if err != nil {
+			return store.ListKeyVersionsResult{}, err
+		}
+		keyVersions = append(keyVersions, kv)
+	}
+	if err := rows.Err(); err != nil {
+		return store.ListKeyVersionsResult{}, err
+	}
+
+	return store.ListKeyVersionsResult{KeyVersions: keyVersions}, nil
+}

--- a/pkg/store/sql/keyversion_test.go
+++ b/pkg/store/sql/keyversion_test.go
@@ -1,0 +1,261 @@
+package sql_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+
+	"github.com/openkcm/krypton/internal/clock"
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+	storesql "github.com/openkcm/krypton/pkg/store/sql"
+)
+
+func TestCreateKeyVersion(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	require.NoError(t, storesql.Migrate(ctx, db))
+	kvStore := storesql.NewKeyVersionStore(db)
+	keyStore := storesql.NewKeyStore(db)
+	tenantStore := storesql.NewTenantStore(db)
+
+	tenant := createTenant(t, tenantStore)
+	key := model.NewKey(tenant.ID, "kv-create-key-"+uuid.NewString(), "K1", nil, "root", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, key))
+
+	t.Run("should create key version without parent", func(t *testing.T) {
+		// given
+		now := clock.Now()
+		kv := model.KeyVersion{
+			TenantID:        tenant.ID,
+			KeyID:           key.ID,
+			Version:         "1",
+			Revision:        0,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: model.KeyVersionUsable,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+
+		// when
+		result, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, kv, result.KeyVersion)
+	})
+
+	t.Run("should create key version with parent references", func(t *testing.T) {
+		// given
+		parentKeyID := uuid.NewString()
+		parentKeyVersion := "2"
+		now := clock.Now()
+		kv := model.KeyVersion{
+			TenantID:         tenant.ID,
+			KeyID:            key.ID,
+			Version:          "2",
+			Revision:         0,
+			ParentKeyID:      &parentKeyID,
+			ParentKeyVersion: &parentKeyVersion,
+			LifeCycleState:   model.KeyLifeCycleActive,
+			ProcessingState:  model.KeyVersionUsable,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		// when
+		result, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, &parentKeyID, result.KeyVersion.ParentKeyID)
+		assert.Equal(t, &parentKeyVersion, result.KeyVersion.ParentKeyVersion)
+	})
+
+	t.Run("should fail on duplicate composite key", func(t *testing.T) {
+		// given
+		now := clock.Now()
+		kv := model.KeyVersion{
+			TenantID:        tenant.ID,
+			KeyID:           key.ID,
+			Version:         "3",
+			Revision:        0,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: model.KeyVersionUsable,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		_, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
+		require.NoError(t, err)
+
+		// when
+		_, err = kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
+
+		// then
+		assert.Error(t, err)
+	})
+
+	t.Run("should fail with invalid tenant reference", func(t *testing.T) {
+		// given
+		now := clock.Now()
+		kv := model.KeyVersion{
+			TenantID:        uuid.NewString(),
+			KeyID:           key.ID,
+			Version:         "1",
+			Revision:        0,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: model.KeyVersionUsable,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+
+		// when
+		_, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
+
+		// then
+		assert.Error(t, err)
+	})
+}
+
+func TestListKeyVersions(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	require.NoError(t, storesql.Migrate(ctx, db))
+	kvStore := storesql.NewKeyVersionStore(db)
+	keyStore := storesql.NewKeyStore(db)
+	tenantStore := storesql.NewTenantStore(db)
+
+	tenant := createTenant(t, tenantStore)
+	key := model.NewKey(tenant.ID, "kv-list-key-"+uuid.NewString(), "K1", nil, "root", nil)
+	require.NoError(t, keyStore.CreateKey(ctx, key))
+
+	// seed: version "1" with revisions 0, 1 (usable), 2 (re-wrapping)
+	now := clock.Now()
+	seeds := []struct {
+		revision        int
+		processingState model.KeyVersionProcessingState
+	}{
+		{0, model.KeyVersionUsable},
+		{1, model.KeyVersionUsable},
+		{2, model.KeyVersionReWrapping},
+	}
+	for _, s := range seeds {
+		kv := model.KeyVersion{
+			TenantID:        tenant.ID,
+			KeyID:           key.ID,
+			Version:         "1",
+			Revision:        s.revision,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: s.processingState,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		_, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
+		require.NoError(t, err)
+	}
+
+	t.Run("should list all revisions for a key version", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID: tenant.ID,
+			KeyID:    key.ID,
+			Version:  "1",
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, result.KeyVersions, 3)
+	})
+
+	t.Run("should filter by processing state", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:        tenant.ID,
+			KeyID:           key.ID,
+			Version:         "1",
+			ProcessingState: model.KeyVersionUsable,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, result.KeyVersions, 2)
+	})
+
+	t.Run("should order by revision descending", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:              tenant.ID,
+			KeyID:                 key.ID,
+			Version:               "1",
+			IsOrderByRevisionDesc: true,
+		})
+
+		// then
+		assert.NoError(t, err)
+		require.Len(t, result.KeyVersions, 3)
+		assert.Equal(t, 2, result.KeyVersions[0].Revision)
+		assert.Equal(t, 1, result.KeyVersions[1].Revision)
+		assert.Equal(t, 0, result.KeyVersions[2].Revision)
+	})
+
+	t.Run("should limit results", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:              tenant.ID,
+			KeyID:                 key.ID,
+			Version:               "1",
+			IsOrderByRevisionDesc: true,
+			Limit:                 1,
+		})
+
+		// then
+		assert.NoError(t, err)
+		require.Len(t, result.KeyVersions, 1)
+		assert.Equal(t, 2, result.KeyVersions[0].Revision)
+	})
+
+	t.Run("should resolve highest usable revision", func(t *testing.T) {
+		// given
+		expRevision := 1
+
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:              tenant.ID,
+			KeyID:                 key.ID,
+			Version:               "1",
+			ProcessingState:       model.KeyVersionUsable,
+			IsOrderByRevisionDesc: true,
+			Limit:                 1,
+		})
+
+		// then
+		assert.NoError(t, err)
+		require.Len(t, result.KeyVersions, 1)
+		assert.Equal(t, expRevision, result.KeyVersions[0].Revision)
+		assert.Equal(t, model.KeyVersionUsable, result.KeyVersions[0].ProcessingState)
+	})
+
+	t.Run("should return empty slice when no matches", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID: tenant.ID,
+			KeyID:    key.ID,
+			Version:  "99",
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Empty(t, result.KeyVersions)
+	})
+}

--- a/pkg/store/sql/migrate.go
+++ b/pkg/store/sql/migrate.go
@@ -48,11 +48,30 @@ CREATE TABLE IF NOT EXISTS keys (
 );
 `
 
+const createKeyVersionsTable = `
+CREATE TABLE IF NOT EXISTS key_versions (
+	tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+	key_id UUID NOT NULL,
+	version TEXT NOT NULL,
+	revision INT NOT NULL,
+	parent_key_id UUID NULL,
+	parent_key_version TEXT NULL,
+	life_cycle_state TEXT NOT NULL,
+	processing_state TEXT NOT NULL,
+	created_at BIGINT NOT NULL,
+	updated_at BIGINT NOT NULL,
+
+	PRIMARY KEY (tenant_id, key_id, version, revision),
+	FOREIGN KEY (tenant_id, key_id) REFERENCES keys(tenant_id, id)
+);
+`
+
 func Migrate(ctx context.Context, db *sql.DB) error {
 	stmts := []string{
 		createTenantsTable,
 		createAgentRegistrationsTable,
 		createKeysTable,
+		createKeyVersionsTable,
 	}
 
 	for _, stmt := range stmts {


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add key version store and sql implementation

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Implement minimal `KeyVersion` store with create and list operations to support the key version resolution mechanism (highest usable revision lookup via filtering, ordering, and limit).
