### PR TITLE
fix: add revision to vault operations

### DIFF
--- a/internal/vault/openbaovault/openbao.go
+++ b/internal/vault/openbaovault/openbao.go
@@ -114,7 +114,7 @@ func (v *Vault) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*vau
 		return v.cli.KVv1(kvMountPath(req.TenantID)).
 			Put(
 				ctx,
-				kvPath(req.KeyID, req.KeyVersion),
+				kvPath(req.KeyID, req.KeyVersion, req.KeyRevision),
 				data,
 			)
 	})
@@ -130,7 +130,7 @@ func (v *Vault) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*vau
 
 	resp, err := securemem.Run(ctx, func(ctx context.Context, hreq *securemem.HandlerRequest) error {
 		data, err := v.cli.KVv1(kvMountPath(req.TenantID)).
-			Get(ctx, kvPath(req.KeyID, req.KeyVersion))
+			Get(ctx, kvPath(req.KeyID, req.KeyVersion, req.KeyRevision))
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func (v *Vault) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*vau
 // DestroyKey removes the key material from the vault.
 func (v *Vault) DestroyKey(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
 	err := v.cli.KVv1(kvMountPath(req.TenantID)).
-		Delete(ctx, kvPath(req.KeyID, req.KeyVersion))
+		Delete(ctx, kvPath(req.KeyID, req.KeyVersion, req.KeyRevision))
 	if err != nil && !isKVPathDeleted(err) {
 		return nil, err
 	}
@@ -246,8 +246,8 @@ func kvMountPath(tenantID string) string {
 	return fmt.Sprintf("%s/%s", tenantID, kvSecretName)
 }
 
-func kvPath(keyID, keyVersion string) string {
-	return fmt.Sprintf("%s/%s", keyID, keyVersion)
+func kvPath(keyID, keyVersion string, keyRevision int) string {
+	return fmt.Sprintf("%s/%s/%d", keyID, keyVersion, keyRevision)
 }
 
 func kvSecretPath(tenantID string) string {

--- a/internal/vault/sqlitevault/unsafesqlite.go
+++ b/internal/vault/sqlitevault/unsafesqlite.go
@@ -21,10 +21,11 @@ CREATE TABLE IF NOT EXISTS keys (
 	tenant_id TEXT NOT NULL CHECK(tenant_id != ''),
 	key_id TEXT NOT NULL CHECK(key_id != ''),
 	key_version TEXT NOT NULL,
+	key_revision INTEGER NOT NULL DEFAULT 0,
 	key_material BLOB NOT NULL,
 	aad BLOB,
 	created_at INTEGER NOT NULL,
-	PRIMARY KEY(tenant_id, key_id, key_version)
+	PRIMARY KEY(tenant_id, key_id, key_version, key_revision)
 )
 `
 
@@ -103,8 +104,8 @@ func (u *Unsafe) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*va
 		return nil, vault.ErrInvalidRequest
 	}
 	_, err := u.db.ExecContext(ctx,
-		"INSERT INTO keys (tenant_id, key_id, key_version, key_material, aad, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-		req.TenantID, req.KeyID, req.KeyVersion, []byte(req.KeyMaterial.SecureBytes()), req.AAD, int64(clock.Now()),
+		"INSERT INTO keys (tenant_id, key_id, key_version, key_revision, key_material, aad, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		req.TenantID, req.KeyID, req.KeyVersion, req.KeyRevision, []byte(req.KeyMaterial.SecureBytes()), req.AAD, int64(clock.Now()),
 	)
 	if err != nil {
 		return nil, err
@@ -113,8 +114,8 @@ func (u *Unsafe) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*va
 }
 
 func (u *Unsafe) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-	query := "SELECT key_material, aad FROM keys WHERE tenant_id = ? AND key_id = ? AND key_version = ?"
-	args := []any{req.TenantID, req.KeyID, req.KeyVersion}
+	query := "SELECT key_material, aad FROM keys WHERE tenant_id = ? AND key_id = ? AND key_version = ? AND key_revision = ?"
+	args := []any{req.TenantID, req.KeyID, req.KeyVersion, req.KeyRevision}
 
 	var rawKey []byte
 	var aad []byte
@@ -140,8 +141,8 @@ func (u *Unsafe) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*va
 
 func (u *Unsafe) DestroyKey(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
 	_, err := u.db.ExecContext(ctx,
-		"DELETE FROM keys WHERE tenant_id = ? AND key_id = ? AND key_version = ?",
-		req.TenantID, req.KeyID, req.KeyVersion,
+		"DELETE FROM keys WHERE tenant_id = ? AND key_id = ? AND key_version = ? AND key_revision = ?",
+		req.TenantID, req.KeyID, req.KeyVersion, req.KeyRevision,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/vault/sqlitevault/unsafesqlite_test.go
+++ b/internal/vault/sqlitevault/unsafesqlite_test.go
@@ -275,6 +275,93 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	_ = resp.KeyMaterial.Destroy()
 }
 
+func TestUnsafe_RevisionCoexistence(t *testing.T) {
+	// given
+	v := newTestUnsafeVault(t)
+	ctx := t.Context()
+
+	rev0Data := []byte("key-material-revision-0-padded!")
+	rev1Data := []byte("key-material-revision-1-padded!")
+
+	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 0,
+		KeyMaterial: newTestSecureData(t, rev0Data),
+		AAD:         []byte("aad-rev-0"),
+	})
+	assert.NoError(t, err)
+
+	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 1,
+		KeyMaterial: newTestSecureData(t, rev1Data),
+		AAD:         []byte("aad-rev-1"),
+	})
+	assert.NoError(t, err)
+
+	// when - export revision 0
+	resp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 0,
+	})
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, rev0Data, []byte(resp.KeyMaterial.SecureBytes()))
+	assert.Equal(t, []byte("aad-rev-0"), resp.AAD)
+	_ = resp.KeyMaterial.Destroy()
+
+	// when - export revision 1
+	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 1,
+	})
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, rev1Data, []byte(resp.KeyMaterial.SecureBytes()))
+	assert.Equal(t, []byte("aad-rev-1"), resp.AAD)
+	_ = resp.KeyMaterial.Destroy()
+
+	// when - destroy revision 0 only
+	_, err = v.DestroyKey(ctx, vault.DestroyKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 0,
+	})
+	assert.NoError(t, err)
+
+	// then - revision 0 is gone
+	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 0,
+	})
+	assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+	assert.Nil(t, resp)
+
+	// then - revision 1 still exists
+	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  "1",
+		KeyRevision: 1,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, rev1Data, []byte(resp.KeyMaterial.SecureBytes()))
+	_ = resp.KeyMaterial.Destroy()
+}
+
 func TestUnsafe_Info(t *testing.T) {
 	t.Run("memory source", func(t *testing.T) {
 		// given

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -49,6 +49,7 @@ type ImportKeyRequest struct {
 	TenantID    string
 	KeyID       string
 	KeyVersion  string
+	KeyRevision int
 	KeyMaterial *securemem.Data
 	AAD         []byte
 }
@@ -60,9 +61,10 @@ type ImportKeyResponse struct {
 
 // ExportKeyRequest contains parameters for retrieving key material from the vault.
 type ExportKeyRequest struct {
-	TenantID   string
-	KeyID      string
-	KeyVersion string
+	TenantID    string
+	KeyID       string
+	KeyVersion  string
+	KeyRevision int
 }
 
 // ExportKeyResponse holds the retrieved key material and its associated authenticated data.
@@ -73,9 +75,10 @@ type ExportKeyResponse struct {
 
 // DestroyKeyRequest contains parameters for destroying a specific key version.
 type DestroyKeyRequest struct {
-	TenantID   string
-	KeyID      string
-	KeyVersion string
+	TenantID    string
+	KeyID       string
+	KeyVersion  string
+	KeyRevision int
 }
 
 // DestroyKeyResponse holds the result of a version destruction operation.


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   add revision to vault operations

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Add KeyRevision to vault request types for per-revision key material storage
