### PR TITLE
feat: add DestroyTenant and make vault destroy operations idempotent

### DIFF
--- a/internal/vault/openbaovault/openbao.go
+++ b/internal/vault/openbaovault/openbao.go
@@ -74,54 +74,53 @@ func New(name string, opts ...Options) (*Vault, error) {
 // PrepareTenant creates a namespace and mounts the kv secret engine for the tenant.
 func (v *Vault) PrepareTenant(ctx context.Context, req vault.PrepareTenantRequest) (*vault.PrepareTenantResponse, error) {
 	// create the namespace for the tenant
-	namespacePath := "sys/namespaces/" + req.TenantID
-	_, err := v.cli.Logical().WriteWithContext(ctx, namespacePath, map[string]any{})
+	_, err := v.cli.Logical().WriteWithContext(ctx, namespacePath(req.TenantID), map[string]any{})
 	if err != nil {
 		return nil, err
 	}
 
-	kvSecretPath := req.TenantID + "/sys/mounts/" + kvSecretName
-	// check if the kv secret engine is already mounted for the tenant
-	_, err = v.cli.Logical().ReadWithContext(ctx, kvSecretPath)
-	if err == nil {
-		return &vault.PrepareTenantResponse{}, nil
+	// mount the kv secret engine for the tenant
+	_, err = v.cli.Logical().WriteWithContext(ctx, kvSecretPath(req.TenantID), kvCreateRequest)
+	if err != nil && !isKVPathExists(err) {
+		return nil, err
+	}
+	return &vault.PrepareTenantResponse{}, nil
+}
+
+// DestroyTenant removes the namespace and kv secret engine for the tenant.
+func (v *Vault) DestroyTenant(ctx context.Context, req vault.DestroyTenantRequest) (*vault.DestroyTenantResponse, error) {
+	_, err := v.cli.Logical().DeleteWithContext(ctx, kvSecretPath(req.TenantID))
+	if err != nil && !isKVPathDeleted(err) {
+		return nil, err
 	}
 
-	var respErr *openbao.ResponseError
-	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusBadRequest {
-		for _, e := range respErr.Errors {
-			if strings.Contains(e, "No secret engine mount at "+kvSecretName+"/") {
-				// create the kv secret mount for the tenant
-				_, err = v.cli.Logical().WriteWithContext(ctx, kvSecretPath, kvCreateRequest)
-				if err != nil {
-					return nil, err
-				}
-				return &vault.PrepareTenantResponse{}, nil
-			}
-		}
+	_, err = v.cli.Logical().DeleteWithContext(ctx, namespacePath(req.TenantID))
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	return &vault.DestroyTenantResponse{}, nil
 }
 
 // ImportKey stores the key material in the vault.
 func (v *Vault) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
+	if req.KeyMaterial == nil {
+		return nil, vault.ErrInvalidRequest
+	}
 	_, err := securemem.Run(ctx, func(ctx context.Context, hreq *securemem.HandlerRequest) error {
 		data, err := toKvData(data{KeyMaterial: base64Encode(req.KeyMaterial.SecureBytes()), AAD: base64Encode(req.AAD)})
 		if err != nil {
 			return err
 		}
-		err = v.cli.KVv1(kvMountPath(req.TenantID)).
+		return v.cli.KVv1(kvMountPath(req.TenantID)).
 			Put(
 				ctx,
 				kvPath(req.KeyID, req.KeyVersion),
 				data,
 			)
-		return err
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	return &vault.ImportKeyResponse{}, nil
 }
 
@@ -146,20 +145,15 @@ func (v *Vault) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*vau
 			return err
 		}
 
-		sKm, err := securemem.NewData(req.KeyID, len(b64Km))
-		if err != nil {
-			return err
-		}
-
-		copy(sKm.SecureBytes(), b64Km)
-
 		// clear the temporary buffer to avoid leaving sensitive data in memory
-		securemem.Zero(b64Km)
+		defer securemem.Zero(b64Km)
 
-		err = hreq.PersistentVault().Import(securememImportKey, sKm)
+		sKm, err := hreq.PersistentVault().Reserve(securememImportKey, len(b64Km))
 		if err != nil {
 			return err
 		}
+
+		copy(sKm, b64Km)
 
 		aad, err = base64Decode(kvData.AAD)
 		return err
@@ -189,36 +183,17 @@ func (v *Vault) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*vau
 
 // DestroyKey removes the key material from the vault.
 func (v *Vault) DestroyKey(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
-	eResp, err := v.ExportKey(ctx, vault.ExportKeyRequest(req))
-	if err != nil {
-		return nil, err
-	}
-
-	err = eResp.KeyMaterial.Destroy()
-	if err != nil {
-		return nil, err
-	}
-
-	err = v.cli.KVv1(kvMountPath(req.TenantID)).
+	err := v.cli.KVv1(kvMountPath(req.TenantID)).
 		Delete(ctx, kvPath(req.KeyID, req.KeyVersion))
-	if err != nil {
+	if err != nil && !isKVPathDeleted(err) {
 		return nil, err
 	}
-
 	return &vault.DestroyKeyResponse{}, nil
 }
 
 // Info returns the vault information.
 func (v *Vault) Info() vault.Info {
 	return v.info
-}
-
-func kvMountPath(tenantID string) string {
-	return fmt.Sprintf("%s/%s", tenantID, kvSecretName)
-}
-
-func kvPath(keyID, keyVersion string) string {
-	return fmt.Sprintf("%s/%s", keyID, keyVersion)
 }
 
 func toKvData(d data) (map[string]any, error) {
@@ -245,4 +220,40 @@ func base64Encode[T securemem.SecureBytes | []byte](b T) string {
 
 func base64Decode(b string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(b)
+}
+
+func isKVPathDeleted(err error) bool {
+	var respErr *openbao.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return false
+}
+
+func isKVPathExists(err error) bool {
+	var respErr *openbao.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusBadRequest {
+		for _, e := range respErr.Errors {
+			if strings.Contains(e, fmt.Sprintf("path is already in use at %s/", kvSecretName)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func kvMountPath(tenantID string) string {
+	return fmt.Sprintf("%s/%s", tenantID, kvSecretName)
+}
+
+func kvPath(keyID, keyVersion string) string {
+	return fmt.Sprintf("%s/%s", keyID, keyVersion)
+}
+
+func kvSecretPath(tenantID string) string {
+	return tenantID + "/sys/mounts/" + kvSecretName
+}
+
+func namespacePath(tenantID string) string {
+	return "sys/namespaces/" + tenantID
 }

--- a/internal/vault/openbaovault/openbao_test.go
+++ b/internal/vault/openbaovault/openbao_test.go
@@ -221,6 +221,45 @@ func TestImportKey(t *testing.T) {
 		assert.NotNil(t, resp)
 	})
 
+	t.Run("should successfully import key for nil aad", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		// prepare tenant first
+		tResp, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID, Name: "Test Tenant"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp)
+
+		// when
+		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    tenantID,
+			KeyID:       keyID,
+			KeyVersion:  "1",
+			KeyMaterial: secretData,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("should fail to import key with nil key material", func(t *testing.T) {
+		// given
+		// when
+		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:   uuid.NewString(),
+			KeyID:      uuid.NewString(),
+			KeyVersion: "1",
+			AAD:        []byte{4, 3, 2, 1},
+		})
+
+		// then
+		require.Error(t, err)
+		assert.ErrorIs(t, err, vault.ErrInvalidRequest)
+		assert.Nil(t, resp)
+	})
+
 	t.Run("should be idempotent when importing the same key", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
@@ -334,6 +373,40 @@ func TestExportKey(t *testing.T) {
 		assert.NotNil(t, resp)
 		assert.Equal(t, secretData.SecureBytes(), resp.KeyMaterial.SecureBytes())
 		assert.Equal(t, []byte{4, 3, 2, 1}, resp.AAD)
+	})
+
+	t.Run("should successfully export key for nil aad", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		// prepare tenant first
+		tResp, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID, Name: "Test Tenant"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp)
+
+		// import key first
+		iResp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    tenantID,
+			KeyID:       keyID,
+			KeyVersion:  "1",
+			KeyMaterial: secretData,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, iResp)
+
+		// when
+		resp, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   tenantID,
+			KeyID:      keyID,
+			KeyVersion: "1",
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, secretData.SecureBytes(), resp.KeyMaterial.SecureBytes())
+		assert.Equal(t, []byte{}, resp.AAD)
 	})
 
 	t.Run("should fail to export key for non-prepared tenant", func(t *testing.T) {
@@ -455,7 +528,7 @@ func TestDestroyKey(t *testing.T) {
 		assert.Nil(t, eResp)
 	})
 
-	t.Run("should fail to destroy key version for non-prepared tenant", func(t *testing.T) {
+	t.Run("should not return error when destroying key version for non-prepared tenant", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
@@ -468,12 +541,11 @@ func TestDestroyKey(t *testing.T) {
 		})
 
 		// then
-		require.Error(t, err)
-		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
-		assert.Nil(t, resp)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
 	})
 
-	t.Run("should fail to destroy key version for non-existing key", func(t *testing.T) {
+	t.Run("should not return error when destroying key version for non-existing key", func(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
@@ -491,9 +563,8 @@ func TestDestroyKey(t *testing.T) {
 		})
 
 		// then
-		require.Error(t, err)
-		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
-		assert.Nil(t, resp)
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
 	})
 }
 
@@ -518,6 +589,181 @@ func TestInfo(t *testing.T) {
 		// then
 		assert.Equal(t, "test-client", info.Name)
 		assert.Equal(t, openbaovault.TypeOpenBao, info.Type)
+	})
+}
+
+func TestDestroyTenant(t *testing.T) {
+	// given
+	ctx := t.Context()
+
+	// start a container
+	port := startOpenBao(t)
+
+	cli, err := openbaovault.New(
+		"test-client",
+		func(c *openbao.Client) error {
+			c.SetToken(validToken)
+			return c.SetAddress("http://localhost:" + port)
+		},
+	)
+	require.NoError(t, err)
+
+	km, err := securemem.NewData("secret", 2)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := km.Destroy()
+		assert.NoError(t, err)
+	})
+
+	t.Run("should successfully destroy tenant with keys", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		kID := uuid.NewString()
+
+		// prepare tenant first
+		tResp, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID, Name: "Test Tenant"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp)
+
+		iResp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    tenantID,
+			KeyID:       kID,
+			KeyVersion:  "1",
+			KeyMaterial: km,
+			AAD:         []byte{},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, iResp)
+
+		// when
+		resp, err := cli.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: tenantID,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// verify that the tenant is destroyed
+		_, err = cli.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   tenantID,
+			KeyID:      kID,
+			KeyVersion: "1",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+	})
+
+	t.Run("should successfully destroy tenant with no keys", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+
+		// prepare tenant first
+		tResp, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID, Name: "Test Tenant"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp)
+
+		// when
+		resp, err := cli.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: tenantID,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("should be idempotent when destroying the same tenant", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+
+		// prepare tenant first
+		tResp, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID, Name: "Test Tenant"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp)
+
+		// when
+		resp, err := cli.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: tenantID,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// second call to destroy the same tenant
+		resp, err = cli.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: tenantID,
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("should not destroy other tenants when destroying a tenant", func(t *testing.T) {
+		// given
+		tenantID1 := uuid.NewString()
+		tenantID2 := uuid.NewString()
+		kID := uuid.NewString()
+
+		// prepare tenant 1
+		tResp1, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID1, Name: "Test Tenant 1"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp1)
+
+		// import a key for tenant 1
+		_, err = cli.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    tenantID1,
+			KeyID:       kID,
+			KeyVersion:  "1",
+			KeyMaterial: km,
+			AAD:         []byte{},
+		})
+		require.NoError(t, err)
+
+		// prepare tenant 2
+		tResp2, err := cli.PrepareTenant(ctx, vault.PrepareTenantRequest{TenantID: tenantID2, Name: "Test Tenant 2"})
+		require.NoError(t, err)
+		assert.NotNil(t, tResp2)
+
+		// import a key for tenant 2
+		_, err = cli.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    tenantID2,
+			KeyID:       kID,
+			KeyVersion:  "1",
+			KeyMaterial: km,
+			AAD:         []byte{},
+		})
+		require.NoError(t, err)
+
+		// when
+		resp, err := cli.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: tenantID1,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// verify that tenant 1 is destroyed
+		eRep, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   tenantID1,
+			KeyID:      kID,
+			KeyVersion: "1",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+		assert.Nil(t, eRep)
+
+		// verify that tenant 2 is still accessible
+		eRep, err = cli.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   tenantID2,
+			KeyID:      kID,
+			KeyVersion: "1",
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, eRep)
+		assert.Equal(t, km.SecureBytes(), eRep.KeyMaterial.SecureBytes())
 	})
 }
 

