### PR TITLE
feat: make key processor manager version aware

### DIFF
--- a/internal/keyprocessor/export_test.go
+++ b/internal/keyprocessor/export_test.go
@@ -21,7 +21,7 @@ func NewProcessor(generator cryptor.SecretGenerator, wrapper, transportSealer, p
 }
 
 func NewManager(s store.Key, kvs store.KeyVersion, processors map[model.KeyKind]Processor) *Manager {
-	return &Manager{store: s, keyVersionStore: kvs, processors: processors}
+	return &Manager{store: s, versionStore: kvs, processors: processors}
 }
 
 func (p *Processor) ResolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {

--- a/internal/keyprocessor/export_test.go
+++ b/internal/keyprocessor/export_test.go
@@ -20,10 +20,10 @@ func NewProcessor(generator cryptor.SecretGenerator, wrapper, transportSealer, p
 	}
 }
 
-func NewManager(s store.Key, processors map[model.KeyKind]Processor) *Manager {
-	return &Manager{store: s, processors: processors}
+func NewManager(s store.Key, kvs store.KeyVersion, processors map[model.KeyKind]Processor) *Manager {
+	return &Manager{store: s, keyVersionStore: kvs, processors: processors}
 }
 
-func (p *Processor) ResolveSecret(ctx context.Context, key model.Key) (*securemem.Data, error) {
-	return p.resolveSecret(ctx, key)
+func (p *Processor) ResolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
+	return p.resolveSecret(ctx, kv)
 }

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -10,23 +10,33 @@ import (
 	"github.com/openkcm/krypton/pkg/store"
 )
 
-// ErrProcessorNotFound is returned when no processor is registered for a key's kind.
-var ErrProcessorNotFound = errors.New("key processor could not be found")
+var (
+	// ErrProcessorNotFound is returned when no processor is registered for a key's kind.
+	ErrProcessorNotFound = errors.New("key processor could not be found")
+	// ErrNoUsableKeyVersion is returned when no usable key version can be resolved.
+	ErrNoUsableKeyVersion = errors.New("no usable key version found")
+)
 
 // TypeManager identifies the Manager cryptor type.
 const TypeManager cryptor.Type = "manager"
 
-// Manager encrypts and decrypts secrets by looking up the key and delegating
-// to the Processor registered for that key's kind.
+// Manager encrypts and decrypts secrets by resolving the appropriate KeyVersion
+// from the store and delegating to the Processor registered for that key's kind.
 type Manager struct {
-	store      store.Key
-	processors map[model.KeyKind]Processor
+	store        store.Key
+	versionStore store.KeyVersion
+	processors   map[model.KeyKind]Processor
 }
 
 var _ cryptor.Cryptor = &Manager{}
 
-// Encrypt looks up the key and delegates to the matching processor.
+// Encrypt resolves the key version and delegates to the matching processor.
 func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
 	if err != nil {
 		return nil, err
@@ -37,9 +47,9 @@ func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cr
 	}
 
 	resp, err := proc.WrapSecret(ctx, WrapSecretRequest{
-		Key:    *key,
-		Secret: req.Plaintext,
-		AAD:    req.AAD,
+		KeyVersion: kv,
+		Secret:     req.Plaintext,
+		AAD:        req.AAD,
 	})
 	if err != nil {
 		return nil, err
@@ -50,8 +60,13 @@ func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cr
 	}, nil
 }
 
-// Decrypt looks up the key and delegates to the matching processor.
+// Decrypt resolves the key version and delegates to the matching processor.
 func (km *Manager) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
+	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
+	if err != nil {
+		return nil, err
+	}
+
 	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
 	if err != nil {
 		return nil, err
@@ -62,7 +77,7 @@ func (km *Manager) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cr
 	}
 
 	resp, err := proc.UnwrapSecret(ctx, UnwrapSecretRequest{
-		Key:           *key,
+		KeyVersion:    kv,
 		WrappedSecret: req.Ciphertext,
 		AAD:           req.AAD,
 	})
@@ -82,4 +97,22 @@ func (km *Manager) Info() cryptor.Info {
 		Type:                     TypeManager,
 		DecryptionSecretRequired: true,
 	}
