### PR TITLE
Proposal: split up the Cryptor interface

### DIFF
--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -29,12 +29,6 @@ type Secret struct {
 
 // EncryptRequest contains parameters for an encryption operation.
 type EncryptRequest struct {
-	// TenantID identifies the tenant owning the key.
-	TenantID string
-	// KeyID is the unique identifier of the key.
-	KeyID string
-	// KeyVersion specifies which version of the key to use.
-	KeyVersion string
 	// Secret holds the key material for encryption. Nil when the Cryptor manages its own secrets.
 	Secret *Secret
 	// Plaintext is the data to encrypt.
@@ -52,12 +46,6 @@ type EncryptResponse struct {
 
 // DecryptRequest contains parameters for a decryption operation.
 type DecryptRequest struct {
-	// TenantID identifies the tenant owning the key.
-	TenantID string
-	// KeyID is the unique identifier of the key.
-	KeyID string
-	// KeyVersion specifies which version of the key to use.
-	KeyVersion string
 	// Secret holds the key material for decryption. Nil when the Cryptor manages its own secrets.
 	Secret *Secret
 	// Ciphertext is the data to decrypt.
@@ -118,15 +106,6 @@ var (
 )
 
 func (req EncryptRequest) Validate() error {
-	if req.TenantID == "" {
-		return fmt.Errorf("invalid tenant ID: %w", ErrRequest)
-	}
-	if req.KeyID == "" {
-		return fmt.Errorf("invalid key ID: %w", ErrRequest)
-	}
-	if req.KeyVersion == "" {
-		return fmt.Errorf("invalid key version: %w", ErrRequest)
-	}
 	if req.Plaintext == nil || len(req.Plaintext.SecureBytes()) == 0 {
 		return fmt.Errorf("invalid plaintext: %w", ErrRequest)
 	}
@@ -134,15 +113,6 @@ func (req EncryptRequest) Validate() error {
 }
 
 func (req DecryptRequest) Validate() error {
-	if req.TenantID == "" {
-		return fmt.Errorf("invalid tenant ID: %w", ErrRequest)
-	}
-	if req.KeyID == "" {
-		return fmt.Errorf("invalid key ID: %w", ErrRequest)
-	}
-	if req.KeyVersion == "" {
-		return fmt.Errorf("invalid key version: %w", ErrRequest)
-	}
 	if req.Ciphertext == nil || len(req.Ciphertext.SecureBytes()) == 0 {
 		return fmt.Errorf("invalid ciphertext: %w", ErrRequest)
 	}

--- a/internal/cryptor/sealer.go
+++ b/internal/cryptor/sealer.go
@@ -1,0 +1,81 @@
+package cryptor
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+type SealRequest struct {
+	Plaintext *securemem.Data
+	AAD       []byte
+}
+
+type SealResponse struct {
+	Ciphertext *securemem.Data
+}
+
+type UnsealRequest struct {
+	Ciphertext *securemem.Data
+	AAD        []byte
+}
+
+type UnsealResponse struct {
+	Plaintext *securemem.Data
+}
+
+// Sealer encrypts and decrypts with a self-managed key bound to a trust anchor.
+// No external secret is provided; the key material is intrinsic to the implementation.
+type Sealer interface {
+	Seal(ctx context.Context, req SealRequest) (*SealResponse, error)
+	Unseal(ctx context.Context, req UnsealRequest) (*UnsealResponse, error)
+	Info() Info
+}
+
+// ErrUnexpectedSecret is returned when a RootSealerAdapter receives a non-nil Secret,
+// indicating a wiring bug in the processor configuration.
+var ErrUnexpectedSecret = errors.New("root sealer adapter received unexpected secret")
+
+// RootSealerAdapter adapts a Sealer to the Cryptor interface for root keys
+// that use a non-Krypton trust anchor. This is a special case for root
+// processors only, not intended for other positions in the hierarchy.
+type RootSealerAdapter struct {
+	sealer Sealer
+}
+
+func NewRootSealerAdapter(s Sealer) *RootSealerAdapter {
+	return &RootSealerAdapter{sealer: s}
+}
+
+func (a *RootSealerAdapter) Encrypt(ctx context.Context, req EncryptRequest) (*EncryptResponse, error) {
+	if req.Secret != nil {
+		return nil, ErrUnexpectedSecret
+	}
+	resp, err := a.sealer.Seal(ctx, SealRequest{
+		Plaintext: req.Plaintext,
+		AAD:       req.AAD,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &EncryptResponse{Ciphertext: resp.Ciphertext}, nil
+}
+
+func (a *RootSealerAdapter) Decrypt(ctx context.Context, req DecryptRequest) (*DecryptResponse, error) {
+	if req.Secret != nil {
+		return nil, ErrUnexpectedSecret
+	}
+	resp, err := a.sealer.Unseal(ctx, UnsealRequest{
+		Ciphertext: req.Ciphertext,
+		AAD:        req.AAD,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &DecryptResponse{Plaintext: resp.Plaintext}, nil
+}
+
+func (a *RootSealerAdapter) Info() Info {
+	return a.sealer.Info()
+}

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
 )
@@ -17,10 +16,7 @@ var (
 	ErrNoUsableKeyVersion = errors.New("no usable key version found")
 )
 
-// TypeManager identifies the Manager cryptor type.
-const TypeManager cryptor.Type = "manager"
-
-// Manager encrypts and decrypts secrets by resolving the appropriate KeyVersion
+// Manager wraps and unwraps secrets by resolving the appropriate KeyVersion
 // from the store and delegating to the Processor registered for that key's kind.
 type Manager struct {
 	store        store.Key
@@ -28,10 +24,10 @@ type Manager struct {
 	processors   map[model.KeyKind]Processor
 }
 
-var _ cryptor.Cryptor = &Manager{}
+var _ SecretWrapper = &Manager{}
 
-// Encrypt resolves the key version and delegates to the matching processor.
-func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+// WrapSecret resolves the key version and delegates to the matching processor.
+func (km *Manager) WrapSecret(ctx context.Context, req SecretWrapRequest) (*SecretWrapResponse, error) {
 	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
 	if err != nil {
 		return nil, err
@@ -48,20 +44,20 @@ func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cr
 
 	resp, err := proc.WrapSecret(ctx, WrapSecretRequest{
 		KeyVersion: kv,
-		Secret:     req.Plaintext,
+		Secret:     req.Secret,
 		AAD:        req.AAD,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &cryptor.EncryptResponse{
-		Ciphertext: resp.WrappedSecret,
+	return &SecretWrapResponse{
+		WrappedSecret: resp.WrappedSecret,
 	}, nil
 }
 
-// Decrypt resolves the key version and delegates to the matching processor.
-func (km *Manager) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
+// UnwrapSecret resolves the key version and delegates to the matching processor.
+func (km *Manager) UnwrapSecret(ctx context.Context, req SecretUnwrapRequest) (*SecretUnwrapResponse, error) {
 	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
 	if err != nil {
 		return nil, err
@@ -78,25 +74,16 @@ func (km *Manager) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cr
 
 	resp, err := proc.UnwrapSecret(ctx, UnwrapSecretRequest{
 		KeyVersion:    kv,
-		WrappedSecret: req.Ciphertext,
+		WrappedSecret: req.WrappedSecret,
 		AAD:           req.AAD,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &cryptor.DecryptResponse{
-		Plaintext: resp.Secret,
+	return &SecretUnwrapResponse{
+		Secret: resp.Secret,
 	}, nil
-}
-
-// Info returns the Manager's cryptor metadata.
-func (km *Manager) Info() cryptor.Info {
-	return cryptor.Info{
-		Name:                     "keyprocessor-manager",
-		Type:                     TypeManager,
-		DecryptionSecretRequired: true,
-	}
 }
 
 func (km *Manager) resolveUsableKeyVersion(ctx context.Context, tenantID, keyID, version string) (model.KeyVersion, error) {

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -21,13 +21,13 @@ var (
 type Manager struct {
 	store        store.Key
 	versionStore store.KeyVersion
-	processors   map[model.KeyKind]Processor
+	processors   map[model.KeyKind]processor
 }
 
 var _ SecretWrapper = &Manager{}
 
 // WrapSecret resolves the key version and delegates to the matching processor.
-func (km *Manager) WrapSecret(ctx context.Context, req SecretWrapRequest) (*SecretWrapResponse, error) {
+func (km *Manager) WrapSecret(ctx context.Context, req WrapSecretRequest) (*WrapSecretResponse, error) {
 	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (km *Manager) WrapSecret(ctx context.Context, req SecretWrapRequest) (*Secr
 		return nil, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
 	}
 
-	resp, err := proc.WrapSecret(ctx, WrapSecretRequest{
+	resp, err := proc.wrapSecret(ctx, wrapSecretRequest{
 		KeyVersion: kv,
 		Secret:     req.Secret,
 		AAD:        req.AAD,
@@ -51,13 +51,13 @@ func (km *Manager) WrapSecret(ctx context.Context, req SecretWrapRequest) (*Secr
 		return nil, err
 	}
 
-	return &SecretWrapResponse{
+	return &WrapSecretResponse{
 		WrappedSecret: resp.WrappedSecret,
 	}, nil
 }
 
 // UnwrapSecret resolves the key version and delegates to the matching processor.
-func (km *Manager) UnwrapSecret(ctx context.Context, req SecretUnwrapRequest) (*SecretUnwrapResponse, error) {
+func (km *Manager) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (*UnwrapSecretResponse, error) {
 	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func (km *Manager) UnwrapSecret(ctx context.Context, req SecretUnwrapRequest) (*
 		return nil, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
 	}
 
-	resp, err := proc.UnwrapSecret(ctx, UnwrapSecretRequest{
+	resp, err := proc.unwrapSecret(ctx, unwrapSecretRequest{
 		KeyVersion:    kv,
 		WrappedSecret: req.WrappedSecret,
 		AAD:           req.AAD,
@@ -81,7 +81,7 @@ func (km *Manager) UnwrapSecret(ctx context.Context, req SecretUnwrapRequest) (*
 		return nil, err
 	}
 
-	return &SecretUnwrapResponse{
+	return &UnwrapSecretResponse{
 		Secret: resp.Secret,
 	}, nil
 }

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -22,9 +22,9 @@ var (
 	ErrSecNotPersisted = errors.New("persisted secret missing from handler response")
 )
 
-// Processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
+// processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
 // It destroys all intermediate secrets that pass through its operations.
-type Processor struct {
+type processor struct {
 	generator       cryptor.SecretGenerator
 	cryptor         cryptor.Cryptor
 	transportSealer cryptor.Sealer
@@ -32,52 +32,52 @@ type Processor struct {
 	vault           vault.Vault
 }
 
-// CreateSecretRequest is the input for CreateSecret.
-type CreateSecretRequest struct {
+// createSecretRequest is the input for CreateSecret.
+type createSecretRequest struct {
 	KeyVersion model.KeyVersion
 	AAD        []byte
 }
 
-// CreateSecretResponse is the output of CreateSecret.
-type CreateSecretResponse struct{}
+// createSecretResponse is the output of CreateSecret.
+type createSecretResponse struct{}
 
-// WrapSecretRequest is the input for WrapSecret.
-type WrapSecretRequest struct {
+// wrapSecretRequest is the input for WrapSecret.
+type wrapSecretRequest struct {
 	KeyVersion model.KeyVersion
 	Secret     *securemem.Data
 	AAD        []byte
 }
 
-// WrapSecretResponse is the output of WrapSecret.
-type WrapSecretResponse struct {
+// wrapSecretResponse is the output of WrapSecret.
+type wrapSecretResponse struct {
 	WrappedSecret *securemem.Data
 }
 
-// UnwrapSecretRequest is the input for UnwrapSecret.
-type UnwrapSecretRequest struct {
+// unwrapSecretRequest is the input for UnwrapSecret.
+type unwrapSecretRequest struct {
 	KeyVersion    model.KeyVersion
 	WrappedSecret *securemem.Data
 	AAD           []byte
 }
 
-// UnwrapSecretResponse is the output of UnwrapSecret.
-type UnwrapSecretResponse struct {
+// unwrapSecretResponse is the output of UnwrapSecret.
+type unwrapSecretResponse struct {
 	Secret *securemem.Data
 }
 
-// DeleteSecretRequest is the input for DeleteSecret.
-type DeleteSecretRequest struct {
+// deleteSecretRequest is the input for DeleteSecret.
+type deleteSecretRequest struct {
 	KeyVersion model.KeyVersion
 }
 
-// DeleteSecretResponse is the output of DeleteSecret.
-type DeleteSecretResponse struct{}
+// deleteSecretResponse is the output of DeleteSecret.
+type deleteSecretResponse struct{}
 
-// CreateSecret generates a secret, seals it, wraps it through the parent chain, and stores it in the vault.
+// createSecret generates a secret, seals it, wraps it through the parent chain, and stores it in the vault.
 // It is a no-op when the cryptor manages its own decryption key.
-func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (CreateSecretResponse, error) {
+func (p *processor) createSecret(ctx context.Context, req createSecretRequest) (createSecretResponse, error) {
 	if !p.cryptor.Info().DecryptionSecretRequired {
-		return CreateSecretResponse{}, nil
+		return createSecretResponse{}, nil
 	}
 
 	_, err := securemem.Run(ctx, func(ctx context.Context, _ *securemem.HandlerRequest) error {
@@ -110,12 +110,12 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		return err
 	})
 
-	return CreateSecretResponse{}, err
+	return createSecretResponse{}, err
 }
 
-// WrapSecret resolves the wrapping secret from the key chain and encrypts the given secret.
+// wrapSecret resolves the wrapping secret from the key chain and encrypts the given secret.
 // When the cryptor manages its own decryption key, it encrypts directly without resolving.
-func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
+func (p *processor) wrapSecret(ctx context.Context, req wrapSecretRequest) (wrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
 		sec, err := p.resolveSecret(ctx, req.KeyVersion)
 		if err != nil {
@@ -135,18 +135,18 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		return sreq.PersistentVault().Import(persistSecName, encResp.Ciphertext)
 	})
 	if err != nil {
-		return WrapSecretResponse{}, err
+		return wrapSecretResponse{}, err
 	}
 	sec, err := getPersistedSec(resp)
 
-	return WrapSecretResponse{
+	return wrapSecretResponse{
 		WrappedSecret: sec,
 	}, err
 }
 
-// UnwrapSecret resolves the wrapping secret from the key chain and decrypts the given wrapped secret.
+// unwrapSecret resolves the wrapping secret from the key chain and decrypts the given wrapped secret.
 // When the cryptor manages its own decryption key, it decrypts directly without resolving.
-func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
+func (p *processor) unwrapSecret(ctx context.Context, req unwrapSecretRequest) (unwrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
 		sec, err := p.resolveSecret(ctx, req.KeyVersion)
 		if err != nil {
@@ -166,20 +166,20 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		return sreq.PersistentVault().Import(persistSecName, decResp.Plaintext)
 	})
 	if err != nil {
-		return UnwrapSecretResponse{}, err
+		return unwrapSecretResponse{}, err
 	}
 	sec, err := getPersistedSec(resp)
 
-	return UnwrapSecretResponse{
+	return unwrapSecretResponse{
 		Secret: sec,
 	}, err
 }
 
-// DeleteSecret removes the wrapping secret from the vault.
+// deleteSecret removes the wrapping secret from the vault.
 // It is a no-op when the cryptor manages its own decryption key.
-func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (DeleteSecretResponse, error) {
+func (p *processor) deleteSecret(ctx context.Context, req deleteSecretRequest) (deleteSecretResponse, error) {
 	if !p.cryptor.Info().DecryptionSecretRequired {
-		return DeleteSecretResponse{}, nil
+		return deleteSecretResponse{}, nil
 	}
 
 	_, err := p.vault.DestroyKey(ctx, vault.DestroyKeyRequest{
@@ -189,13 +189,13 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 		KeyRevision: req.KeyVersion.Revision,
 	})
 	if err != nil {
-		return DeleteSecretResponse{}, err
+		return deleteSecretResponse{}, err
 	}
 
-	return DeleteSecretResponse{}, nil
+	return deleteSecretResponse{}, nil
 }
 
-func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
+func (p *processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
 	if !p.cryptor.Info().DecryptionSecretRequired {
 		return nil, nil //nolint:nilnil
 	}
@@ -239,7 +239,7 @@ func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*se
 	return getPersistedSec(resp)
 }
 
-func (p *Processor) transportSeal(ctx context.Context, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *processor) transportSeal(ctx context.Context, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
@@ -253,7 +253,7 @@ func (p *Processor) transportSeal(ctx context.Context, sec *securemem.Data, aad 
 	return resp.Ciphertext, nil
 }
 
-func (p *Processor) unseal(ctx context.Context, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *processor) unseal(ctx context.Context, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
@@ -267,14 +267,14 @@ func (p *Processor) unseal(ctx context.Context, sec *securemem.Data, aad []byte)
 	return resp.Plaintext, nil
 }
 
-func (p *Processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.parent == nil {
 		return sec, nil
 	}
 	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
 		return nil, ErrMissingParentKeyVersion
 	}
-	resp, err := p.parent.WrapSecret(ctx, SecretWrapRequest{
+	resp, err := p.parent.WrapSecret(ctx, WrapSecretRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      *kv.ParentKeyID,
 		KeyVersion: *kv.ParentKeyVersion,
@@ -287,14 +287,14 @@ func (p *Processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *se
 	return resp.WrappedSecret, nil
 }
 
-func (p *Processor) parentUnwrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *processor) parentUnwrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.parent == nil {
 		return sec, nil
 	}
 	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
 		return nil, ErrMissingParentKeyVersion
 	}
-	resp, err := p.parent.UnwrapSecret(ctx, SecretUnwrapRequest{
+	resp, err := p.parent.UnwrapSecret(ctx, UnwrapSecretRequest{
 		TenantID:      kv.TenantID,
 		KeyID:         *kv.ParentKeyID,
 		KeyVersion:    *kv.ParentKeyVersion,

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -26,9 +26,9 @@ var (
 // It destroys all intermediate secrets that pass through its operations.
 type Processor struct {
 	generator       cryptor.SecretGenerator
-	wrapper         cryptor.Cryptor
-	transportSealer cryptor.Cryptor
-	parent          cryptor.Cryptor
+	cryptor         cryptor.Cryptor
+	transportSealer cryptor.Sealer
+	parent          SecretWrapper
 	vault           vault.Vault
 }
 
@@ -74,9 +74,9 @@ type DeleteSecretRequest struct {
 type DeleteSecretResponse struct{}
 
 // CreateSecret generates a secret, seals it, wraps it through the parent chain, and stores it in the vault.
-// It is a no-op when the wrapper manages its own decryption key.
+// It is a no-op when the cryptor manages its own decryption key.
 func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (CreateSecretResponse, error) {
-	if !p.wrapper.Info().DecryptionSecretRequired {
+	if !p.cryptor.Info().DecryptionSecretRequired {
 		return CreateSecretResponse{}, nil
 	}
 
@@ -87,7 +87,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		}
 		defer destroySec(resp.Secret)
 
-		sealSec, err := p.transportSeal(ctx, req.KeyVersion, resp.Secret, req.AAD)
+		sealSec, err := p.transportSeal(ctx, resp.Secret, req.AAD)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 }
 
 // WrapSecret resolves the wrapping secret from the key chain and encrypts the given secret.
-// When the wrapper manages its own decryption key, it encrypts directly without resolving.
+// When the cryptor manages its own decryption key, it encrypts directly without resolving.
 func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
 		sec, err := p.resolveSecret(ctx, req.KeyVersion)
@@ -123,13 +123,10 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		}
 		defer destroySec(sec)
 
-		encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   req.KeyVersion.TenantID,
-			KeyID:      req.KeyVersion.KeyID,
-			KeyVersion: req.KeyVersion.Version,
-			Secret:     toCryptorSecret(sec),
-			Plaintext:  req.Secret,
-			AAD:        req.AAD,
+		encResp, err := p.cryptor.Encrypt(ctx, cryptor.EncryptRequest{
+			Secret:    toCryptorSecret(sec),
+			Plaintext: req.Secret,
+			AAD:       req.AAD,
 		})
 		if err != nil {
 			return err
@@ -148,7 +145,7 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 }
 
 // UnwrapSecret resolves the wrapping secret from the key chain and decrypts the given wrapped secret.
-// When the wrapper manages its own decryption key, it decrypts directly without resolving.
+// When the cryptor manages its own decryption key, it decrypts directly without resolving.
 func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
 		sec, err := p.resolveSecret(ctx, req.KeyVersion)
@@ -157,10 +154,7 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		}
 		defer destroySec(sec)
 
-		decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   req.KeyVersion.TenantID,
-			KeyID:      req.KeyVersion.KeyID,
-			KeyVersion: req.KeyVersion.Version,
+		decResp, err := p.cryptor.Decrypt(ctx, cryptor.DecryptRequest{
 			Secret:     toCryptorSecret(sec),
 			Ciphertext: req.WrappedSecret,
 			AAD:        req.AAD,
@@ -182,9 +176,9 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 }
 
 // DeleteSecret removes the wrapping secret from the vault.
-// It is a no-op when the wrapper manages its own decryption key.
+// It is a no-op when the cryptor manages its own decryption key.
 func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (DeleteSecretResponse, error) {
-	if !p.wrapper.Info().DecryptionSecretRequired {
+	if !p.cryptor.Info().DecryptionSecretRequired {
 		return DeleteSecretResponse{}, nil
 	}
 
@@ -202,7 +196,7 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 }
 
 func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
-	if !p.wrapper.Info().DecryptionSecretRequired {
+	if !p.cryptor.Info().DecryptionSecretRequired {
 		return nil, nil //nolint:nilnil
 	}
 
@@ -224,7 +218,7 @@ func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*se
 		}
 		defer destroySec(unwrapSec)
 
-		unsealSec, err := p.unseal(ctx, kv, unwrapSec, exported.AAD)
+		unsealSec, err := p.unseal(ctx, unwrapSec, exported.AAD)
 		if err != nil {
 			return err
 		}
@@ -245,16 +239,13 @@ func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*se
 	return getPersistedSec(resp)
 }
 
-func (p *Processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) transportSeal(ctx context.Context, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
-	resp, err := p.transportSealer.Encrypt(ctx, cryptor.EncryptRequest{
-		TenantID:   kv.TenantID,
-		KeyID:      kv.KeyID,
-		KeyVersion: kv.Version,
-		Plaintext:  sec,
-		AAD:        aad,
+	resp, err := p.transportSealer.Seal(ctx, cryptor.SealRequest{
+		Plaintext: sec,
+		AAD:       aad,
 	})
 	if err != nil {
 		return nil, err
@@ -262,14 +253,11 @@ func (p *Processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec 
 	return resp.Ciphertext, nil
 }
 
-func (p *Processor) unseal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *Processor) unseal(ctx context.Context, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
-	resp, err := p.transportSealer.Decrypt(ctx, cryptor.DecryptRequest{
-		TenantID:   kv.TenantID,
-		KeyID:      kv.KeyID,
-		KeyVersion: kv.Version,
+	resp, err := p.transportSealer.Unseal(ctx, cryptor.UnsealRequest{
 		Ciphertext: sec,
 		AAD:        aad,
 	})
@@ -286,17 +274,17 @@ func (p *Processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *se
 	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
 		return nil, ErrMissingParentKeyVersion
 	}
-	resp, err := p.parent.Encrypt(ctx, cryptor.EncryptRequest{
+	resp, err := p.parent.WrapSecret(ctx, SecretWrapRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      *kv.ParentKeyID,
 		KeyVersion: *kv.ParentKeyVersion,
-		Plaintext:  sec,
+		Secret:     sec,
 		AAD:        aad,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return resp.Ciphertext, nil
+	return resp.WrappedSecret, nil
 }
 
 func (p *Processor) parentUnwrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
@@ -306,17 +294,17 @@ func (p *Processor) parentUnwrap(ctx context.Context, kv model.KeyVersion, sec *
 	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
 		return nil, ErrMissingParentKeyVersion
 	}
-	resp, err := p.parent.Decrypt(ctx, cryptor.DecryptRequest{
-		TenantID:   kv.TenantID,
-		KeyID:      *kv.ParentKeyID,
-		KeyVersion: *kv.ParentKeyVersion,
-		Ciphertext: sec,
-		AAD:        aad,
+	resp, err := p.parent.UnwrapSecret(ctx, SecretUnwrapRequest{
+		TenantID:      kv.TenantID,
+		KeyID:         *kv.ParentKeyID,
+		KeyVersion:    *kv.ParentKeyVersion,
+		WrappedSecret: sec,
+		AAD:           aad,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return resp.Plaintext, nil
+	return resp.Secret, nil
 }
 
 func destroySec(sec *securemem.Data) {

--- a/internal/keyprocessor/secret_wrapper.go
+++ b/internal/keyprocessor/secret_wrapper.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openkcm/krypton/internal/securemem"
 )
 
-type SecretWrapRequest struct {
+type WrapSecretRequest struct {
 	TenantID   string
 	KeyID      string
 	KeyVersion string
@@ -14,11 +14,11 @@ type SecretWrapRequest struct {
 	AAD        []byte
 }
 
-type SecretWrapResponse struct {
+type WrapSecretResponse struct {
 	WrappedSecret *securemem.Data
 }
 
-type SecretUnwrapRequest struct {
+type UnwrapSecretRequest struct {
 	TenantID      string
 	KeyID         string
 	KeyVersion    string
@@ -26,12 +26,12 @@ type SecretUnwrapRequest struct {
 	AAD           []byte
 }
 
-type SecretUnwrapResponse struct {
+type UnwrapSecretResponse struct {
 	Secret *securemem.Data
 }
 
 // SecretWrapper wraps and unwraps secrets within a key hierarchy.
 type SecretWrapper interface {
-	WrapSecret(ctx context.Context, req SecretWrapRequest) (*SecretWrapResponse, error)
-	UnwrapSecret(ctx context.Context, req SecretUnwrapRequest) (*SecretUnwrapResponse, error)
+	WrapSecret(ctx context.Context, req WrapSecretRequest) (*WrapSecretResponse, error)
+	UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (*UnwrapSecretResponse, error)
 }

--- a/internal/keyprocessor/secret_wrapper.go
+++ b/internal/keyprocessor/secret_wrapper.go
@@ -1,0 +1,37 @@
+package keyprocessor
+
+import (
+	"context"
+
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+type SecretWrapRequest struct {
+	TenantID   string
+	KeyID      string
+	KeyVersion string
+	Secret     *securemem.Data
+	AAD        []byte
+}
+
+type SecretWrapResponse struct {
+	WrappedSecret *securemem.Data
+}
+
+type SecretUnwrapRequest struct {
+	TenantID      string
+	KeyID         string
+	KeyVersion    string
+	WrappedSecret *securemem.Data
+	AAD           []byte
+}
+
+type SecretUnwrapResponse struct {
+	Secret *securemem.Data
+}
+
+// SecretWrapper wraps and unwraps secrets within a key hierarchy.
+type SecretWrapper interface {
+	WrapSecret(ctx context.Context, req SecretWrapRequest) (*SecretWrapResponse, error)
+	UnwrapSecret(ctx context.Context, req SecretUnwrapRequest) (*SecretUnwrapResponse, error)
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->
The `cryptor.Cryptor` used for all three roles in the key processor is split into three purpose-specific interfaces:

- **`cryptor.Cryptor`** (`internal/cryptor/cryptor.go`): encrypts/decrypts using an externally provided secret and AAD
- **`cryptor.Sealer`** (`internal/cryptor/sealer.go`): seals/unseals with a self-managed key bound to a trust anchor; no external secret
- **`keyprocessor.SecretWrapper`** (`internal/keyprocessor/secret_wrapper.go`): wraps/unwraps secrets within a key hierarchy using a key-version path

A `RootSealerAdapter` bridges the root-HSM case where a `Sealer` must sit in the `Cryptor` slot.

**Benefits**

- Compile-time guarantees prevent plugging the wrong implementation into the wrong slot
- Each interface exposes only what its role requires; no optional/ignorable fields
- Method names reflect intent (`Seal` vs `Encrypt` vs `WrapSecret`), making the code self-documenting

**Drawbacks**

- `DecryptionSecretRequired` remains a runtime flag since root can use either a `Sealer`-backed or a full `Cryptor`
- A few breaking changes across existing implementations and callers due to the interface split