--- a/internal/vault/sqlitevault/unsafesqlite.go
+++ b/internal/vault/sqlitevault/unsafesqlite.go
@@ -81,6 +81,23 @@ func (u *Unsafe) migrate(ctx context.Context) error {
 	return err
 }
 
+// PrepareTenant creates a new tenant in the vault. In this unsafe implementation, it does nothing.
+func (u *Unsafe) PrepareTenant(ctx context.Context, req vault.PrepareTenantRequest) (*vault.PrepareTenantResponse, error) {
+	return &vault.PrepareTenantResponse{}, nil
+}
+
+// DestroyTenant removes all keys associated with the given tenant from the vault.
+func (u *Unsafe) DestroyTenant(ctx context.Context, req vault.DestroyTenantRequest) (*vault.DestroyTenantResponse, error) {
+	_, err := u.db.ExecContext(ctx,
+		"DELETE FROM keys WHERE tenant_id = ?",
+		req.TenantID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &vault.DestroyTenantResponse{}, nil
+}
+
 func (u *Unsafe) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
 	if req.KeyMaterial == nil {
 		return nil, vault.ErrInvalidRequest

--- a/internal/vault/sqlitevault/unsafesqlite.go
+++ b/internal/vault/sqlitevault/unsafesqlite.go
@@ -139,20 +139,12 @@ func (u *Unsafe) ExportKey(ctx context.Context, req vault.ExportKeyRequest) (*va
 }
 
 func (u *Unsafe) DestroyKey(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
-	result, err := u.db.ExecContext(ctx,
+	_, err := u.db.ExecContext(ctx,
 		"DELETE FROM keys WHERE tenant_id = ? AND key_id = ? AND key_version = ?",
 		req.TenantID, req.KeyID, req.KeyVersion,
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return nil, err
-	}
-	if affected == 0 {
-		return nil, vault.ErrKeyNotFound
 	}
 
 	return &vault.DestroyKeyResponse{}, nil

--- a/internal/vault/sqlitevault/unsafesqlite_test.go
+++ b/internal/vault/sqlitevault/unsafesqlite_test.go
@@ -360,3 +360,112 @@ func TestUnsafe_FileSourcePersistence(t *testing.T) {
 	assert.Equal(t, aad, resp.AAD)
 	_ = resp.KeyMaterial.Destroy()
 }
+
+func TestPrepareTenant(t *testing.T) {
+	// given
+	v := newTestUnsafeVault(t)
+	ctx := t.Context()
+
+	// when
+	resp, err := v.PrepareTenant(ctx, vault.PrepareTenantRequest{
+		TenantID: "tenant-1",
+		Name:     "Test Tenant",
+	})
+
+	// then
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestDestroyTenant(t *testing.T) {
+	// given
+	v := newTestUnsafeVault(t)
+	ctx := t.Context()
+
+	t.Run("destroy tenant with keys", func(t *testing.T) {
+		// given
+		_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    "tenant-1",
+			KeyID:       "key-1",
+			KeyVersion:  "1",
+			KeyMaterial: newTestSecureData(t, []byte("key-material")),
+		})
+		assert.NoError(t, err)
+
+		// when
+		resp, err := v.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: "tenant-1",
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// verify keys are deleted
+		exportResp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: "1",
+		})
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+		assert.Nil(t, exportResp)
+	})
+
+	t.Run("destroy tenant without keys", func(t *testing.T) {
+		// when
+		resp, err := v.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: "tenant-2",
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("should destroy only keys of the specified tenant", func(t *testing.T) {
+		// given
+		_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    "tenant-1",
+			KeyID:       "key-1",
+			KeyVersion:  "1",
+			KeyMaterial: newTestSecureData(t, []byte("key-material-1")),
+		})
+		assert.NoError(t, err)
+
+		_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
+			TenantID:    "tenant-2",
+			KeyID:       "key-2",
+			KeyVersion:  "1",
+			KeyMaterial: newTestSecureData(t, []byte("key-material-2")),
+		})
+		assert.NoError(t, err)
+
+		// when
+		resp, err := v.DestroyTenant(ctx, vault.DestroyTenantRequest{
+			TenantID: "tenant-1",
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// verify keys of tenant-1 are deleted
+		exportResp1, err := v.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   "tenant-1",
+			KeyID:      "key-1",
+			KeyVersion: "1",
+		})
+		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
+		assert.Nil(t, exportResp1)
+
+		// verify keys of tenant-2 still exist
+		exportResp2, err := v.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:   "tenant-2",
+			KeyID:      "key-2",
+			KeyVersion: "1",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("key-material-2"), []byte(exportResp2.KeyMaterial.SecureBytes()))
+		_ = exportResp2.KeyMaterial.Destroy()
+	})
+}