+}
+
+func (km *Manager) resolveUsableKeyVersion(ctx context.Context, tenantID, keyID, version string) (model.KeyVersion, error) {
+	result, err := km.versionStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+		TenantID:              tenantID,
+		KeyID:                 keyID,
+		Version:               version,
+		ProcessingState:       model.KeyVersionUsable,
+		IsOrderByRevisionDesc: true,
+		Limit:                 1,
+	})
+	if err != nil {
+		return model.KeyVersion{}, err
+	}
+	if len(result.KeyVersions) == 0 {
+		return model.KeyVersion{}, fmt.Errorf("%w: key %s version %s", ErrNoUsableKeyVersion, keyID, version)
+	}
+	return result.KeyVersions[0], nil
 }

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -17,25 +17,83 @@ import (
 )
 
 func TestManagerEncrypt(t *testing.T) {
+	t.Run("should return error if key version resolution fails", func(t *testing.T) {
+		// given
+		kvStoreErr := errors.New("database unavailable")
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, q store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			assert.Equal(t, keyID, q.KeyID)
+			assert.Equal(t, tenantID, q.TenantID)
+			return store.ListKeyVersionsResult{}, kvStoreErr
+		}
+		c := keyprocessor.NewManager(nil, kvs, nil)
+
+		// when
+		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+			TenantID:   tenantID,
+			KeyID:      keyID,
+			KeyVersion: "1",
+			Plaintext:  newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, kvStoreErr)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("should return error if no usable key version found", func(t *testing.T) {
+		// given
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			return store.ListKeyVersionsResult{KeyVersions: []model.KeyVersion{}}, nil
+		}
+		c := keyprocessor.NewManager(nil, kvs, nil)
+
+		// when
+		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+			TenantID:   tenantID,
+			KeyID:      keyID,
+			KeyVersion: "1",
+			Plaintext:  newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrNoUsableKeyVersion)
+		assert.Nil(t, resp)
+	})
+
 	t.Run("should return error if store lookup fails", func(t *testing.T) {
 		// given
 		storeErr := errors.New("database unavailable")
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			return store.ListKeyVersionsResult{
+				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+			}, nil
+		}
 		ks := &keyStoreWrapper{}
 		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
 			assert.Equal(t, keyID, id)
 			assert.Equal(t, tenantID, tid)
 			return nil, storeErr
 		}
-		c := keyprocessor.NewManager(ks, nil)
+		c := keyprocessor.NewManager(ks, kvs, nil)
 
 		// when
 		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
-			TenantID:  tenantID,
-			KeyID:     keyID,
-			Plaintext: newTestData(t, []byte("data")),
+			TenantID:   tenantID,
+			KeyID:      keyID,
+			KeyVersion: "1",
+			Plaintext:  newTestData(t, []byte("data")),
 		})
 
 		// then
@@ -51,19 +109,26 @@ func TestManagerEncrypt(t *testing.T) {
 			Kind:     "UNKNOWN_KIND",
 		}
 
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			return store.ListKeyVersionsResult{
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+			}, nil
+		}
 		ks := &keyStoreWrapper{}
 		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
 			assert.Equal(t, key.ID, id)
 			assert.Equal(t, key.TenantID, tid)
 			return key, nil
 		}
-		c := keyprocessor.NewManager(ks, map[model.KeyKind]keyprocessor.Processor{})
+		c := keyprocessor.NewManager(ks, kvs, map[model.KeyKind]keyprocessor.Processor{})
 
 		// when
 		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
-			TenantID:  key.TenantID,
-			KeyID:     key.ID,
-			Plaintext: newTestData(t, []byte("data")),
+			TenantID:   key.TenantID,
+			KeyID:      key.ID,
+			KeyVersion: "1",
+			Plaintext:  newTestData(t, []byte("data")),
 		})
 
 		// then
@@ -76,22 +141,28 @@ func TestManagerEncrypt(t *testing.T) {
 		db := createDatabase(t)
 		tenantID := createTenant(t, db)
 		keyStore := storesql.NewKeyStore(db)
+		kvStore := storesql.NewKeyVersionStore(db)
 
 		key := model.NewKey(tenantID, "enc-key-"+uuid.NewString(), "K0", nil, "test", nil)
 		require.NoError(t, keyStore.CreateKey(t.Context(), key))
 
+		kv := model.NewKeyVersion(tenantID, key.ID, "1", nil, nil)
+		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: kv})
+		require.NoError(t, err)
+
 		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err = proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
-		c := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
+		c := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
 
 		// when
 		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
-			TenantID:  tenantID,
-			KeyID:     key.ID,
-			Plaintext: newTestData(t, []byte("secret payload")),
-			AAD:       []byte("aad"),
+			TenantID:   tenantID,
+			KeyID:      key.ID,
+			KeyVersion: "1",
+			Plaintext:  newTestData(t, []byte("secret payload")),
+			AAD:        []byte("aad"),
 		})
 
 		// then
@@ -103,24 +174,58 @@ func TestManagerEncrypt(t *testing.T) {
 }
 
 func TestManagerDecrypt(t *testing.T) {
+	t.Run("should return error if key version resolution fails", func(t *testing.T) {
+		// given
+		kvStoreErr := errors.New("database unavailable")
+		tenantID := uuid.NewString()
+		keyID := uuid.NewString()
+
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, q store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			assert.Equal(t, keyID, q.KeyID)
+			assert.Equal(t, tenantID, q.TenantID)
+			return store.ListKeyVersionsResult{}, kvStoreErr
+		}
+		c := keyprocessor.NewManager(nil, kvs, nil)
+
+		// when
+		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+			TenantID:   tenantID,
+			KeyID:      keyID,
+			KeyVersion: "1",
+			Ciphertext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, kvStoreErr)
+		assert.Nil(t, resp)
+	})
+
 	t.Run("should return error if store lookup fails", func(t *testing.T) {
 		// given
 		storeErr := errors.New("database unavailable")
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			return store.ListKeyVersionsResult{
+				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+			}, nil
+		}
 		ks := &keyStoreWrapper{}
 		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
 			assert.Equal(t, keyID, id)
 			assert.Equal(t, tenantID, tid)
 			return nil, storeErr
 		}
-		c := keyprocessor.NewManager(ks, nil)
+		c := keyprocessor.NewManager(ks, kvs, nil)
 
 		// when
 		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
