### PR TITLE
refactor: change KeyVersion type from int to string in cryptor requests

### DIFF
--- a/internal/cryptor/aes256gcm/aes256gcm_test.go
+++ b/internal/cryptor/aes256gcm/aes256gcm_test.go
@@ -22,7 +22,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 			},
@@ -43,7 +43,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret:     nil, // missing secret
 			Plaintext:  plainText,
 		}
@@ -62,7 +62,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: "unknown-algorithm", // unsupported algorithm
 				Data:      newSecretKey(t),
@@ -85,7 +85,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      nil, // missing secret
@@ -109,7 +109,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -140,7 +140,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret, // invalid key size
@@ -164,7 +164,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -193,7 +193,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -222,7 +222,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 			},
@@ -244,7 +244,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret:     nil,
 			Ciphertext: plainText,
 		}
@@ -265,7 +265,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		decResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -278,7 +278,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: "unknown-algorithm", // unsupported algorithm
 				Data:      secret,
@@ -301,7 +301,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      nil, // missing secret
@@ -329,7 +329,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret, // invalid key size
@@ -353,7 +353,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -389,7 +389,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -409,7 +409,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -437,7 +437,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -455,7 +455,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -480,7 +480,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secretKey,
@@ -498,7 +498,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secretKey,
@@ -522,7 +522,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret1,
@@ -539,7 +539,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret2,
@@ -561,7 +561,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -587,7 +587,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -609,7 +609,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -633,7 +633,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -655,7 +655,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
@@ -668,7 +668,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret: &cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -34,7 +34,7 @@ type EncryptRequest struct {
 	// KeyID is the unique identifier of the key.
 	KeyID string
 	// KeyVersion specifies which version of the key to use.
-	KeyVersion int
+	KeyVersion string
 	// Secret holds the key material for encryption. Nil when the Cryptor manages its own secrets.
 	Secret *Secret
 	// Plaintext is the data to encrypt.
@@ -57,7 +57,7 @@ type DecryptRequest struct {
 	// KeyID is the unique identifier of the key.
 	KeyID string
 	// KeyVersion specifies which version of the key to use.
-	KeyVersion int
+	KeyVersion string
 	// Secret holds the key material for decryption. Nil when the Cryptor manages its own secrets.
 	Secret *Secret
 	// Ciphertext is the data to decrypt.
@@ -124,7 +124,7 @@ func (req EncryptRequest) Validate() error {
 	if req.KeyID == "" {
 		return fmt.Errorf("invalid key ID: %w", ErrRequest)
 	}
-	if req.KeyVersion == 0 {
+	if req.KeyVersion == "" {
 		return fmt.Errorf("invalid key version: %w", ErrRequest)
 	}
 	if req.Plaintext == nil || len(req.Plaintext.SecureBytes()) == 0 {
@@ -140,7 +140,7 @@ func (req DecryptRequest) Validate() error {
 	if req.KeyID == "" {
 		return fmt.Errorf("invalid key ID: %w", ErrRequest)
 	}
-	if req.KeyVersion == 0 {
+	if req.KeyVersion == "" {
 		return fmt.Errorf("invalid key version: %w", ErrRequest)
 	}
 	if req.Ciphertext == nil || len(req.Ciphertext.SecureBytes()) == 0 {

--- a/internal/cryptor/cryptor_test.go
+++ b/internal/cryptor/cryptor_test.go
@@ -35,7 +35,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: validData,
 			},
 			wantErr: nil,
@@ -45,7 +45,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -55,11 +55,11 @@ func TestDecryptRequestValidate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "valid request with negative key version",
+			name: "valid request with non empty key version",
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: -1,
+				KeyVersion: "-1",
 				Ciphertext: validData,
 			},
 			wantErr: nil,
@@ -68,8 +68,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 			name: "missing tenant ID",
 			req: cryptor.DecryptRequest{
 				KeyID:      "key1",
-				KeyVersion: 1,
-				Ciphertext: &securemem.Data{},
+				KeyVersion: "1",
+				Ciphertext: validData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -77,8 +77,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 			name: "missing key ID",
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
-				KeyVersion: 1,
-				Ciphertext: &securemem.Data{},
+				KeyVersion: "1",
+				Ciphertext: validData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -87,8 +87,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 0,
-				Ciphertext: &securemem.Data{},
+				KeyVersion: "",
+				Ciphertext: validData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -97,7 +97,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -106,7 +106,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: destroyedData,
 			},
 			wantErr: cryptor.ErrRequest,
@@ -116,7 +116,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: &securemem.Data{},
 			},
 			wantErr: cryptor.ErrRequest,
@@ -126,7 +126,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: validData,
 				Secret: &cryptor.Secret{
 					Data: validData,
@@ -139,7 +139,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -153,7 +153,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -167,7 +167,7 @@ func TestDecryptRequestValidate(t *testing.T) {
 			req: cryptor.DecryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Ciphertext: validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -214,7 +214,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  validData,
 			},
 			wantErr: nil,
@@ -224,7 +224,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -234,11 +234,11 @@ func TestEncryptRequestValidate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "valid request with negative key version",
+			name: "valid request with non empty key version",
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: -1,
+				KeyVersion: "-1",
 				Plaintext:  validData,
 			},
 			wantErr: nil,
@@ -247,8 +247,8 @@ func TestEncryptRequestValidate(t *testing.T) {
 			name: "missing tenant ID",
 			req: cryptor.EncryptRequest{
 				KeyID:      "key1",
-				KeyVersion: 1,
-				Plaintext:  &securemem.Data{},
+				KeyVersion: "1",
+				Plaintext:  validData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -256,8 +256,8 @@ func TestEncryptRequestValidate(t *testing.T) {
 			name: "missing key ID",
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
-				KeyVersion: 1,
-				Plaintext:  &securemem.Data{},
+				KeyVersion: "1",
+				Plaintext:  validData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -266,8 +266,8 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 0,
-				Plaintext:  &securemem.Data{},
+				KeyVersion: "",
+				Plaintext:  validData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -276,7 +276,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 			},
 			wantErr: cryptor.ErrRequest,
 		},
@@ -285,7 +285,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  destroyedData,
 			},
 			wantErr: cryptor.ErrRequest,
@@ -295,7 +295,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  &securemem.Data{},
 			},
 			wantErr: cryptor.ErrRequest,
@@ -305,7 +305,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  validData,
 				Secret: &cryptor.Secret{
 					Data: validData,
@@ -318,7 +318,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -332,7 +332,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
@@ -346,7 +346,7 @@ func TestEncryptRequestValidate(t *testing.T) {
 			req: cryptor.EncryptRequest{
 				TenantID:   "tenant1",
 				KeyID:      "key1",
-				KeyVersion: 1,
+				KeyVersion: "1",
 				Plaintext:  validData,
 				Secret: &cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,

--- a/internal/cryptor/staticsecret/staticsecret_test.go
+++ b/internal/cryptor/staticsecret/staticsecret_test.go
@@ -85,7 +85,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  nil, // missing plaintext
 		}
 
@@ -104,7 +104,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 			Secret: &cryptor.Secret{
 				Data:      newSecretKey(t),
@@ -127,7 +127,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 			Secret:     &cryptor.Secret{},
 		}
@@ -147,7 +147,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 			Secret:     nil, // missing secret
 		}
@@ -168,7 +168,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		}
 
@@ -190,7 +190,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		}
 
@@ -214,7 +214,7 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		req := cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		}
 
@@ -239,7 +239,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: nil, // missing ciphertext
 		}
 
@@ -256,7 +256,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  newSecureMemData(t, []byte("ciphertext")),
 		})
 		require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 			Secret: &cryptor.Secret{
 				Data:      newSecretKey(t),
@@ -286,7 +286,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  newSecureMemData(t, []byte("ciphertext")),
 		})
 		require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 			Secret:     &cryptor.Secret{},
 		}