--- a/internal/vault/sqlitevault/unsafesqlite_test.go
+++ b/internal/vault/sqlitevault/unsafesqlite_test.go
@@ -275,22 +275,6 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	_ = resp.KeyMaterial.Destroy()
 }
 
-func TestUnsafe_DestroyKeyNotFound(t *testing.T) {
-	// given
-	v := newTestUnsafeVault(t)
-	ctx := t.Context()
-
-	// when
-	_, err := v.DestroyKey(ctx, vault.DestroyKeyRequest{
-		TenantID:   "tenant-1",
-		KeyID:      "key-1",
-		KeyVersion: "99",
-	})
-
-	// then
-	assert.ErrorIs(t, err, vault.ErrKeyNotFound)
-}
-
 func TestUnsafe_Info(t *testing.T) {
 	t.Run("memory source", func(t *testing.T) {
 		// given

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -18,9 +18,11 @@ var (
 
 // Vault provides secure storage and retrieval of versioned key material.
 type Vault interface {
+	PrepareTenant(ctx context.Context, req PrepareTenantRequest) (*PrepareTenantResponse, error)
 	ImportKey(ctx context.Context, req ImportKeyRequest) (*ImportKeyResponse, error)
 	ExportKey(ctx context.Context, req ExportKeyRequest) (*ExportKeyResponse, error)
 	DestroyKey(ctx context.Context, req DestroyKeyRequest) (*DestroyKeyResponse, error)
+	DestroyTenant(ctx context.Context, req DestroyTenantRequest) (*DestroyTenantResponse, error)
 	Info() Info
 }
 
@@ -85,4 +87,14 @@ type DestroyKeyResponse struct {
 type Info struct {
 	Name string
 	Type Type
+}
+
+// DestroyTenantRequest contains parameters for removing a tenant from the vault.
+type DestroyTenantRequest struct {
+	TenantID string
+}
+
+// DestroyTenantResponse holds the result of a tenant destruction operation.
+type DestroyTenantResponse struct {
+	// Empty for now, success indicated by nil error
 }


### PR DESCRIPTION
- Add DestroyTenant to Vault interface (OpenBao deletes namespace+KV mount, SQLite deletes all tenant keys)
- Make OpenBao DestroyKey idempotent (tolerate missing keys instead of erroring)
- Simplify PrepareTenant error handling with isKVPathExists helper
- Improve ExportKey memory safety using Reserve + defer Zero
- Add nil KeyMaterial guard to OpenBao ImportKey