+			KeyVersion: "1",
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -137,18 +242,25 @@ func TestManagerDecrypt(t *testing.T) {
 			Kind:     "UNKNOWN_KIND",
 		}
 
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			return store.ListKeyVersionsResult{
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+			}, nil
+		}
 		ks := &keyStoreWrapper{}
 		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
 			assert.Equal(t, key.ID, id)
 			assert.Equal(t, key.TenantID, tid)
 			return key, nil
 		}
-		c := keyprocessor.NewManager(ks, map[model.KeyKind]keyprocessor.Processor{})
+		c := keyprocessor.NewManager(ks, kvs, map[model.KeyKind]keyprocessor.Processor{})
 
 		// when
 		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
+			KeyVersion: "1",
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -162,21 +274,27 @@ func TestManagerDecrypt(t *testing.T) {
 		db := createDatabase(t)
 		tenantID := createTenant(t, db)
 		keyStore := storesql.NewKeyStore(db)
+		kvStore := storesql.NewKeyVersionStore(db)
 
 		key := model.NewKey(tenantID, "dec-key-"+uuid.NewString(), "K0", nil, "test", nil)
 		require.NoError(t, keyStore.CreateKey(t.Context(), key))
 
+		kv := model.NewKeyVersion(tenantID, key.ID, "1", nil, nil)
+		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: kv})
+		require.NoError(t, err)
+
 		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err = proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
-		c := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
+		c := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
 
 		encResp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
-			TenantID:  tenantID,
-			KeyID:     key.ID,
-			Plaintext: newTestData(t, []byte("round trip data")),
-			AAD:       []byte("aad"),
+			TenantID:   tenantID,
+			KeyID:      key.ID,
+			KeyVersion: "1",
+			Plaintext:  newTestData(t, []byte("round trip data")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
@@ -184,6 +302,7 @@ func TestManagerDecrypt(t *testing.T) {
 		decResp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
+			KeyVersion: "1",
 			Ciphertext: encResp.Ciphertext,
 			AAD:        []byte("aad"),
 		})