@@ -313,7 +313,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  newSecureMemData(t, []byte("ciphertext")),
 		})
 		require.NoError(t, err)
@@ -322,7 +322,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 			Secret:     nil, // missing secret
 		}
@@ -343,7 +343,7 @@ func TestStaticSecret_Decrypt(t *testing.T) {
 		req := cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: cipherText,
 		}
 
@@ -376,7 +376,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		})
 
@@ -392,7 +392,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 		})
 
@@ -415,7 +415,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 			AAD:        aad,
 		})
@@ -429,7 +429,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 			AAD:        aad,
 		})
@@ -449,7 +449,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 			AAD:        []byte("correct-aad"),
 		})
@@ -463,7 +463,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 			AAD:        []byte("wrong-aad"),
 		})
@@ -481,7 +481,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		})
 
@@ -497,7 +497,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj1.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 		})
 
@@ -514,7 +514,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		})
 
@@ -536,7 +536,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: tampered,
 		})
 
@@ -553,7 +553,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		})
 
@@ -573,7 +573,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: truncated,
 		})
 
@@ -590,7 +590,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Plaintext:  plainText,
 		})
 		require.NoError(t, err)
@@ -599,7 +599,7 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 		})
 		require.NoError(t, err)

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -125,7 +125,7 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
 			TenantID:   req.Key.TenantID,
 			KeyID:      req.Key.ID,
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret:     toCryptorSecret(sec),
 			Plaintext:  req.Secret,
 			AAD:        req.AAD,
@@ -159,7 +159,7 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
 			TenantID:   req.Key.TenantID,
 			KeyID:      req.Key.ID,
-			KeyVersion: 1,
+			KeyVersion: "1",
 			Secret:     toCryptorSecret(sec),
 			Ciphertext: req.WrappedSecret,
 			AAD:        req.AAD,
@@ -249,7 +249,7 @@ func (p *Processor) transportSeal(ctx context.Context, key model.Key, sec *secur
 	resp, err := p.transportSealer.Encrypt(ctx, cryptor.EncryptRequest{
 		TenantID:   key.TenantID,
 		KeyID:      key.ID,
-		KeyVersion: 1,
+		KeyVersion: "1",
 		Plaintext:  sec,
 		AAD:        aad,
 	})
@@ -266,7 +266,7 @@ func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Da
 	resp, err := p.transportSealer.Decrypt(ctx, cryptor.DecryptRequest{
 		TenantID:   key.TenantID,
 		KeyID:      key.ID,
-		KeyVersion: 1,
+		KeyVersion: "1",
 		Ciphertext: sec,
 		AAD:        aad,
 	})


### PR DESCRIPTION
IMHO we should also consider if we need `KeyVersion`, if we need then we should also add `KeyRevision`