@@ -198,7 +317,7 @@ func TestManagerDecrypt(t *testing.T) {
 func TestManagerInfo(t *testing.T) {
 	t.Run("should return manager info with decryption secret required", func(t *testing.T) {
 		// given
-		c := keyprocessor.NewManager(nil, nil)
+		c := keyprocessor.NewManager(nil, nil, nil)
 
 		// when
 		info := c.Info()
@@ -223,4 +342,17 @@ func (w *keyStoreWrapper) GetKeyByID(ctx context.Context, id, tenantID string) (
 		return w.getKeyByIDFn(ctx, id, tenantID)
 	}
 	return w.Key.GetKeyByID(ctx, id, tenantID)
+}
+
+type keyVersionStoreWrapper struct {
+	store.KeyVersion
+
+	listKeyVersionsFn func(context.Context, store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error)
+}
+
+func (w *keyVersionStoreWrapper) ListKeyVersions(ctx context.Context, q store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+	if w.listKeyVersionsFn != nil {
+		return w.listKeyVersionsFn(ctx, q)
+	}
+	return w.KeyVersion.ListKeyVersions(ctx, q)
 }

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -14,9 +14,9 @@ import (
 const persistSecName = "persistedSec"
 
 var (
-	// ErrMissingParentID is returned when a processor has a parent cryptor set
-	// but the key does not specify a parent ID.
-	ErrMissingParentID = errors.New("parent set but key has no parent ID")
+	// ErrMissingParentKeyVersion is returned when a processor has a parent cryptor set
+	// but the key version does not specify a parent key ID or parent key version.
+	ErrMissingParentKeyVersion = errors.New("parent set but key version has no parent key version")
 	// ErrSecNotPersisted is returned when a handler completes successfully
 	// but the secret is missing from the persistent vault, indicating a bug
 	ErrSecNotPersisted = errors.New("persisted secret missing from handler response")
@@ -34,8 +34,8 @@ type Processor struct {
 
 // CreateSecretRequest is the input for CreateSecret.
 type CreateSecretRequest struct {
-	Key model.Key
-	AAD []byte
+	KeyVersion model.KeyVersion
+	AAD        []byte
 }
 
 // CreateSecretResponse is the output of CreateSecret.
@@ -43,9 +43,9 @@ type CreateSecretResponse struct{}
 
 // WrapSecretRequest is the input for WrapSecret.
 type WrapSecretRequest struct {
-	Key    model.Key
-	Secret *securemem.Data
-	AAD    []byte
+	KeyVersion model.KeyVersion
+	Secret     *securemem.Data
+	AAD        []byte
 }
 
 // WrapSecretResponse is the output of WrapSecret.
@@ -55,7 +55,7 @@ type WrapSecretResponse struct {
 
 // UnwrapSecretRequest is the input for UnwrapSecret.
 type UnwrapSecretRequest struct {
-	Key           model.Key
+	KeyVersion    model.KeyVersion
 	WrappedSecret *securemem.Data
 	AAD           []byte
 }
@@ -67,7 +67,7 @@ type UnwrapSecretResponse struct {
 
 // DeleteSecretRequest is the input for DeleteSecret.
 type DeleteSecretRequest struct {
-	Key model.Key
+	KeyVersion model.KeyVersion
 }
 
 // DeleteSecretResponse is the output of DeleteSecret.
@@ -87,22 +87,23 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		}
 		defer destroySec(resp.Secret)
 
-		sealSec, err := p.transportSeal(ctx, req.Key, resp.Secret, req.AAD)
+		sealSec, err := p.transportSeal(ctx, req.KeyVersion, resp.Secret, req.AAD)
 		if err != nil {
 			return err
 		}
 		defer destroySec(sealSec)
 
-		wrapSec, err := p.parentWrap(ctx, req.Key, sealSec, req.AAD)
+		wrapSec, err := p.parentWrap(ctx, req.KeyVersion, sealSec, req.AAD)
 		if err != nil {
 			return err
 		}
 		defer destroySec(wrapSec)
 
 		_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
-			TenantID:    req.Key.TenantID,
-			KeyID:       req.Key.ID,
-			KeyVersion:  "1",
+			TenantID:    req.KeyVersion.TenantID,
+			KeyID:       req.KeyVersion.KeyID,
+			KeyVersion:  req.KeyVersion.Version,
+			KeyRevision: req.KeyVersion.Revision,
 			KeyMaterial: wrapSec,
 			AAD:         req.AAD,
 		})
@@ -116,16 +117,16 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 // When the wrapper manages its own decryption key, it encrypts directly without resolving.
 func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
-		sec, err := p.resolveSecret(ctx, req.Key)
+		sec, err := p.resolveSecret(ctx, req.KeyVersion)
 		if err != nil {
 			return err
 		}
 		defer destroySec(sec)
 
 		encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   req.Key.TenantID,
-			KeyID:      req.Key.ID,
-			KeyVersion: "1",
+			TenantID:   req.KeyVersion.TenantID,
+			KeyID:      req.KeyVersion.KeyID,
+			KeyVersion: req.KeyVersion.Version,
 			Secret:     toCryptorSecret(sec),
 			Plaintext:  req.Secret,
 			AAD:        req.AAD,
@@ -150,16 +151,16 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 // When the wrapper manages its own decryption key, it decrypts directly without resolving.
 func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
-		sec, err := p.resolveSecret(ctx, req.Key)
+		sec, err := p.resolveSecret(ctx, req.KeyVersion)
 		if err != nil {
 			return err
 		}
 		defer destroySec(sec)
 
 		decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   req.Key.TenantID,
-			KeyID:      req.Key.ID,
-			KeyVersion: "1",
+			TenantID:   req.KeyVersion.TenantID,
+			KeyID:      req.KeyVersion.KeyID,
+			KeyVersion: req.KeyVersion.Version,
 			Secret:     toCryptorSecret(sec),
 			Ciphertext: req.WrappedSecret,
 			AAD:        req.AAD,
@@ -188,9 +189,10 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 	}
 
 	_, err := p.vault.DestroyKey(ctx, vault.DestroyKeyRequest{
-		TenantID:   req.Key.TenantID,
-		KeyID:      req.Key.ID,
-		KeyVersion: "1",
+		TenantID:    req.KeyVersion.TenantID,
+		KeyID:       req.KeyVersion.KeyID,
+		KeyVersion:  req.KeyVersion.Version,
+		KeyRevision: req.KeyVersion.Revision,
 	})
 	if err != nil {
 		return DeleteSecretResponse{}, err
@@ -199,29 +201,30 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 	return DeleteSecretResponse{}, nil
 }
 
-func (p *Processor) resolveSecret(ctx context.Context, key model.Key) (*securemem.Data, error) {
+func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
 	if !p.wrapper.Info().DecryptionSecretRequired {
 		return nil, nil //nolint:nilnil
 	}
 
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
 		exported, err := p.vault.ExportKey(ctx, vault.ExportKeyRequest{
-			TenantID:   key.TenantID,
-			KeyID:      key.ID,
-			KeyVersion: "1",
+			TenantID:    kv.TenantID,
+			KeyID:       kv.KeyID,
+			KeyVersion:  kv.Version,
+			KeyRevision: kv.Revision,
 		})
 		if err != nil {
 			return err
 		}
 		defer destroySec(exported.KeyMaterial)
 
-		unwrapSec, err := p.parentUnwrap(ctx, key, exported.KeyMaterial, exported.AAD)
+		unwrapSec, err := p.parentUnwrap(ctx, kv, exported.KeyMaterial, exported.AAD)
 		if err != nil {
 			return err
 		}
 		defer destroySec(unwrapSec)
 
-		unsealSec, err := p.unseal(ctx, key, unwrapSec, exported.AAD)
+		unsealSec, err := p.unseal(ctx, kv, unwrapSec, exported.AAD)
 		if err != nil {
 			return err
 		}
@@ -242,14 +245,14 @@ func (p *Processor) resolveSecret(ctx context.Context, key model.Key) (*secureme
 	return getPersistedSec(resp)
 }
 
-func (p *Processor) transportSeal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
 	resp, err := p.transportSealer.Encrypt(ctx, cryptor.EncryptRequest{
-		TenantID:   key.TenantID,
-		KeyID:      key.ID,
-		KeyVersion: "1",
+		TenantID:   kv.TenantID,
+		KeyID:      kv.KeyID,
+		KeyVersion: kv.Version,
 		Plaintext:  sec,
 		AAD:        aad,
 	})
@@ -259,14 +262,14 @@ func (p *Processor) transportSeal(ctx context.Context, key model.Key, sec *secur
 	return resp.Ciphertext, nil
 }
 
-func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) unseal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
 	resp, err := p.transportSealer.Decrypt(ctx, cryptor.DecryptRequest{
-		TenantID:   key.TenantID,
-		KeyID:      key.ID,
-		KeyVersion: "1",
+		TenantID:   kv.TenantID,
+		KeyID:      kv.KeyID,
+		KeyVersion: kv.Version,
 		Ciphertext: sec,
 		AAD:        aad,
 	})
@@ -276,18 +279,19 @@ func (p *Processor) unseal(ctx context.Context, key model.Key, sec *securemem.Da
 	return resp.Plaintext, nil
 }
 
-func (p *Processor) parentWrap(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.parent == nil {
 		return sec, nil
 	}
-	if key.ParentID == nil {
-		return nil, ErrMissingParentID
+	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
+		return nil, ErrMissingParentKeyVersion
 	}
 	resp, err := p.parent.Encrypt(ctx, cryptor.EncryptRequest{
-		TenantID:  key.TenantID,
-		KeyID:     *key.ParentID,
-		Plaintext: sec,
-		AAD:       aad,
+		TenantID:   kv.TenantID,
+		KeyID:      *kv.ParentKeyID,
+		KeyVersion: *kv.ParentKeyVersion,
+		Plaintext:  sec,
+		AAD:        aad,
 	})
 	if err != nil {
 		return nil, err
@@ -295,16 +299,17 @@ func (p *Processor) parentWrap(ctx context.Context, key model.Key, sec *secureme
 	return resp.Ciphertext, nil
 }
 
-func (p *Processor) parentUnwrap(ctx context.Context, key model.Key, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) parentUnwrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.parent == nil {
 		return sec, nil
 	}
-	if key.ParentID == nil {
-		return nil, ErrMissingParentID
+	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
+		return nil, ErrMissingParentKeyVersion
 	}
 	resp, err := p.parent.Decrypt(ctx, cryptor.DecryptRequest{
-		TenantID:   key.TenantID,
-		KeyID:      *key.ParentID,
+		TenantID:   kv.TenantID,
+		KeyID:      *kv.ParentKeyID,
+		KeyVersion: *kv.ParentKeyVersion,
 		Ciphertext: sec,
 		AAD:        aad,
 	})

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -18,8 +18,47 @@ import (
 	"github.com/openkcm/krypton/internal/vault"
 	"github.com/openkcm/krypton/internal/vault/sqlitevault"
 	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
 	storesql "github.com/openkcm/krypton/pkg/store/sql"
 )
+
+type parentSetup struct {
+	tenantID  string
+	parentKey model.Key
+	parentKV  model.KeyVersion
+	manager   *keyprocessor.Manager
+	vault     *vaultWrapper // exposed for error injection in tests
+}
+
+func setupParent(t *testing.T) *parentSetup {
+	t.Helper()
+	db := createDatabase(t)
+	tenantID := createTenant(t, db)
+	keyStore := storesql.NewKeyStore(db)
+	kvStore := storesql.NewKeyVersionStore(db)
+
+	parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
+	require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+
+	parentKV := model.NewKeyVersion(tenantID, parentKey.ID, "1", nil, nil)
+	_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: parentKV})
+	require.NoError(t, err)
+
+	v := &vaultWrapper{Vault: newTestVault(t)}
+	parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+	_, err = parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: parentKV})
+	require.NoError(t, err)
+
+	mgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
+
+	return &parentSetup{
+		tenantID:  tenantID,
+		parentKey: parentKey,
+		parentKV:  parentKV,
+		manager:   mgr,
+		vault:     v,
+	}
+}
 
 func TestCreateSecret(t *testing.T) {
 	t.Run("should not create if wrapper manages its own decryption key", func(t *testing.T) {
@@ -28,7 +67,7 @@ func TestCreateSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
 		})
 
 		// then
@@ -48,7 +87,7 @@ func TestCreateSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
 		})
 
 		// then
@@ -83,7 +122,7 @@ func TestCreateSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: model.Key{TenantID: tenantID, ID: keyID},
+			KeyVersion: model.NewKeyVersion(tenantID, keyID, "1", nil, nil),
 		})
 
 		// then
@@ -95,13 +134,10 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should return error if parent wrapping fails", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent vault down")
-
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+		ps := setupParent(t)
+		ps.vault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			return nil, parentErr
+		}
 
 		var genSec *securemem.Data
 		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
@@ -113,21 +149,12 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentVault.exportKeyFn = func(_ context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, parentKey.ID, req.KeyID)
-			return nil, parentErr
-		}
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, parent, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.manager, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: childKey,
+			KeyVersion: childKV,
 		})
 
 		// then
@@ -139,13 +166,10 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should return error if parent wrapping fails after sealing", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent vault down")
-
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+		ps := setupParent(t)
+		ps.vault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+			return nil, parentErr
+		}
 
 		var genSec *securemem.Data
 		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
@@ -156,13 +180,6 @@ func TestCreateSecret(t *testing.T) {
 			}
 			return resp, err
 		}
-
-		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentVault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, parentErr
-		}
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
 
 		realSealer := newStaticSecretCryptor(t)
 		var sealedSec *securemem.Data
@@ -175,12 +192,12 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, parent, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, ps.manager, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: childKey,
+			KeyVersion: childKV,
 		})
 
 		// then
@@ -194,13 +211,7 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should return error if vault import fails", func(t *testing.T) {
 		// given
 		importErr := errors.New("disk full")
-
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+		ps := setupParent(t)
 
 		var genSec *securemem.Data
 		gen := &secretGenWrapper{SecretGenerator: newTestSecretGen()}
@@ -212,23 +223,19 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		childKeyID := uuid.NewString()
+		childKV := model.NewKeyVersion(ps.tenantID, childKeyID, "1", &ps.parentKey.ID, &ps.parentKV.Version)
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		v.importKeyFn = func(_ context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
-			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, childKey.ID, req.KeyID)
+			assert.Equal(t, ps.tenantID, req.TenantID)
+			assert.Equal(t, childKeyID, req.KeyID)
 			return nil, importErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, parent, v)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.manager, v)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: childKey,
+			KeyVersion: childKV,
 		})
 
 		// then
@@ -237,31 +244,19 @@ func TestCreateSecret(t *testing.T) {
 		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should return error if parent set but key has no parent ID", func(t *testing.T) {
+	t.Run("should return error if parent set but key version has no parent key version", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		// Key without ParentID but processor has a parent
-		orphanKey := model.Key{TenantID: tenantID, ID: uuid.NewString()}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		ps := setupParent(t)
+		orphanKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", nil, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: orphanKey,
+			KeyVersion: orphanKV,
 		})
 
 		// then
-		assert.ErrorIs(t, err, keyprocessor.ErrMissingParentID)
+		assert.ErrorIs(t, err, keyprocessor.ErrMissingParentKeyVersion)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
@@ -271,7 +266,7 @@ func TestCreateSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
 		})
 
 		// then
@@ -281,24 +276,13 @@ func TestCreateSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: childKey,
+			KeyVersion: childKV,
 		})
 
 		// then
@@ -308,24 +292,13 @@ func TestCreateSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: childKey,
+			KeyVersion: childKV,
 		})
 
 		// then
@@ -340,7 +313,7 @@ func TestResolveSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()})
+		sec, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil))
 
 		// then
 		assert.NoError(t, err)
@@ -352,7 +325,7 @@ func TestResolveSecret(t *testing.T) {
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()})
+		resp, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil))
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -365,11 +338,11 @@ func TestResolveSecret(t *testing.T) {
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		key := model.Key{TenantID: tenantID, ID: keyID}
+		kv := model.NewKeyVersion(tenantID, keyID, "1", nil, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		v.exportKeyFn = func(_ context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
@@ -379,7 +352,7 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), key)
+		resp, err := processor.ResolveSecret(t.Context(), kv)
 
 		// then
 		assert.ErrorIs(t, err, exportErr)
@@ -389,24 +362,12 @@ func TestResolveSecret(t *testing.T) {
 	t.Run("should return error if parent unwrap fails", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent unavailable")
+		ps := setupParent(t)
 
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, v)
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, v)
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -417,14 +378,12 @@ func TestResolveSecret(t *testing.T) {
 			}
 			return resp, err
 		}
-		parentVault.exportKeyFn = func(_ context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			assert.Equal(t, tenantID, req.TenantID)
-			assert.Equal(t, parentKey.ID, req.KeyID)
+		ps.vault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			return nil, parentErr
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), childKey)
+		resp, err := processor.ResolveSecret(t.Context(), childKV)
 
 		// then
 		assert.ErrorIs(t, err, parentErr)
@@ -437,9 +396,7 @@ func TestResolveSecret(t *testing.T) {
 		// given
 		unsealErr := errors.New("unsealing failed")
 
-		tenantID := uuid.NewString()
-		keyID := uuid.NewString()
-		key := model.Key{TenantID: tenantID, ID: keyID}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		realSealer := newStaticSecretCryptor(t)
 		sealer := &cryptorWrapper{Cryptor: realSealer}
@@ -449,7 +406,7 @@ func TestResolveSecret(t *testing.T) {
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), sealer, nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -462,7 +419,7 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), key)
+		resp, err := processor.ResolveSecret(t.Context(), kv)
 
 		// then
 		assert.ErrorIs(t, err, unsealErr)
@@ -473,14 +430,14 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), key)
+		sec, err := processor.ResolveSecret(t.Context(), kv)
 
 		// then
 		assert.NoError(t, err)
@@ -490,25 +447,14 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), childKey)
+		sec, err := processor.ResolveSecret(t.Context(), childKV)
 
 		// then
 		assert.NoError(t, err)
@@ -518,25 +464,14 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), childKey)
+		sec, err := processor.ResolveSecret(t.Context(), childKV)
 
 		// then
 		assert.NoError(t, err)
@@ -552,8 +487,8 @@ func TestWrapSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
-			Secret: newTestData(t, []byte("data")),
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
+			Secret:     newTestData(t, []byte("data")),
 		})
 
 		// then
@@ -563,11 +498,11 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should return error if encryption fails", func(t *testing.T) {
 		// given
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -581,8 +516,8 @@ func TestWrapSecret(t *testing.T) {
 
 		// when — nil plaintext is rejected by aes256gcm
 		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    key,
-			Secret: nil,
+			KeyVersion: kv,
+			Secret:     nil,
 		})
 
 		// then
@@ -594,17 +529,17 @@ func TestWrapSecret(t *testing.T) {
 	t.Run("should wrap without resolving if wrapper manages its own decryption key", func(t *testing.T) {
 		// given
 		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    key,
-			Secret: newTestData(t, []byte("data")),
+			KeyVersion: kv,
+			Secret:     newTestData(t, []byte("data")),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           key,
+			KeyVersion:    kv,
 			WrappedSecret: wrapResp.WrappedSecret,
 		})
 
@@ -615,11 +550,11 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		var exportSec *securemem.Data
@@ -633,14 +568,14 @@ func TestWrapSecret(t *testing.T) {
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    key,
-			Secret: newTestData(t, []byte("payload")),
-			AAD:    []byte("aad"),
+			KeyVersion: kv,
+			Secret:     newTestData(t, []byte("payload")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           key,
+			KeyVersion:    kv,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -654,33 +589,22 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    childKey,
-			Secret: newTestData(t, []byte("payload")),
-			AAD:    []byte("aad"),
+			KeyVersion: childKV,
+			Secret:     newTestData(t, []byte("payload")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           childKey,
+			KeyVersion:    childKV,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -692,33 +616,22 @@ func TestWrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    childKey,
-			Secret: newTestData(t, []byte("payload")),
-			AAD:    []byte("aad"),
+			KeyVersion: childKV,
+			Secret:     newTestData(t, []byte("payload")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           childKey,
+			KeyVersion:    childKV,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -736,7 +649,7 @@ func TestUnwrapSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+			KeyVersion:    model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
 			WrappedSecret: newTestData(t, []byte("ciphertext")),
 		})
 
@@ -747,15 +660,15 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should return error if decryption fails with tampered ciphertext", func(t *testing.T) {
 		// given
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    key,
-			Secret: newTestData(t, []byte("data")),
+			KeyVersion: kv,
+			Secret:     newTestData(t, []byte("data")),
 		})
 		assert.NoError(t, err)
 
@@ -766,7 +679,7 @@ func TestUnwrapSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           key,
+			KeyVersion:    kv,
 			WrappedSecret: newTestData(t, tampered),
 		})
 
@@ -777,25 +690,25 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should return error if decryption fails with wrong AAD", func(t *testing.T) {
 		// given
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			Key: key,
-			AAD: []byte("create-aad"),
+			KeyVersion: kv,
+			AAD:        []byte("create-aad"),
 		})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    key,
-			Secret: newTestData(t, []byte("data")),
-			AAD:    []byte("wrap-aad"),
+			KeyVersion: kv,
+			Secret:     newTestData(t, []byte("data")),
+			AAD:        []byte("wrap-aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           key,
+			KeyVersion:    kv,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("wrong-aad"),
 		})
@@ -807,22 +720,22 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer", func(t *testing.T) {
 		// given
-		key := model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()}
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
 
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    key,
-			Secret: newTestData(t, []byte("payload")),
-			AAD:    []byte("aad"),
+			KeyVersion: kv,
+			Secret:     newTestData(t, []byte("payload")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           key,
+			KeyVersion:    kv,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -834,33 +747,22 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    childKey,
-			Secret: newTestData(t, []byte("payload")),
-			AAD:    []byte("aad"),
+			KeyVersion: childKV,
+			Secret:     newTestData(t, []byte("payload")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           childKey,
+			KeyVersion:    childKV,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -872,33 +774,22 @@ func TestUnwrapSecret(t *testing.T) {
 
 	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), parent, newTestVault(t))
-		_, err = processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    childKey,
-			Secret: newTestData(t, []byte("payload")),
-			AAD:    []byte("aad"),
+			KeyVersion: childKV,
+			Secret:     newTestData(t, []byte("payload")),
+			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
 		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           childKey,
+			KeyVersion:    childKV,
 			WrappedSecret: wrapResp.WrappedSecret,
 			AAD:           []byte("aad"),
 		})
@@ -923,7 +814,7 @@ func TestDeleteSecret(t *testing.T) {
 
 		// when
 		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
-			Key: model.Key{TenantID: uuid.NewString(), ID: uuid.NewString()},
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
 		})
 
 		// then
@@ -938,11 +829,11 @@ func TestDeleteSecret(t *testing.T) {
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		key := model.Key{TenantID: tenantID, ID: keyID}
+		kv := model.NewKeyVersion(tenantID, keyID, "1", nil, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		v.destroyKeyFn = func(_ context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
@@ -952,7 +843,7 @@ func TestDeleteSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{Key: key})
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{KeyVersion: kv})
 
 		// then
 		assert.ErrorIs(t, err, destroyErr)
@@ -963,11 +854,11 @@ func TestDeleteSecret(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		key := model.Key{TenantID: tenantID, ID: keyID}
+		kv := model.NewKeyVersion(tenantID, keyID, "1", nil, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: key})
+		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		v.destroyKeyFn = func(ctx context.Context, req vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
@@ -977,7 +868,7 @@ func TestDeleteSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{Key: key})
+		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{KeyVersion: kv})
 
 		// then
 		assert.NoError(t, err)
@@ -988,32 +879,21 @@ func TestDeleteSecret(t *testing.T) {
 func TestHierarchy(t *testing.T) {
 	t.Run("should succeed for two-level chain round trip", func(t *testing.T) {
 		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
-		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		ps := setupParent(t)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		_, err := child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    childKey,
-			Secret: newTestData(t, []byte("classified")),
+			KeyVersion: childKV,
+			Secret:     newTestData(t, []byte("classified")),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := child.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           childKey,
+			KeyVersion:    childKV,
 			WrappedSecret: wrapResp.WrappedSecret,
 		})
 
@@ -1027,36 +907,44 @@ func TestHierarchy(t *testing.T) {
 		db := createDatabase(t)
 		tenantID := createTenant(t, db)
 		keyStore := storesql.NewKeyStore(db)
+		kvStore := storesql.NewKeyVersionStore(db)
 
 		rootKey := model.NewKey(tenantID, "root-"+uuid.NewString(), "K0", nil, "test", nil)
 		require.NoError(t, keyStore.CreateKey(t.Context(), rootKey))
+		rootKV := model.NewKeyVersion(tenantID, rootKey.ID, "1", nil, nil)
+		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: rootKV})
+		require.NoError(t, err)
 
 		rootProc := keyprocessor.NewProcessor(newTestSecretGen(), newStaticSecretCryptor(t), nil, nil, newTestVault(t))
-		_, err := rootProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: rootKey})
+		_, err = rootProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: rootKV})
 		assert.NoError(t, err)
-		rootCryptor := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{rootKey.Kind: *rootProc})
+		rootMgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{rootKey.Kind: *rootProc})
 
 		midKey := model.NewKey(tenantID, "mid-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
 		require.NoError(t, keyStore.CreateKey(t.Context(), midKey))
-		midProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), rootCryptor, newTestVault(t))
-		_, err = midProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: midKey})
-		assert.NoError(t, err)
-		midCryptor := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{midKey.Kind: *midProc})
+		midKV := model.NewKeyVersion(tenantID, midKey.ID, "1", &rootKey.ID, &rootKV.Version)
+		_, err = kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: midKV})
+		require.NoError(t, err)
 
-		leafKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &midKey.ID, Kind: "K2"}
-		leafProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, midCryptor, newTestVault(t))
-		_, err = leafProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: leafKey})
+		midProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), rootMgr, newTestVault(t))
+		_, err = midProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: midKV})
+		assert.NoError(t, err)
+		midMgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{midKey.Kind: *midProc})
+
+		leafKV := model.NewKeyVersion(tenantID, uuid.NewString(), "1", &midKey.ID, &midKV.Version)
+		leafProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, midMgr, newTestVault(t))
+		_, err = leafProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: leafKV})
 		assert.NoError(t, err)
 
 		// when
 		wrapResp, err := leafProc.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    leafKey,
-			Secret: newTestData(t, []byte("top secret")),
+			KeyVersion: leafKV,
+			Secret:     newTestData(t, []byte("top secret")),
 		})
 		assert.NoError(t, err)
 
 		unwrapResp, err := leafProc.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			Key:           leafKey,
+			KeyVersion:    leafKV,
 			WrappedSecret: wrapResp.WrappedSecret,
 		})
 
@@ -1068,33 +956,21 @@ func TestHierarchy(t *testing.T) {
 	t.Run("should return error if parent vault fails during child resolve", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent compromised")
+		ps := setupParent(t)
 
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-
-		parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
-
-		parentVault := &vaultWrapper{Vault: newTestVault(t)}
-		parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, parentVault)
-		_, err := parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: parentKey})
-		assert.NoError(t, err)
-		parent := keyprocessor.NewManager(keyStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
-
-		childKey := model.Key{TenantID: tenantID, ID: uuid.NewString(), ParentID: &parentKey.ID}
-		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, parent, newTestVault(t))
-		_, err = child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{Key: childKey})
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		_, err := child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
-		parentVault.exportKeyFn = func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
+		ps.vault.exportKeyFn = func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
 			return nil, parentErr
 		}
 
 		// when
 		resp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			Key:    childKey,
-			Secret: newTestData(t, []byte("data")),
+			KeyVersion: childKV,
+			Secret:     newTestData(t, []byte("data")),
 		})
 
 		// then

--- a/pkg/model/keyversion.go
+++ b/pkg/model/keyversion.go
@@ -25,3 +25,19 @@ type KeyVersion struct {
 	CreatedAt        clock.UnixNano            `json:"created_at"`
 	UpdatedAt        clock.UnixNano            `json:"updated_at"`
 }
+
+func NewKeyVersion(tenantID, keyID, version string, parentKeyID, parentKeyVersion *string) KeyVersion {
+	now := clock.Now()
+	return KeyVersion{
+		TenantID:         tenantID,
+		KeyID:            keyID,
+		Version:          version,
+		Revision:         0,
+		ParentKeyID:      parentKeyID,
+		ParentKeyVersion: parentKeyVersion,
+		LifeCycleState:   KeyLifeCycleActive,
+		ProcessingState:  KeyVersionUsable,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   make key processor manager version aware

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
Introduce key versioning to the key processor by replacing `model.Key` with `model.KeyVersion` in all processor request types and adding version-aware resolution in the Manager, which now resolves the highest usable revision from the store before dispatching to processors
