### PR TITLE
feat: add sealer interface

### DIFF
--- a/internal/cryptor/aes256gcm/aes256gcm.go
+++ b/internal/cryptor/aes256gcm/aes256gcm.go
@@ -53,9 +53,8 @@ var ErrAllocatedDataNotFound = errors.New("allocated data not found in vault")
 func New(name string) *AES256GCM {
 	return &AES256GCM{
 		info: cryptor.Info{
-			Name:                     name,
-			Type:                     TypeAES256GCM,
-			DecryptionSecretRequired: true,
+			Name: name,
+			Type: TypeAES256GCM,
 		},
 	}
 }
@@ -69,10 +68,6 @@ func (a *AES256GCM) Info() cryptor.Info {
 func (a *AES256GCM) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
-	}
-
-	if req.Secret == nil {
-		return nil, fmt.Errorf("missing encryption secret: %w", cryptor.ErrRequest)
 	}
 
 	if req.Secret.Algorithm != cryptor.KeyAlgorithmAES256 {
@@ -143,10 +138,6 @@ func (a *AES256GCM) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*c
 func (a *AES256GCM) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
-	}
-
-	if req.Secret == nil {
-		return nil, fmt.Errorf("missing decryption secret: %w", cryptor.ErrRequest)
 	}
 
 	if req.Secret.Algorithm != cryptor.KeyAlgorithmAES256 {

--- a/internal/cryptor/aes256gcm/aes256gcm_test.go
+++ b/internal/cryptor/aes256gcm/aes256gcm_test.go
@@ -20,10 +20,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 	t.Run("should fail if encrypt request validation fails", func(t *testing.T) {
 		// given
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 			},
 			Plaintext: nil, // missing plaintext
@@ -41,11 +38,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("plaintext"))
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret:     nil, // missing secret
-			Plaintext:  plainText,
+			Plaintext: plainText,
 		}
 
 		// when
@@ -60,10 +53,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: "unknown-algorithm", // unsupported algorithm
 				Data:      newSecretKey(t),
 			},
@@ -83,10 +73,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      nil, // missing secret
 			},
@@ -107,10 +94,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		secret := newSecretKey(t)
 
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -138,10 +122,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		t.Cleanup(func() { _ = secret.Destroy() })
 
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret, // invalid key size
 			},
@@ -162,10 +143,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		secret := newSecretKey(t)
 
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -191,10 +169,7 @@ func TestAES256GCM_Encrypt(t *testing.T) {
 		secret := newSecretKey(t)
 
 		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -220,10 +195,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 	t.Run("should fail if decrypt request validation fails", func(t *testing.T) {
 		// given
 		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 			},
 			Ciphertext: nil, // missing ciphertext
@@ -242,10 +214,6 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		plainText := newSecureMemData(t, []byte("ciphertext"))
 
 		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret:     nil,
 			Ciphertext: plainText,
 		}
 
@@ -263,10 +231,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		secret := newSecretKey(t)
 
 		decResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -276,10 +241,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		t.Cleanup(func() { _ = decResp.Ciphertext.Destroy() })
 
 		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: "unknown-algorithm", // unsupported algorithm
 				Data:      secret,
 			},
@@ -299,10 +261,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		cipherText := newSecureMemData(t, []byte("ciphertext"))
 
 		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      nil, // missing secret
 			},
@@ -327,10 +286,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		t.Cleanup(func() { _ = secret.Destroy() })
 
 		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret, // invalid key size
 			},
@@ -351,10 +307,7 @@ func TestAES256GCM_Decrypt(t *testing.T) {
 		secret := newSecretKey(t)
 
 		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -387,10 +340,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		// when
 		// encrypt
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -407,10 +357,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		// when
 		// decrypt
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -435,10 +382,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		// when
 		// encrypt with AAD
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -453,10 +397,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		// when
 		// decrypt with same AAD succeeds
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -478,10 +419,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secretKey,
 			},
@@ -496,10 +434,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		// when
 		// decrypt with wrong AAD must fail
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secretKey,
 			},
@@ -520,10 +455,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret1,
 			},
@@ -537,10 +469,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		// when
 		// decrypt with different key must fail
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret2,
 			},
@@ -559,10 +488,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -585,10 +511,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -607,10 +530,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -631,10 +551,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -653,10 +570,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 
 		// when
 		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -666,10 +580,7 @@ func TestAES256GCM_EncryptDecrypt(t *testing.T) {
 		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
 
 		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Secret: &cryptor.Secret{
+			Secret: cryptor.Secret{
 				Algorithm: cryptor.KeyAlgorithmAES256,
 				Data:      secret,
 			},
@@ -695,7 +606,6 @@ func TestAES256GCM_Info(t *testing.T) {
 	// then
 	assert.Equal(t, "test-aes256gcm", info.Name)
 	assert.Equal(t, aes256gcm.TypeAES256GCM, info.Type)
-	assert.True(t, info.DecryptionSecretRequired)
 }
 
 // newSecretKey allocate a 32-byte AES key in secure memory

--- a/internal/cryptor/cryptor.go
+++ b/internal/cryptor/cryptor.go
@@ -29,14 +29,8 @@ type Secret struct {
 
 // EncryptRequest contains parameters for an encryption operation.
 type EncryptRequest struct {
-	// TenantID identifies the tenant owning the key.
-	TenantID string
-	// KeyID is the unique identifier of the key.
-	KeyID string
-	// KeyVersion specifies which version of the key to use.
-	KeyVersion string
-	// Secret holds the key material for encryption. Nil when the Cryptor manages its own secrets.
-	Secret *Secret
+	// Secret holds the key material for encryption.
+	Secret Secret
 	// Plaintext is the data to encrypt.
 	// The Plaintext field should not be nil.
 	Plaintext *securemem.Data
@@ -52,14 +46,8 @@ type EncryptResponse struct {
 
 // DecryptRequest contains parameters for a decryption operation.
 type DecryptRequest struct {
-	// TenantID identifies the tenant owning the key.
-	TenantID string
-	// KeyID is the unique identifier of the key.
-	KeyID string
-	// KeyVersion specifies which version of the key to use.
-	KeyVersion string
-	// Secret holds the key material for decryption. Nil when the Cryptor manages its own secrets.
-	Secret *Secret
+	// Secret holds the key material for decryption.
+	Secret Secret
 	// Ciphertext is the data to decrypt.
 	// The Ciphertext field should not be nil.
 	Ciphertext *securemem.Data
@@ -79,8 +67,6 @@ type Info struct {
 	Name string
 	// Type identifies the cryptor implementation (e.g., "aes256gcm").
 	Type Type
-	// DecryptionSecretRequired is false if cryptor manages its own secret (e.g., HSM).
-	DecryptionSecretRequired bool
 }
 
 // Bundle pairs a Cryptor with an optional SecretGenerator for key material creation.
@@ -118,15 +104,6 @@ var (
 )
 
 func (req EncryptRequest) Validate() error {
-	if req.TenantID == "" {
-		return fmt.Errorf("invalid tenant ID: %w", ErrRequest)
-	}
-	if req.KeyID == "" {
-		return fmt.Errorf("invalid key ID: %w", ErrRequest)
-	}
-	if req.KeyVersion == "" {
-		return fmt.Errorf("invalid key version: %w", ErrRequest)
-	}
 	if req.Plaintext == nil || len(req.Plaintext.SecureBytes()) == 0 {
 		return fmt.Errorf("invalid plaintext: %w", ErrRequest)
 	}
@@ -134,29 +111,18 @@ func (req EncryptRequest) Validate() error {
 }
 
 func (req DecryptRequest) Validate() error {
-	if req.TenantID == "" {
-		return fmt.Errorf("invalid tenant ID: %w", ErrRequest)
-	}
-	if req.KeyID == "" {
-		return fmt.Errorf("invalid key ID: %w", ErrRequest)
-	}
-	if req.KeyVersion == "" {
-		return fmt.Errorf("invalid key version: %w", ErrRequest)
-	}
 	if req.Ciphertext == nil || len(req.Ciphertext.SecureBytes()) == 0 {
 		return fmt.Errorf("invalid ciphertext: %w", ErrRequest)
 	}
 	return req.Secret.Validate()
 }
 
-func (cs *Secret) Validate() error {
-	if cs != nil {
-		if cs.Algorithm == "" {
-			return fmt.Errorf("invalid secret algorithm: %w", ErrRequest)
-		}
-		if cs.Data == nil || len(cs.Data.SecureBytes()) == 0 {
-			return fmt.Errorf("invalid secret data: %w", ErrRequest)
-		}
+func (cs Secret) Validate() error {
+	if cs.Algorithm == "" {
+		return fmt.Errorf("invalid secret algorithm: %w", ErrRequest)
+	}
+	if cs.Data == nil || len(cs.Data.SecureBytes()) == 0 {
+		return fmt.Errorf("invalid secret data: %w", ErrRequest)
 	}
 	return nil
 }

--- a/internal/cryptor/cryptor_test.go
+++ b/internal/cryptor/cryptor_test.go
@@ -31,23 +31,10 @@ func TestDecryptRequestValidate(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "valid request without secret",
-			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Ciphertext: validData,
-			},
-			wantErr: nil,
-		},
-		{
 			name: "valid request with secret",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: validData,
-				Secret: &cryptor.Secret{
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      validData,
 				},
@@ -55,58 +42,13 @@ func TestDecryptRequestValidate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "valid request with non empty key version",
-			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "-1",
-				Ciphertext: validData,
-			},
-			wantErr: nil,
-		},
-		{
-			name: "missing tenant ID",
-			req: cryptor.DecryptRequest{
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Ciphertext: validData,
-			},
-			wantErr: cryptor.ErrRequest,
-		},
-		{
-			name: "missing key ID",
-			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyVersion: "1",
-				Ciphertext: validData,
-			},
-			wantErr: cryptor.ErrRequest,
-		},
-		{
-			name: "invalid key version",
-			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "",
-				Ciphertext: validData,
-			},
-			wantErr: cryptor.ErrRequest,
-		},
-		{
-			name: "missing ciphertext",
-			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-			},
+			name:    "missing ciphertext",
+			req:     cryptor.DecryptRequest{},
 			wantErr: cryptor.ErrRequest,
 		},
 		{
 			name: "destroyed ciphertext",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: destroyedData,
 			},
 			wantErr: cryptor.ErrRequest,
@@ -114,9 +56,6 @@ func TestDecryptRequestValidate(t *testing.T) {
 		{
 			name: "empty ciphertext data",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: &securemem.Data{},
 			},
 			wantErr: cryptor.ErrRequest,
@@ -124,11 +63,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 		{
 			name: "empty algorithm in secret",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: validData,
-				Secret: &cryptor.Secret{
+				Secret: cryptor.Secret{
 					Data: validData,
 				},
 			},
@@ -137,11 +73,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 		{
 			name: "empty data in secret",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: validData,
-				Secret: &cryptor.Secret{
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      &securemem.Data{},
 				},
@@ -151,11 +84,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 		{
 			name: "destroyed data in secret",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: validData,
-				Secret: &cryptor.Secret{
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      destroyedData,
 				},
@@ -165,11 +95,8 @@ func TestDecryptRequestValidate(t *testing.T) {
 		{
 			name: "nil data in secret",
 			req: cryptor.DecryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
 				Ciphertext: validData,
-				Secret: &cryptor.Secret{
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      nil,
 				},
@@ -210,23 +137,10 @@ func TestEncryptRequestValidate(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "valid request without secret",
-			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-			},
-			wantErr: nil,
-		},
-		{
 			name: "valid request with secret",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-				Secret: &cryptor.Secret{
+				Plaintext: validData,
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      validData,
 				},
@@ -234,80 +148,29 @@ func TestEncryptRequestValidate(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "valid request with non empty key version",
-			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "-1",
-				Plaintext:  validData,
-			},
-			wantErr: nil,
-		},
-		{
-			name: "missing tenant ID",
-			req: cryptor.EncryptRequest{
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-			},
-			wantErr: cryptor.ErrRequest,
-		},
-		{
-			name: "missing key ID",
-			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-			},
-			wantErr: cryptor.ErrRequest,
-		},
-		{
-			name: "invalid key version",
-			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "",
-				Plaintext:  validData,
-			},
-			wantErr: cryptor.ErrRequest,
-		},
-		{
-			name: "missing plaintext",
-			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-			},
+			name:    "missing plaintext",
+			req:     cryptor.EncryptRequest{},
 			wantErr: cryptor.ErrRequest,
 		},
 		{
 			name: "destroyed plaintext",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  destroyedData,
+				Plaintext: destroyedData,
 			},
 			wantErr: cryptor.ErrRequest,
 		},
 		{
 			name: "empty ciphertext data",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  &securemem.Data{},
+				Plaintext: &securemem.Data{},
 			},
 			wantErr: cryptor.ErrRequest,
 		},
 		{
 			name: "empty algorithm in secret",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-				Secret: &cryptor.Secret{
+				Plaintext: validData,
+				Secret: cryptor.Secret{
 					Data: validData,
 				},
 			},
@@ -316,11 +179,8 @@ func TestEncryptRequestValidate(t *testing.T) {
 		{
 			name: "empty data in secret",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-				Secret: &cryptor.Secret{
+				Plaintext: validData,
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      &securemem.Data{},
 				},
@@ -330,11 +190,8 @@ func TestEncryptRequestValidate(t *testing.T) {
 		{
 			name: "destroyed data in secret",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-				Secret: &cryptor.Secret{
+				Plaintext: validData,
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      destroyedData,
 				},
@@ -344,11 +201,8 @@ func TestEncryptRequestValidate(t *testing.T) {
 		{
 			name: "nil data in secret",
 			req: cryptor.EncryptRequest{
-				TenantID:   "tenant1",
-				KeyID:      "key1",
-				KeyVersion: "1",
-				Plaintext:  validData,
-				Secret: &cryptor.Secret{
+				Plaintext: validData,
+				Secret: cryptor.Secret{
 					Algorithm: cryptor.KeyAlgorithmAES256,
 					Data:      nil,
 				},

--- a/internal/cryptor/cryptorprovider/provider.go
+++ b/internal/cryptor/cryptorprovider/provider.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
-	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
-	"github.com/openkcm/krypton/internal/secret/secretprovider"
 )
 
 var ErrCryptorNameEmpty = errors.New("cryptor name is empty")
@@ -82,23 +80,11 @@ func (s *Spec) Validate() error {
 
 // GetBundle constructs a ready-to-use cryptor Bundle from the given Spec.
 func GetBundle(ctx context.Context, spec Spec) (cryptor.Bundle, error) {
-	switch c := spec.Config.(type) {
+	switch spec.Config.(type) {
 	case *aes256gcm.Config:
 		return cryptor.Bundle{
 			Cryptor:         aes256gcm.New(spec.Name),
 			SecretGenerator: cryptor.NewAES256SecretGenerator(),
-		}, nil
-	case *staticsecret.Config:
-		secret, err := getSecret(ctx, c)
-		if err != nil {
-			return cryptor.Bundle{}, err
-		}
-		cryp, err := staticsecret.New(spec.Name, secret.Data)
-		if err != nil {
-			return cryptor.Bundle{}, err
-		}
-		return cryptor.Bundle{
-			Cryptor: cryp,
 		}, nil
 	default:
 		return cryptor.Bundle{}, fmt.Errorf("%w: %T", cryptor.ErrUnknownType, spec.Config)
@@ -110,21 +96,7 @@ func newCryptorConfig(t cryptor.Type) (cryptor.Config, error) {
 	switch t {
 	case aes256gcm.TypeAES256GCM:
 		return &aes256gcm.Config{}, nil
-	case staticsecret.TypeStaticSecret:
-		return &staticsecret.Config{}, nil
 	default:
 		return nil, fmt.Errorf("%w: %q", cryptor.ErrUnknownType, t)
 	}
-}
-
-// getSecret gets the cryptor secret for a static-secret cryptor via the configured secret source.
-func getSecret(ctx context.Context, cfg *staticsecret.Config) (cryptor.Secret, error) {
-	data, err := secretprovider.GetSecret(ctx, cfg.Secret)
-	if err != nil {
-		return cryptor.Secret{}, err
-	}
-	return cryptor.Secret{
-		Algorithm: cryptor.KeyAlgorithmAES256,
-		Data:      data,
-	}, nil
 }

--- a/internal/cryptor/cryptorprovider/provider_test.go
+++ b/internal/cryptor/cryptorprovider/provider_test.go
@@ -1,7 +1,6 @@
 package cryptorprovider_test
 
 import (
-	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,16 +10,7 @@ import (
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
 	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
-	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
-	"github.com/openkcm/krypton/internal/secret/envvar"
-	"github.com/openkcm/krypton/internal/secret/secretprovider"
 )
-
-// testKey is a 32-byte AES-256 key for testing.
-var testKey = []byte("01234567890123456789012345678901")
-
-// testKeyBase64 is testKey encoded as base64 (standard encoding).
-var testKeyBase64 = base64.StdEncoding.EncodeToString(testKey)
 
 func TestSpec_Validate(t *testing.T) {
 	tts := []struct {
@@ -44,19 +34,6 @@ func TestSpec_Validate(t *testing.T) {
 				Type:   aes256gcm.TypeAES256GCM,
 				Config: &aes256gcm.Config{},
 			},
-		},
-		{
-			name: "should propagate config validation error",
-			spec: cryptorprovider.Spec{
-				Name: "my-cryptor",
-				Type: staticsecret.TypeStaticSecret,
-				Config: &staticsecret.Config{
-					Secret: secretprovider.Spec{
-						Type: "",
-					},
-				},
-			},
-			expErr: secretprovider.ErrUnknownType,
 		},
 	}
 
@@ -92,35 +69,6 @@ config: {}
 		assert.Equal(t, "root-cryptor", spec.Name)
 		assert.Equal(t, aes256gcm.TypeAES256GCM, spec.Type)
 		assert.IsType(t, &aes256gcm.Config{}, spec.Config)
-	})
-
-	t.Run("should unmarshal staticsecret spec with nested secret config", func(t *testing.T) {
-		// given
-		input := `
-name: static-cryptor
-type: aes256gcm-staticsecret
-config:
-  secret:
-    type: envvar
-    config:
-      name: MY_ROOT_KEY
-`
-		// when
-		var spec cryptorprovider.Spec
-		err := yaml.Unmarshal([]byte(input), &spec)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, "static-cryptor", spec.Name)
-		assert.Equal(t, staticsecret.TypeStaticSecret, spec.Type)
-
-		cfg, ok := spec.Config.(*staticsecret.Config)
-		require.True(t, ok)
-		assert.Equal(t, envvar.Type, cfg.Secret.Type)
-
-		envCfg, ok := cfg.Secret.Config.(*envvar.Config)
-		require.True(t, ok)
-		assert.Equal(t, "MY_ROOT_KEY", envCfg.Name)
 	})
 
 	t.Run("should return error for unknown cryptor type", func(t *testing.T) {
@@ -160,39 +108,6 @@ func TestGetBundle(t *testing.T) {
 		info := bundle.Cryptor.Info()
 		assert.Equal(t, "test-cryptor", info.Name)
 		assert.Equal(t, aes256gcm.TypeAES256GCM, info.Type)
-		assert.True(t, info.DecryptionSecretRequired)
-	})
-
-	t.Run("should return bundle with cryptor for staticsecret", func(t *testing.T) {
-		// given
-		ctx := t.Context()
-		t.Setenv("TEST_STATIC_KEY", testKeyBase64)
-
-		spec := cryptorprovider.Spec{
-			Name: "static-cryptor",
-			Type: staticsecret.TypeStaticSecret,
-			Config: &staticsecret.Config{
-				Secret: secretprovider.Spec{
-					Type: envvar.Type,
-					Config: &envvar.Config{
-						Name: "TEST_STATIC_KEY",
-					},
-				},
-			},
-		}
-
-		// when
-		bundle, err := cryptorprovider.GetBundle(ctx, spec)
-
-		// then
-		require.NoError(t, err)
-		assert.NotNil(t, bundle.Cryptor)
-		assert.Nil(t, bundle.SecretGenerator)
-
-		info := bundle.Cryptor.Info()
-		assert.Equal(t, "static-cryptor", info.Name)
-		assert.Equal(t, staticsecret.TypeStaticSecret, info.Type)
-		assert.False(t, info.DecryptionSecretRequired)
 	})
 
 	t.Run("should return error for unknown config type", func(t *testing.T) {

--- a/internal/cryptor/sealer.go
+++ b/internal/cryptor/sealer.go
@@ -10,7 +10,7 @@ import (
 type SealRequest struct {
 	TenantID   string
 	KeyID      string
-	KeyVersion *string
+	KeyVersion string
 	Plaintext  *securemem.Data
 	AAD        []byte
 }
@@ -24,7 +24,7 @@ type SealResponse struct {
 type UnsealRequest struct {
 	TenantID   string
 	KeyID      string
-	KeyVersion *string
+	KeyVersion string
 	Ciphertext *securemem.Data
 	AAD        []byte
 }

--- a/internal/cryptor/sealer.go
+++ b/internal/cryptor/sealer.go
@@ -1,0 +1,41 @@
+package cryptor
+
+import (
+	"context"
+
+	"github.com/openkcm/krypton/internal/securemem"
+)
+
+// SealRequest identifies a key version and provides the plaintext and AAD to seal.
+type SealRequest struct {
+	TenantID   string
+	KeyID      string
+	KeyVersion *string
+	Plaintext  *securemem.Data
+	AAD        []byte
+}
+
+// SealResponse holds the sealed ciphertext.
+type SealResponse struct {
+	Ciphertext *securemem.Data
+}
+
+// UnsealRequest identifies a key version and provides the ciphertext and AAD to unseal.
+type UnsealRequest struct {
+	TenantID   string
+	KeyID      string
+	KeyVersion *string
+	Ciphertext *securemem.Data
+	AAD        []byte
+}
+
+// UnsealResponse holds the unsealed plaintext.
+type UnsealResponse struct {
+	Plaintext *securemem.Data
+}
+
+// Sealer seals and unseals data for a given key version.
+type Sealer interface {
+	Seal(context.Context, SealRequest) (SealResponse, error)
+	Unseal(context.Context, UnsealRequest) (UnsealResponse, error)
+}

--- a/internal/cryptor/staticsecret/staticsecret.go
+++ b/internal/cryptor/staticsecret/staticsecret.go
@@ -1,4 +1,4 @@
-// Package staticsecret provides a [cryptor.Cryptor] that embeds a fixed AES-256-GCM key,
+// Package staticsecret provides a [cryptor.Sealer] that embeds a fixed AES-256-GCM key,
 // removing the need for callers to supply secrets per-request.
 package staticsecret
 
@@ -27,23 +27,22 @@ func (c *Config) ValidateCryptorConfig() error {
 	return c.Secret.Validate()
 }
 
-// StaticSecret is a [Cryptor] that wraps [AES256GCM] with a pre-configured key,
-// so callers don't need to supply secrets per-request. It rejects requests that
-// include a secret, and injects its own before delegating to the underlying cipher.
+// StaticSecret is a [cryptor.Sealer] that seals [aes256gcm.AES256GCM] with a pre-configured key,
+// so callers don't need to supply secrets per-request.
 //
 // The caller retains ownership of the secret and must not destroy it while
 // StaticSecret is in use.
 type StaticSecret struct {
 	secret    *securemem.Data
 	aes256gcm *aes256gcm.AES256GCM
-	info      cryptor.Info
+	name      string
 }
 
 // ErrInitializationFailed indicates that New could not be constructed
 // due to an unsupported algorithm or invalid key material.
 var ErrInitializationFailed = errors.New("static secret initialization failed")
 
-var _ cryptor.Cryptor = &StaticSecret{}
+var _ cryptor.Sealer = &StaticSecret{}
 
 // New returns a StaticSecret with the given instance name and key material.
 // The secret must be non-nil and exactly 32 bytes (AES-256).
@@ -59,53 +58,52 @@ func New(name string, secret *securemem.Data) (*StaticSecret, error) {
 	return &StaticSecret{
 		secret:    secret,
 		aes256gcm: aes256gcm.New(name),
-		info: cryptor.Info{
-			Name:                     name,
-			Type:                     TypeStaticSecret,
-			DecryptionSecretRequired: false,
-		},
+		name:      name,
 	}, nil
 }
 
-// Decrypt implements [Cryptor]. It returns an error if the request contains a secret.
-func (s *StaticSecret) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
-	err := req.Validate()
+// Seal seals the plaintext using the embedded static key.
+func (s *StaticSecret) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
+	if req.Plaintext == nil || len(req.Plaintext.SecureBytes()) == 0 {
+		return cryptor.SealResponse{}, fmt.Errorf("invalid plaintext: %w", cryptor.ErrRequest)
+	}
+
+	resp, err := s.aes256gcm.Encrypt(ctx, cryptor.EncryptRequest{
+		Secret: cryptor.Secret{
+			Data:      s.secret,
+			Algorithm: cryptor.KeyAlgorithmAES256,
+		},
+		Plaintext: req.Plaintext,
+		AAD:       req.AAD,
+	})
 	if err != nil {
-		return nil, err
+		return cryptor.SealResponse{}, err
 	}
 
-	if req.Secret != nil {
-		return nil, fmt.Errorf("decryption secret should not be provided in the request: %w", cryptor.ErrRequest)
-	}
-	// replacing the secret in the request with the static secret
-	req.Secret = &cryptor.Secret{
-		Data:      s.secret,
-		Algorithm: cryptor.KeyAlgorithmAES256,
-	}
-
-	return s.aes256gcm.Decrypt(ctx, req)
+	return cryptor.SealResponse{
+		Ciphertext: resp.Ciphertext,
+	}, nil
 }
 
-// Encrypt implements [Cryptor]. It returns an error if the request contains a secret.
-func (s *StaticSecret) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
-	err := req.Validate()
+// Unseal unseals the ciphertext using the embedded static key.
+func (s *StaticSecret) Unseal(ctx context.Context, req cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
+	if req.Ciphertext == nil || len(req.Ciphertext.SecureBytes()) == 0 {
+		return cryptor.UnsealResponse{}, fmt.Errorf("invalid ciphertext: %w", cryptor.ErrRequest)
+	}
+
+	resp, err := s.aes256gcm.Decrypt(ctx, cryptor.DecryptRequest{
+		Secret: cryptor.Secret{
+			Data:      s.secret,
+			Algorithm: cryptor.KeyAlgorithmAES256,
+		},
+		Ciphertext: req.Ciphertext,
+		AAD:        req.AAD,
+	})
 	if err != nil {
-		return nil, err
+		return cryptor.UnsealResponse{}, err
 	}
 
-	if req.Secret != nil {
-		return nil, fmt.Errorf("encryption secret should not be provided in the request: %w", cryptor.ErrRequest)
-	}
-	// replacing the secret in the request with the static secret
-	req.Secret = &cryptor.Secret{
-		Data:      s.secret,
-		Algorithm: cryptor.KeyAlgorithmAES256,
-	}
-
-	return s.aes256gcm.Encrypt(ctx, req)
-}
-
-// Info implements [Cryptor].
-func (s *StaticSecret) Info() cryptor.Info {
-	return s.info
+	return cryptor.UnsealResponse{
+		Plaintext: resp.Plaintext,
+	}, nil
 }

--- a/internal/cryptor/staticsecret/staticsecret_test.go
+++ b/internal/cryptor/staticsecret/staticsecret_test.go
@@ -73,133 +73,77 @@ func TestStaticSecret_New(t *testing.T) {
 	}
 }
 
-func TestStaticSecret_Encrypt(t *testing.T) {
+func TestStaticSecret_Seal(t *testing.T) {
 	// given
 	ctx := t.Context()
 
 	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
-	t.Run("should fail if encrypt request validation fails", func(t *testing.T) {
+	t.Run("should fail if plaintext is nil", func(t *testing.T) {
 		// given
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  nil, // missing plaintext
+		req := cryptor.SealRequest{
+			Plaintext: nil,
 		}
 
 		// when
-		resp, err := subj.Encrypt(ctx, req)
+		resp, err := subj.Seal(ctx, req)
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
 	})
 
-	t.Run("should fail if encrypt request contains a secret", func(t *testing.T) {
+	t.Run("should succeed with valid plaintext", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
-			Secret: &cryptor.Secret{
-				Data:      newSecretKey(t),
-				Algorithm: cryptor.KeyAlgorithmAES256,
-			},
+		req := cryptor.SealRequest{
+			Plaintext: plainText,
 		}
 
 		// when
-		resp, err := subj.Encrypt(ctx, req)
-
-		// then
-		assert.Error(t, err)
-		assert.Nil(t, resp)
-	})
-
-	t.Run("should fail if encrypt request contains empty secret", func(t *testing.T) {
-		// given
-		plainText := newSecureMemData(t, []byte("plaintext"))
-
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
-			Secret:     &cryptor.Secret{},
-		}
-
-		// when
-		resp, err := subj.Encrypt(ctx, req)
-
-		// then
-		assert.Error(t, err)
-		assert.Nil(t, resp)
-	})
-
-	t.Run("should not fail if encrypt request is missing secret", func(t *testing.T) {
-		// given
-		plainText := newSecureMemData(t, []byte("plaintext"))
-
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
-			Secret:     nil, // missing secret
-		}
-
-		// when
-		resp, err := subj.Encrypt(ctx, req)
+		resp, err := subj.Seal(ctx, req)
 
 		// then
 		assert.NoError(t, err)
-		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.Ciphertext)
 		t.Cleanup(func() { _ = resp.Ciphertext.Destroy() })
 	})
 
-	t.Run("should fail to encrypt if plaintext data is destroyed", func(t *testing.T) {
+	t.Run("should fail to seal if plaintext data is destroyed", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		req := cryptor.SealRequest{
+			Plaintext: plainText,
 		}
 
-		// destroy plaintext before encryption
+		// destroy plaintext before sealing
 		require.NoError(t, plainText.Destroy())
 
 		// when
-		resp, err := subj.Encrypt(ctx, req)
+		resp, err := subj.Seal(ctx, req)
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
 	})
 
 	t.Run("should generate different ciphertext for same plaintext and key", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		req := cryptor.SealRequest{
+			Plaintext: plainText,
 		}
 
 		// when
-		resp1, err := subj.Encrypt(ctx, req)
+		resp1, err := subj.Seal(ctx, req)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = resp1.Ciphertext.Destroy() })
 
-		resp2, err := subj.Encrypt(ctx, req)
+		resp2, err := subj.Seal(ctx, req)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = resp2.Ciphertext.Destroy() })
 
@@ -207,19 +151,16 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 		assert.NotEqual(t, resp1.Ciphertext.SecureBytes(), resp2.Ciphertext.SecureBytes())
 	})
 
-	t.Run("should not destroy plaintext after encryption", func(t *testing.T) {
+	t.Run("should not destroy plaintext after sealing", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
-		req := cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		req := cryptor.SealRequest{
+			Plaintext: plainText,
 		}
 
 		// when
-		resp, err := subj.Encrypt(ctx, req)
+		resp, err := subj.Seal(ctx, req)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = resp.Ciphertext.Destroy() })
 
@@ -228,302 +169,178 @@ func TestStaticSecret_Encrypt(t *testing.T) {
 	})
 }
 
-func TestStaticSecret_Decrypt(t *testing.T) {
+func TestStaticSecret_Unseal(t *testing.T) {
 	// given
 	ctx := t.Context()
 	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
-	t.Run("should fail if decrypt request validation fails", func(t *testing.T) {
+	t.Run("should fail if ciphertext is nil", func(t *testing.T) {
 		// given
-		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: nil, // missing ciphertext
+		req := cryptor.UnsealRequest{
+			Ciphertext: nil,
 		}
 
 		// when
-		resp, err := subj.Decrypt(ctx, req)
+		resp, err := subj.Unseal(ctx, req)
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.UnsealResponse{}, resp)
 	})
 
-	t.Run("should fail if decrypt request contains a secret", func(t *testing.T) {
-		// given
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  newSecureMemData(t, []byte("ciphertext")),
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
-
-		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
-			Secret: &cryptor.Secret{
-				Data:      newSecretKey(t),
-				Algorithm: cryptor.KeyAlgorithmAES256,
-			},
-		}
-
-		// when
-		resp, err := subj.Decrypt(ctx, req)
-
-		// then
-		assert.Error(t, err)
-		assert.Nil(t, resp)
-	})
-
-	t.Run("should fail if decrypt request contains empty secret", func(t *testing.T) {
-		// given
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  newSecureMemData(t, []byte("ciphertext")),
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
-
-		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
-			Secret:     &cryptor.Secret{},
-		}
-
-		// when
-		resp, err := subj.Decrypt(ctx, req)
-
-		// then
-		assert.Error(t, err)
-		assert.Nil(t, resp)
-	})
-
-	t.Run("should not fail if decrypt request is missing secret", func(t *testing.T) {
-		// given
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  newSecureMemData(t, []byte("ciphertext")),
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
-
-		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
-			Secret:     nil, // missing secret
-		}
-
-		// when
-		resp, err := subj.Decrypt(ctx, req)
-
-		// then
-		assert.NoError(t, err)
-		assert.NotNil(t, resp)
-		t.Cleanup(func() { _ = resp.Plaintext.Destroy() })
-	})
-
-	t.Run("should fail to decrypt if ciphertext data is destroyed", func(t *testing.T) {
+	t.Run("should fail to unseal if ciphertext data is destroyed", func(t *testing.T) {
 		// given
 		cipherText := newSecureMemData(t, []byte("ciphertext"))
 
-		req := cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
+		req := cryptor.UnsealRequest{
 			Ciphertext: cipherText,
 		}
 
-		// destroy ciphertext before decryption
+		// destroy ciphertext before unsealing
 		require.NoError(t, cipherText.Destroy())
 
 		// when
-		resp, err := subj.Decrypt(ctx, req)
+		resp, err := subj.Unseal(ctx, req)
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.UnsealResponse{}, resp)
 	})
 }
 
-func TestStaticSecret_EncryptDecrypt(t *testing.T) {
+func TestStaticSecret_SealUnseal(t *testing.T) {
 	// given
 	ctx := t.Context()
 
 	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
 	require.NoError(t, err)
 
-	t.Run("should encrypt and decrypt plaintext successfully", func(t *testing.T) {
+	t.Run("should seal and unseal plaintext successfully", func(t *testing.T) {
 		// given
 		text := []byte("hello, secure world!")
 		plainText := newSecureMemData(t, text)
 
 		// when
-		// encrypt
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
 		// ciphertext must differ from plaintext
-		assert.NotEqual(t, text, []byte(encResp.Ciphertext.SecureBytes()))
+		assert.NotEqual(t, text, []byte(sealResp.Ciphertext.SecureBytes()))
 
 		// when
-		// decrypt
-		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
+		unsealResp, err := subj.Unseal(ctx, cryptor.UnsealRequest{
+			Ciphertext: sealResp.Ciphertext,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+		t.Cleanup(func() { _ = unsealResp.Plaintext.Destroy() })
 
 		// recovered plaintext must match original
-		assert.Equal(t, text, []byte(decResp.Plaintext.SecureBytes()))
+		assert.Equal(t, text, []byte(unsealResp.Plaintext.SecureBytes()))
 	})
 
-	t.Run("should encrypt and decrypt with AAD successfully", func(t *testing.T) {
+	t.Run("should seal and unseal with AAD successfully", func(t *testing.T) {
 		// given
 		text := []byte("authenticated payload")
 		plainText := newSecureMemData(t, text)
 		aad := []byte("context-binding-data")
 
 		// when
-		// encrypt with AAD
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
-			AAD:        aad,
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
+			AAD:       aad,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
 		// when
-		// decrypt with same AAD succeeds
-		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
+		unsealResp, err := subj.Unseal(ctx, cryptor.UnsealRequest{
+			Ciphertext: sealResp.Ciphertext,
 			AAD:        aad,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+		t.Cleanup(func() { _ = unsealResp.Plaintext.Destroy() })
 
-		assert.Equal(t, text, []byte(decResp.Plaintext.SecureBytes()))
+		assert.Equal(t, text, []byte(unsealResp.Plaintext.SecureBytes()))
 	})
 
-	t.Run("should fail to decrypt with wrong AAD", func(t *testing.T) {
+	t.Run("should fail to unseal with wrong AAD", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("secret"))
 
 		// when
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
-			AAD:        []byte("correct-aad"),
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
+			AAD:       []byte("correct-aad"),
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
 		// when
-		// decrypt with wrong AAD must fail
-		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
+		unsealResp, err := subj.Unseal(ctx, cryptor.UnsealRequest{
+			Ciphertext: sealResp.Ciphertext,
 			AAD:        []byte("wrong-aad"),
 		})
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, decResp)
+		assert.Equal(t, cryptor.UnsealResponse{}, unsealResp)
 	})
 
-	t.Run("should fail to decrypt with wrong key", func(t *testing.T) {
+	t.Run("should fail to unseal with wrong key", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("secret"))
 
 		// when
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
 		// when
-		// decrypt with different staticsecret must fail
 		subj1, err := staticsecret.New("test-static-secret", newSecretKey(t))
 		require.NoError(t, err)
 
-		decResp, err := subj1.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
+		unsealResp, err := subj1.Unseal(ctx, cryptor.UnsealRequest{
+			Ciphertext: sealResp.Ciphertext,
 		})
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, decResp)
+		assert.Equal(t, cryptor.UnsealResponse{}, unsealResp)
 	})
 
-	t.Run("should fail to decrypt tampered ciphertext", func(t *testing.T) {
+	t.Run("should fail to unseal tampered ciphertext", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("do not tamper"))
 
 		// when
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
 		// copy ciphertext into writable secure memory and flip a byte
-		ct := encResp.Ciphertext.SecureBytes()
+		ct := sealResp.Ciphertext.SecureBytes()
 		tampered, err := securemem.NewData("tampered", len(ct))
 		require.NoError(t, err)
 
@@ -533,36 +350,30 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		tampered.SecureBytes()[len(ct)-1] ^= 0xFF
 
 		// when
-		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
+		unsealResp, err := subj.Unseal(ctx, cryptor.UnsealRequest{
 			Ciphertext: tampered,
 		})
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, decResp)
+		assert.Equal(t, cryptor.UnsealResponse{}, unsealResp)
 	})
 
-	t.Run("should fail to decrypt if ciphertext is too short to contain nonce and tag", func(t *testing.T) {
+	t.Run("should fail to unseal if ciphertext is too short to contain nonce and tag", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("short cipher"))
 
 		// when
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
 		})
 
 		// then
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
 		// create a truncated ciphertext that is too short to contain nonce and tag
-		ct := encResp.Ciphertext.SecureBytes()
+		ct := sealResp.Ciphertext.SecureBytes()
 		truncated, err := securemem.NewData("truncated", 8) // too short for nonce+tag
 		require.NoError(t, err)
 
@@ -570,58 +381,35 @@ func TestStaticSecret_EncryptDecrypt(t *testing.T) {
 		copy(truncated.SecureBytes(), ct[:8])
 
 		// when
-		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
+		unsealResp, err := subj.Unseal(ctx, cryptor.UnsealRequest{
 			Ciphertext: truncated,
 		})
 
 		// then
 		assert.Error(t, err)
-		assert.Nil(t, decResp)
+		assert.Equal(t, cryptor.UnsealResponse{}, unsealResp)
 	})
 
-	t.Run("should not destroy ciphertext after decryption", func(t *testing.T) {
+	t.Run("should not destroy ciphertext after unsealing", func(t *testing.T) {
 		// given
 		plainText := newSecureMemData(t, []byte("plaintext"))
 
 		// when
-		encResp, err := subj.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Plaintext:  plainText,
+		sealResp, err := subj.Seal(ctx, cryptor.SealRequest{
+			Plaintext: plainText,
 		})
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = encResp.Ciphertext.Destroy() })
+		t.Cleanup(func() { _ = sealResp.Ciphertext.Destroy() })
 
-		decResp, err := subj.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   "tenant-1",
-			KeyID:      "key-1",
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
+		unsealResp, err := subj.Unseal(ctx, cryptor.UnsealRequest{
+			Ciphertext: sealResp.Ciphertext,
 		})
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = decResp.Plaintext.Destroy() })
+		t.Cleanup(func() { _ = unsealResp.Plaintext.Destroy() })
 
 		// then
-		assert.NotNil(t, encResp.Ciphertext.SecureBytes())
+		assert.NotNil(t, sealResp.Ciphertext.SecureBytes())
 	})
-}
-
-func TestStaticSecret_Info(t *testing.T) {
-	// given
-	subj, err := staticsecret.New("test-static-secret", newSecretKey(t))
-	require.NoError(t, err)
-
-	// when
-	info := subj.Info()
-
-	// then
-	assert.Equal(t, "test-static-secret", info.Name)
-	assert.Equal(t, staticsecret.TypeStaticSecret, info.Type)
-	assert.False(t, info.DecryptionSecretRequired)
 }
 
 // newSecretKey allocate a 32-byte AES key in secure memory

--- a/internal/keyprocessor/export_test.go
+++ b/internal/keyprocessor/export_test.go
@@ -4,26 +4,53 @@ import (
 	"context"
 
 	"github.com/openkcm/krypton/internal/cryptor"
-	"github.com/openkcm/krypton/internal/securemem"
 	"github.com/openkcm/krypton/internal/vault"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
 )
 
-func NewProcessor(generator cryptor.SecretGenerator, wrapper, transportSealer, parent cryptor.Cryptor, v vault.Vault) *Processor {
-	return &Processor{
+type (
+	Processor            = processor
+	CreateSecretRequest  = createSecretRequest
+	CreateSecretResponse = createSecretResponse
+	DeleteSecretRequest  = deleteSecretRequest
+	DeleteSecretResponse = deleteSecretResponse
+)
+
+func (p *processor) CreateSecret(ctx context.Context, req createSecretRequest) (createSecretResponse, error) {
+	return p.createSecret(ctx, req)
+}
+
+func (p *processor) DeleteSecret(ctx context.Context, req deleteSecretRequest) (deleteSecretResponse, error) {
+	return p.deleteSecret(ctx, req)
+}
+
+func (p *processor) ResolveSecret(ctx context.Context, kv model.KeyVersion) (cryptor.Secret, error) {
+	return p.resolveSecret(ctx, kv)
+}
+
+func (p *processor) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+	return p.encrypt(ctx, req)
+}
+
+func (p *processor) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
+	return p.decrypt(ctx, req)
+}
+
+func NewProcessor(generator cryptor.SecretGenerator, cryptor cryptor.Cryptor, transportSealer, parent cryptor.Sealer, v vault.Vault) *processor {
+	return &processor{
 		generator:       generator,
-		wrapper:         wrapper,
+		cryptor:         cryptor,
 		transportSealer: transportSealer,
 		parent:          parent,
 		vault:           v,
 	}
 }
 
-func NewManager(s store.Key, kvs store.KeyVersion, processors map[model.KeyKind]Processor) *Manager {
+func NewManager(s store.Key, kvs store.KeyVersion, processors map[model.KeyKind]processor) *Manager {
 	return &Manager{store: s, versionStore: kvs, processors: processors}
 }
 
-func (p *Processor) ResolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
-	return p.resolveSecret(ctx, kv)
+func NewRootManager(s store.Key, sealer cryptor.Sealer) *RootManager {
+	return &RootManager{store: s, sealer: sealer}
 }

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -15,88 +15,138 @@ var (
 	ErrProcessorNotFound = errors.New("key processor could not be found")
 	// ErrNoUsableKeyVersion is returned when no usable key version can be resolved.
 	ErrNoUsableKeyVersion = errors.New("no usable key version found")
+	// ErrKeyNotActivated is returned when the key is not in an active lifecycle state.
+	ErrKeyNotActivated = errors.New("key is not in activated state")
+	// ErrKeyVersionRequired is returned when the key version is not specified.
+	ErrKeyVersionRequired = errors.New("key version is required")
 )
 
-// TypeManager identifies the Manager cryptor type.
-const TypeManager cryptor.Type = "manager"
-
-// Manager encrypts and decrypts secrets by resolving the appropriate KeyVersion
-// from the store and delegating to the Processor registered for that key's kind.
+// Manager validates the key lifecycle, resolves key versions, and delegates to processors.
 type Manager struct {
 	store        store.Key
 	versionStore store.KeyVersion
-	processors   map[model.KeyKind]Processor
+	processors   map[model.KeyKind]processor
 }
 
-var _ cryptor.Cryptor = &Manager{}
+var _ cryptor.Sealer = &Manager{}
 
-// Encrypt resolves the key version and delegates to the matching processor.
-func (km *Manager) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
-	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
+// Seal validates the key lifecycle, resolves the key version and its secret to encrypt the plaintext.
+func (km *Manager) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
+	if req.KeyVersion == nil {
+		return cryptor.SealResponse{}, ErrKeyVersionRequired
+	}
+	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, *req.KeyVersion)
 	if err != nil {
-		return nil, err
+		return cryptor.SealResponse{}, err
 	}
 
 	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
 	if err != nil {
-		return nil, err
+		return cryptor.SealResponse{}, err
+	}
+	if key.LifeCycleState != model.KeyLifeCycleActive {
+		return cryptor.SealResponse{}, fmt.Errorf("%w: key %s is in state %s", ErrKeyNotActivated, key.ID, key.LifeCycleState)
 	}
 	proc, ok := km.processors[key.Kind]
 	if !ok {
-		return nil, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
+		return cryptor.SealResponse{}, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
 	}
 
-	resp, err := proc.WrapSecret(ctx, WrapSecretRequest{
-		KeyVersion: kv,
-		Secret:     req.Plaintext,
+	sec, err := proc.resolveSecret(ctx, kv)
+	if err != nil {
+		return cryptor.SealResponse{}, err
+	}
+	defer destroySec(sec.Data)
+
+	resp, err := proc.encrypt(ctx, cryptor.EncryptRequest{
+		Secret:    sec,
+		Plaintext: req.Plaintext,
+		AAD:       req.AAD,
+	})
+	if err != nil {
+		return cryptor.SealResponse{}, err
+	}
+
+	return cryptor.SealResponse{
+		Ciphertext: resp.Ciphertext,
+	}, nil
+}
+
+// Unseal validates the key lifecycle, resolves the key version and its secret to decrypt the ciphertext.
+func (km *Manager) Unseal(ctx context.Context, req cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
+	if req.KeyVersion == nil {
+		return cryptor.UnsealResponse{}, ErrKeyVersionRequired
+	}
+	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, *req.KeyVersion)
+	if err != nil {
+		return cryptor.UnsealResponse{}, err
+	}
+
+	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
+	if err != nil {
+		return cryptor.UnsealResponse{}, err
+	}
+	if key.LifeCycleState != model.KeyLifeCycleActive {
+		return cryptor.UnsealResponse{}, fmt.Errorf("%w: key %s is in state %s", ErrKeyNotActivated, key.ID, key.LifeCycleState)
+	}
+	proc, ok := km.processors[key.Kind]
+	if !ok {
+		return cryptor.UnsealResponse{}, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
+	}
+
+	sec, err := proc.resolveSecret(ctx, kv)
+	if err != nil {
+		return cryptor.UnsealResponse{}, err
+	}
+	defer destroySec(sec.Data)
+
+	resp, err := proc.decrypt(ctx, cryptor.DecryptRequest{
+		Secret:     sec,
+		Ciphertext: req.Ciphertext,
 		AAD:        req.AAD,
 	})
 	if err != nil {
-		return nil, err
+		return cryptor.UnsealResponse{}, err
 	}
 
-	return &cryptor.EncryptResponse{
-		Ciphertext: resp.WrappedSecret,
+	return cryptor.UnsealResponse{
+		Plaintext: resp.Plaintext,
 	}, nil
 }
 
-// Decrypt resolves the key version and delegates to the matching processor.
-func (km *Manager) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
-	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	key, err := km.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
-	if err != nil {
-		return nil, err
-	}
-	proc, ok := km.processors[key.Kind]
-	if !ok {
-		return nil, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, key.Kind)
-	}
-
-	resp, err := proc.UnwrapSecret(ctx, UnwrapSecretRequest{
-		KeyVersion:    kv,
-		WrappedSecret: req.Ciphertext,
-		AAD:           req.AAD,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &cryptor.DecryptResponse{
-		Plaintext: resp.Secret,
-	}, nil
+// RootManager validates key lifecycle and delegates to a sealer for root keys
+// that manage their own secret.
+type RootManager struct {
+	store  store.Key
+	sealer cryptor.Sealer
 }
 
-// Info returns the Manager's cryptor metadata.
-func (km *Manager) Info() cryptor.Info {
-	return cryptor.Info{
-		Name:                     "keyprocessor-manager",
-		Type:                     TypeManager,
-		DecryptionSecretRequired: true,
+var _ cryptor.Sealer = &RootManager{}
+
+// Seal validates the key lifecycle and seals the plaintext using the underlying sealer.
+func (rm *RootManager) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
+	key, err := rm.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
+	if err != nil {
+		return cryptor.SealResponse{}, err
 	}
+	if key.LifeCycleState != model.KeyLifeCycleActive {
+		return cryptor.SealResponse{}, fmt.Errorf("%w: key %s is in state %s", ErrKeyNotActivated, key.ID, key.LifeCycleState)
+	}
+
+	return rm.sealer.Seal(ctx, req)
+}
+
+// Unseal validates the key lifecycle and unseals the ciphertext using the underlying sealer.
+func (rm *RootManager) Unseal(ctx context.Context, req cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
+	key, err := rm.store.GetKeyByID(ctx, req.KeyID, req.TenantID)
+	if err != nil {
+		return cryptor.UnsealResponse{}, err
+	}
+	if key.LifeCycleState != model.KeyLifeCycleActive {
+		return cryptor.UnsealResponse{}, fmt.Errorf("%w: key %s is in state %s", ErrKeyNotActivated, key.ID, key.LifeCycleState)
+	}
+
+	return rm.sealer.Unseal(ctx, req)
 }
 
 func (km *Manager) resolveUsableKeyVersion(ctx context.Context, tenantID, keyID, version string) (model.KeyVersion, error) {

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -32,10 +32,10 @@ var _ cryptor.Sealer = &Manager{}
 
 // Seal validates the key lifecycle, resolves the key version and its secret to encrypt the plaintext.
 func (km *Manager) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
-	if req.KeyVersion == nil {
+	if req.KeyVersion == "" {
 		return cryptor.SealResponse{}, ErrKeyVersionRequired
 	}
-	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, *req.KeyVersion)
+	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
 	if err != nil {
 		return cryptor.SealResponse{}, err
 	}
@@ -74,10 +74,10 @@ func (km *Manager) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.S
 
 // Unseal validates the key lifecycle, resolves the key version and its secret to decrypt the ciphertext.
 func (km *Manager) Unseal(ctx context.Context, req cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
-	if req.KeyVersion == nil {
+	if req.KeyVersion == "" {
 		return cryptor.UnsealResponse{}, ErrKeyVersionRequired
 	}
-	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, *req.KeyVersion)
+	kv, err := km.resolveUsableKeyVersion(ctx, req.TenantID, req.KeyID, req.KeyVersion)
 	if err != nil {
 		return cryptor.UnsealResponse{}, err
 	}

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestManagerSeal(t *testing.T) {
-	t.Run("should return error if key version is nil", func(t *testing.T) {
+	t.Run("should return error if key version is empty", func(t *testing.T) {
 		// given
 		c := keyprocessor.NewManager(nil, nil, nil)
 
@@ -51,7 +51,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -75,7 +75,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -108,7 +108,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -142,7 +142,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -176,7 +176,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -215,7 +215,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("secret payload")),
 			AAD:        []byte("aad"),
 		})
@@ -228,7 +228,7 @@ func TestManagerSeal(t *testing.T) {
 }
 
 func TestManagerUnseal(t *testing.T) {
-	t.Run("should return error if key version is nil", func(t *testing.T) {
+	t.Run("should return error if key version is empty", func(t *testing.T) {
 		// given
 		c := keyprocessor.NewManager(nil, nil, nil)
 
@@ -262,7 +262,7 @@ func TestManagerUnseal(t *testing.T) {
 		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -293,7 +293,7 @@ func TestManagerUnseal(t *testing.T) {
 		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -327,7 +327,7 @@ func TestManagerUnseal(t *testing.T) {
 		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -365,7 +365,7 @@ func TestManagerUnseal(t *testing.T) {
 		sealResp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("round trip data")),
 			AAD:        []byte("aad"),
 		})
@@ -375,7 +375,7 @@ func TestManagerUnseal(t *testing.T) {
 		unsealResp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Ciphertext: sealResp.Ciphertext,
 			AAD:        []byte("aad"),
 		})
@@ -511,7 +511,7 @@ func TestManagerHierarchy(t *testing.T) {
 		sealResp, err := leafMgr.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      leafKey.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Plaintext:  newTestData(t, []byte("top secret")),
 		})
 		assert.NoError(t, err)
@@ -519,7 +519,7 @@ func TestManagerHierarchy(t *testing.T) {
 		unsealResp, err := leafMgr.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      leafKey.ID,
-			KeyVersion: new("1"),
+			KeyVersion: "1",
 			Ciphertext: sealResp.Ciphertext,
 		})
 

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -16,7 +16,23 @@ import (
 	storesql "github.com/openkcm/krypton/pkg/store/sql"
 )
 
-func TestManagerEncrypt(t *testing.T) {
+func TestManagerSeal(t *testing.T) {
+	t.Run("should return error if key version is nil", func(t *testing.T) {
+		// given
+		c := keyprocessor.NewManager(nil, nil, nil)
+
+		// when
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
+			TenantID:  uuid.NewString(),
+			KeyID:     uuid.NewString(),
+			Plaintext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrKeyVersionRequired)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
+	})
+
 	t.Run("should return error if key version resolution fails", func(t *testing.T) {
 		// given
 		kvStoreErr := errors.New("database unavailable")
@@ -32,16 +48,16 @@ func TestManagerEncrypt(t *testing.T) {
 		c := keyprocessor.NewManager(nil, kvs, nil)
 
 		// when
-		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, kvStoreErr)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
 	})
 
 	t.Run("should return error if no usable key version found", func(t *testing.T) {
@@ -56,16 +72,16 @@ func TestManagerEncrypt(t *testing.T) {
 		c := keyprocessor.NewManager(nil, kvs, nil)
 
 		// when
-		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, keyprocessor.ErrNoUsableKeyVersion)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
 	})
 
 	t.Run("should return error if store lookup fails", func(t *testing.T) {
@@ -89,24 +105,25 @@ func TestManagerEncrypt(t *testing.T) {
 		c := keyprocessor.NewManager(ks, kvs, nil)
 
 		// when
-		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, storeErr)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
 	})
 
-	t.Run("should return error if processor not found for key kind", func(t *testing.T) {
+	t.Run("should return error if key is not active", func(t *testing.T) {
 		// given
 		key := &model.Key{
-			ID:       uuid.NewString(),
-			TenantID: uuid.NewString(),
-			Kind:     "UNKNOWN_KIND",
+			ID:             uuid.NewString(),
+			TenantID:       uuid.NewString(),
+			Kind:           "K1",
+			LifeCycleState: model.KeyLifeCycleDeactivated,
 		}
 
 		kvs := &keyVersionStoreWrapper{}
@@ -116,24 +133,56 @@ func TestManagerEncrypt(t *testing.T) {
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
-		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
-			assert.Equal(t, key.ID, id)
-			assert.Equal(t, key.TenantID, tid)
+		ks.getKeyByIDFn = func(_ context.Context, _, _ string) (*model.Key, error) {
+			return key, nil
+		}
+		c := keyprocessor.NewManager(ks, kvs, nil)
+
+		// when
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
+			TenantID:   key.TenantID,
+			KeyID:      key.ID,
+			KeyVersion: new("1"),
+			Plaintext:  newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrKeyNotActivated)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
+	})
+
+	t.Run("should return error if processor not found for key kind", func(t *testing.T) {
+		// given
+		key := &model.Key{
+			ID:             uuid.NewString(),
+			TenantID:       uuid.NewString(),
+			Kind:           "UNKNOWN_KIND",
+			LifeCycleState: model.KeyLifeCycleActive,
+		}
+
+		kvs := &keyVersionStoreWrapper{}
+		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
+			return store.ListKeyVersionsResult{
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+			}, nil
+		}
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, _, _ string) (*model.Key, error) {
 			return key, nil
 		}
 		c := keyprocessor.NewManager(ks, kvs, map[model.KeyKind]keyprocessor.Processor{})
 
 		// when
-		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, keyprocessor.ErrProcessorNotFound)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
 	})
 
 	t.Run("should succeed", func(t *testing.T) {
@@ -143,37 +192,58 @@ func TestManagerEncrypt(t *testing.T) {
 		keyStore := storesql.NewKeyStore(db)
 		kvStore := storesql.NewKeyVersionStore(db)
 
-		key := model.NewKey(tenantID, "enc-key-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+		rootKey := model.NewKey(tenantID, "root-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), rootKey))
+		activateKey(t, db, rootKey)
+		rootMgr := keyprocessor.NewRootManager(keyStore, newTestSealer(t))
 
-		kv := model.NewKeyVersion(tenantID, key.ID, "1", nil, nil)
+		key := model.NewKey(tenantID, "enc-key-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+		activateKey(t, db, key)
+
+		kv := model.NewKeyVersion(tenantID, key.ID, "1", &rootKey.ID, nil)
 		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: kv})
 		require.NoError(t, err)
 
-		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, rootMgr, newTestVault(t))
 		_, err = proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		c := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
 
 		// when
-		resp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Plaintext:  newTestData(t, []byte("secret payload")),
 			AAD:        []byte("aad"),
 		})
 
 		// then
 		assert.NoError(t, err)
-		assert.NotNil(t, resp)
 		assert.NotNil(t, resp.Ciphertext)
 		assert.NotEmpty(t, resp.Ciphertext.SecureBytes())
 	})
 }
 
-func TestManagerDecrypt(t *testing.T) {
+func TestManagerUnseal(t *testing.T) {
+	t.Run("should return error if key version is nil", func(t *testing.T) {
+		// given
+		c := keyprocessor.NewManager(nil, nil, nil)
+
+		// when
+		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
+			TenantID:   uuid.NewString(),
+			KeyID:      uuid.NewString(),
+			Ciphertext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrKeyVersionRequired)
+		assert.Equal(t, cryptor.UnsealResponse{}, resp)
+	})
+
 	t.Run("should return error if key version resolution fails", func(t *testing.T) {
 		// given
 		kvStoreErr := errors.New("database unavailable")
@@ -189,16 +259,16 @@ func TestManagerDecrypt(t *testing.T) {
 		c := keyprocessor.NewManager(nil, kvs, nil)
 
 		// when
-		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, kvStoreErr)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.UnsealResponse{}, resp)
 	})
 
 	t.Run("should return error if store lookup fails", func(t *testing.T) {
@@ -214,32 +284,31 @@ func TestManagerDecrypt(t *testing.T) {
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
-		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
-			assert.Equal(t, keyID, id)
-			assert.Equal(t, tenantID, tid)
+		ks.getKeyByIDFn = func(_ context.Context, _, _ string) (*model.Key, error) {
 			return nil, storeErr
 		}
 		c := keyprocessor.NewManager(ks, kvs, nil)
 
 		// when
-		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, storeErr)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.UnsealResponse{}, resp)
 	})
 
 	t.Run("should return error if processor not found for key kind", func(t *testing.T) {
 		// given
 		key := &model.Key{
-			ID:       uuid.NewString(),
-			TenantID: uuid.NewString(),
-			Kind:     "UNKNOWN_KIND",
+			ID:             uuid.NewString(),
+			TenantID:       uuid.NewString(),
+			Kind:           "UNKNOWN_KIND",
+			LifeCycleState: model.KeyLifeCycleActive,
 		}
 
 		kvs := &keyVersionStoreWrapper{}
@@ -249,24 +318,22 @@ func TestManagerDecrypt(t *testing.T) {
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
-		ks.getKeyByIDFn = func(_ context.Context, id, tid string) (*model.Key, error) {
-			assert.Equal(t, key.ID, id)
-			assert.Equal(t, key.TenantID, tid)
+		ks.getKeyByIDFn = func(_ context.Context, _, _ string) (*model.Key, error) {
 			return key, nil
 		}
 		c := keyprocessor.NewManager(ks, kvs, map[model.KeyKind]keyprocessor.Processor{})
 
 		// when
-		resp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
 		// then
 		assert.ErrorIs(t, err, keyprocessor.ErrProcessorNotFound)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.UnsealResponse{}, resp)
 	})
 
 	t.Run("should succeed with round trip", func(t *testing.T) {
@@ -276,58 +343,189 @@ func TestManagerDecrypt(t *testing.T) {
 		keyStore := storesql.NewKeyStore(db)
 		kvStore := storesql.NewKeyVersionStore(db)
 
-		key := model.NewKey(tenantID, "dec-key-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+		rootKey := model.NewKey(tenantID, "root-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), rootKey))
+		activateKey(t, db, rootKey)
+		rootMgr := keyprocessor.NewRootManager(keyStore, newTestSealer(t))
 
-		kv := model.NewKeyVersion(tenantID, key.ID, "1", nil, nil)
+		key := model.NewKey(tenantID, "dec-key-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+		activateKey(t, db, key)
+
+		kv := model.NewKeyVersion(tenantID, key.ID, "1", &rootKey.ID, nil)
 		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: kv})
 		require.NoError(t, err)
 
-		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		proc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, rootMgr, newTestVault(t))
 		_, err = proc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
 		c := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{key.Kind: *proc})
 
-		encResp, err := c.Encrypt(t.Context(), cryptor.EncryptRequest{
+		sealResp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: new("1"),
 			Plaintext:  newTestData(t, []byte("round trip data")),
 			AAD:        []byte("aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
-		decResp, err := c.Decrypt(t.Context(), cryptor.DecryptRequest{
+		unsealResp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
-			Ciphertext: encResp.Ciphertext,
+			KeyVersion: new("1"),
+			Ciphertext: sealResp.Ciphertext,
 			AAD:        []byte("aad"),
 		})
 
 		// then
 		assert.NoError(t, err)
-		assert.NotNil(t, decResp)
-		assert.Equal(t, []byte("round trip data"), []byte(decResp.Plaintext.SecureBytes()))
+		assert.Equal(t, []byte("round trip data"), []byte(unsealResp.Plaintext.SecureBytes()))
 	})
 }
 
-func TestManagerInfo(t *testing.T) {
-	t.Run("should return manager info with decryption secret required", func(t *testing.T) {
+func TestRootManager(t *testing.T) {
+	t.Run("should return error if store lookup fails", func(t *testing.T) {
 		// given
-		c := keyprocessor.NewManager(nil, nil, nil)
+		storeErr := errors.New("store unavailable")
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, _, _ string) (*model.Key, error) {
+			return nil, storeErr
+		}
+		c := keyprocessor.NewRootManager(ks, newTestSealer(t))
 
 		// when
-		info := c.Info()
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
+			TenantID:  uuid.NewString(),
+			KeyID:     uuid.NewString(),
+			Plaintext: newTestData(t, []byte("data")),
+		})
 
 		// then
-		assert.Equal(t, cryptor.Info{
-			Name:                     "keyprocessor-manager",
-			Type:                     keyprocessor.TypeManager,
-			DecryptionSecretRequired: true,
-		}, info)
+		assert.ErrorIs(t, err, storeErr)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
+	})
+
+	t.Run("should return error if key is not active", func(t *testing.T) {
+		// given
+		key := &model.Key{
+			ID:             uuid.NewString(),
+			TenantID:       uuid.NewString(),
+			LifeCycleState: model.KeyLifeCycleDeactivated,
+		}
+		ks := &keyStoreWrapper{}
+		ks.getKeyByIDFn = func(_ context.Context, _, _ string) (*model.Key, error) {
+			return key, nil
+		}
+		c := keyprocessor.NewRootManager(ks, newTestSealer(t))
+
+		// when
+		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
+			TenantID:  key.TenantID,
+			KeyID:     key.ID,
+			Plaintext: newTestData(t, []byte("data")),
+		})
+
+		// then
+		assert.ErrorIs(t, err, keyprocessor.ErrKeyNotActivated)
+		assert.Equal(t, cryptor.SealResponse{}, resp)
+	})
+
+	t.Run("should seal and unseal successfully", func(t *testing.T) {
+		// given
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+
+		key := model.NewKey(tenantID, "root-key-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), key))
+		activateKey(t, db, key)
+
+		c := keyprocessor.NewRootManager(keyStore, newTestSealer(t))
+
+		// when
+		sealResp, err := c.Seal(t.Context(), cryptor.SealRequest{
+			TenantID:  tenantID,
+			KeyID:     key.ID,
+			Plaintext: newTestData(t, []byte("root secret")),
+			AAD:       []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		unsealResp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
+			TenantID:   tenantID,
+			KeyID:      key.ID,
+			Ciphertext: sealResp.Ciphertext,
+			AAD:        []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("root secret"), []byte(unsealResp.Plaintext.SecureBytes()))
+	})
+}
+
+func TestManagerHierarchy(t *testing.T) {
+	t.Run("should succeed for three-level chain round trip", func(t *testing.T) {
+		// given
+		db := createDatabase(t)
+		tenantID := createTenant(t, db)
+		keyStore := storesql.NewKeyStore(db)
+		kvStore := storesql.NewKeyVersionStore(db)
+
+		// root level
+		rootKey := model.NewKey(tenantID, "root-"+uuid.NewString(), "K0", nil, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), rootKey))
+		activateKey(t, db, rootKey)
+		rootMgr := keyprocessor.NewRootManager(keyStore, newTestSealer(t))
+
+		// mid level
+		midKey := model.NewKey(tenantID, "mid-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), midKey))
+		activateKey(t, db, midKey)
+		midKV := model.NewKeyVersion(tenantID, midKey.ID, "1", &rootKey.ID, nil)
+		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: midKV})
+		require.NoError(t, err)
+
+		midProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newTestSealer(t), rootMgr, newTestVault(t))
+		_, err = midProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: midKV})
+		assert.NoError(t, err)
+		midMgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{"K1": *midProc})
+
+		// leaf level
+		leafKey := model.NewKey(tenantID, "leaf-"+uuid.NewString(), "K2", &midKey.ID, "test", nil)
+		require.NoError(t, keyStore.CreateKey(t.Context(), leafKey))
+		activateKey(t, db, leafKey)
+		leafKV := model.NewKeyVersion(tenantID, leafKey.ID, "1", &midKey.ID, &midKV.Version)
+		_, err = kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: leafKV})
+		require.NoError(t, err)
+
+		leafProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, midMgr, newTestVault(t))
+		_, err = leafProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: leafKV})
+		assert.NoError(t, err)
+		leafMgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{"K2": *leafProc})
+
+		// when
+		sealResp, err := leafMgr.Seal(t.Context(), cryptor.SealRequest{
+			TenantID:   tenantID,
+			KeyID:      leafKey.ID,
+			KeyVersion: new("1"),
+			Plaintext:  newTestData(t, []byte("top secret")),
+		})
+		assert.NoError(t, err)
+
+		unsealResp, err := leafMgr.Unseal(t.Context(), cryptor.UnsealRequest{
+			TenantID:   tenantID,
+			KeyID:      leafKey.ID,
+			KeyVersion: new("1"),
+			Ciphertext: sealResp.Ciphertext,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("top secret"), []byte(unsealResp.Plaintext.SecureBytes()))
 	})
 }
 

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -14,72 +14,38 @@ import (
 const persistSecName = "persistedSec"
 
 var (
-	// ErrMissingParentKeyVersion is returned when a processor has a parent cryptor set
-	// but the key version does not specify a parent key ID or parent key version.
-	ErrMissingParentKeyVersion = errors.New("parent set but key version has no parent key version")
+	// ErrMissingParentKey is returned when a processor has a parent set
+	// but the key version does not specify a parent key ID.
+	ErrMissingParentKey = errors.New("parent set but key version has no parent key")
 	// ErrSecNotPersisted is returned when a handler completes successfully
 	// but the secret is missing from the persistent vault, indicating a bug
 	ErrSecNotPersisted = errors.New("persisted secret missing from handler response")
 )
 
-// Processor creates, wraps, unwraps, and deletes secrets within a key hierarchy.
-// It destroys all intermediate secrets that pass through its operations.
-type Processor struct {
+// processor manages secret lifecycle and encryption within a key hierarchy.
+type processor struct {
 	generator       cryptor.SecretGenerator
-	wrapper         cryptor.Cryptor
-	transportSealer cryptor.Cryptor
-	parent          cryptor.Cryptor
+	cryptor         cryptor.Cryptor
+	transportSealer cryptor.Sealer
+	parent          cryptor.Sealer
 	vault           vault.Vault
 }
 
-// CreateSecretRequest is the input for CreateSecret.
-type CreateSecretRequest struct {
+type createSecretRequest struct {
 	KeyVersion model.KeyVersion
 	AAD        []byte
 }
 
-// CreateSecretResponse is the output of CreateSecret.
-type CreateSecretResponse struct{}
+type createSecretResponse struct{}
 
-// WrapSecretRequest is the input for WrapSecret.
-type WrapSecretRequest struct {
-	KeyVersion model.KeyVersion
-	Secret     *securemem.Data
-	AAD        []byte
-}
-
-// WrapSecretResponse is the output of WrapSecret.
-type WrapSecretResponse struct {
-	WrappedSecret *securemem.Data
-}
-
-// UnwrapSecretRequest is the input for UnwrapSecret.
-type UnwrapSecretRequest struct {
-	KeyVersion    model.KeyVersion
-	WrappedSecret *securemem.Data
-	AAD           []byte
-}
-
-// UnwrapSecretResponse is the output of UnwrapSecret.
-type UnwrapSecretResponse struct {
-	Secret *securemem.Data
-}
-
-// DeleteSecretRequest is the input for DeleteSecret.
-type DeleteSecretRequest struct {
+type deleteSecretRequest struct {
 	KeyVersion model.KeyVersion
 }
 
-// DeleteSecretResponse is the output of DeleteSecret.
-type DeleteSecretResponse struct{}
+type deleteSecretResponse struct{}
 
-// CreateSecret generates a secret, seals it, wraps it through the parent chain, and stores it in the vault.
-// It is a no-op when the wrapper manages its own decryption key.
-func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (CreateSecretResponse, error) {
-	if !p.wrapper.Info().DecryptionSecretRequired {
-		return CreateSecretResponse{}, nil
-	}
-
+// createSecret generates, seals, and stores a new secret for the given key version.
+func (p *processor) createSecret(ctx context.Context, req createSecretRequest) (createSecretResponse, error) {
 	_, err := securemem.Run(ctx, func(ctx context.Context, _ *securemem.HandlerRequest) error {
 		resp, err := p.generator.GenerateSecret(ctx)
 		if err != nil {
@@ -87,50 +53,36 @@ func (p *Processor) CreateSecret(ctx context.Context, req CreateSecretRequest) (
 		}
 		defer destroySec(resp.Secret)
 
-		sealSec, err := p.transportSeal(ctx, req.KeyVersion, resp.Secret, req.AAD)
+		transSealed, err := p.transportSeal(ctx, req.KeyVersion, resp.Secret, req.AAD)
 		if err != nil {
 			return err
 		}
-		defer destroySec(sealSec)
+		defer destroySec(transSealed)
 
-		wrapSec, err := p.parentWrap(ctx, req.KeyVersion, sealSec, req.AAD)
+		parentSealed, err := p.parentSeal(ctx, req.KeyVersion, transSealed, req.AAD)
 		if err != nil {
 			return err
 		}
-		defer destroySec(wrapSec)
+		defer destroySec(parentSealed)
 
 		_, err = p.vault.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    req.KeyVersion.TenantID,
 			KeyID:       req.KeyVersion.KeyID,
 			KeyVersion:  req.KeyVersion.Version,
 			KeyRevision: req.KeyVersion.Revision,
-			KeyMaterial: wrapSec,
+			KeyMaterial: parentSealed,
 			AAD:         req.AAD,
 		})
 		return err
 	})
 
-	return CreateSecretResponse{}, err
+	return createSecretResponse{}, err
 }
 
-// WrapSecret resolves the wrapping secret from the key chain and encrypts the given secret.
-// When the wrapper manages its own decryption key, it encrypts directly without resolving.
-func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (WrapSecretResponse, error) {
+// encrypt encrypts plaintext using the provided secret.
+func (p *processor) encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
-		sec, err := p.resolveSecret(ctx, req.KeyVersion)
-		if err != nil {
-			return err
-		}
-		defer destroySec(sec)
-
-		encResp, err := p.wrapper.Encrypt(ctx, cryptor.EncryptRequest{
-			TenantID:   req.KeyVersion.TenantID,
-			KeyID:      req.KeyVersion.KeyID,
-			KeyVersion: req.KeyVersion.Version,
-			Secret:     toCryptorSecret(sec),
-			Plaintext:  req.Secret,
-			AAD:        req.AAD,
-		})
+		encResp, err := p.cryptor.Encrypt(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -138,33 +90,22 @@ func (p *Processor) WrapSecret(ctx context.Context, req WrapSecretRequest) (Wrap
 		return sreq.PersistentVault().Import(persistSecName, encResp.Ciphertext)
 	})
 	if err != nil {
-		return WrapSecretResponse{}, err
+		return nil, err
 	}
 	sec, err := getPersistedSec(resp)
+	if err != nil {
+		return nil, err
+	}
 
-	return WrapSecretResponse{
-		WrappedSecret: sec,
-	}, err
+	return &cryptor.EncryptResponse{
+		Ciphertext: sec,
+	}, nil
 }
 
-// UnwrapSecret resolves the wrapping secret from the key chain and decrypts the given wrapped secret.
-// When the wrapper manages its own decryption key, it decrypts directly without resolving.
-func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (UnwrapSecretResponse, error) {
+// decrypt decrypts ciphertext using the provided secret.
+func (p *processor) decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
-		sec, err := p.resolveSecret(ctx, req.KeyVersion)
-		if err != nil {
-			return err
-		}
-		defer destroySec(sec)
-
-		decResp, err := p.wrapper.Decrypt(ctx, cryptor.DecryptRequest{
-			TenantID:   req.KeyVersion.TenantID,
-			KeyID:      req.KeyVersion.KeyID,
-			KeyVersion: req.KeyVersion.Version,
-			Secret:     toCryptorSecret(sec),
-			Ciphertext: req.WrappedSecret,
-			AAD:        req.AAD,
-		})
+		decResp, err := p.cryptor.Decrypt(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -172,22 +113,20 @@ func (p *Processor) UnwrapSecret(ctx context.Context, req UnwrapSecretRequest) (
 		return sreq.PersistentVault().Import(persistSecName, decResp.Plaintext)
 	})
 	if err != nil {
-		return UnwrapSecretResponse{}, err
+		return nil, err
 	}
 	sec, err := getPersistedSec(resp)
-
-	return UnwrapSecretResponse{
-		Secret: sec,
-	}, err
-}
-
-// DeleteSecret removes the wrapping secret from the vault.
-// It is a no-op when the wrapper manages its own decryption key.
-func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (DeleteSecretResponse, error) {
-	if !p.wrapper.Info().DecryptionSecretRequired {
-		return DeleteSecretResponse{}, nil
+	if err != nil {
+		return nil, err
 	}
 
+	return &cryptor.DecryptResponse{
+		Plaintext: sec,
+	}, nil
+}
+
+// deleteSecret removes a secret from the vault.
+func (p *processor) deleteSecret(ctx context.Context, req deleteSecretRequest) (deleteSecretResponse, error) {
 	_, err := p.vault.DestroyKey(ctx, vault.DestroyKeyRequest{
 		TenantID:    req.KeyVersion.TenantID,
 		KeyID:       req.KeyVersion.KeyID,
@@ -195,17 +134,14 @@ func (p *Processor) DeleteSecret(ctx context.Context, req DeleteSecretRequest) (
 		KeyRevision: req.KeyVersion.Revision,
 	})
 	if err != nil {
-		return DeleteSecretResponse{}, err
+		return deleteSecretResponse{}, err
 	}
 
-	return DeleteSecretResponse{}, nil
+	return deleteSecretResponse{}, nil
 }
 
-func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*securemem.Data, error) {
-	if !p.wrapper.Info().DecryptionSecretRequired {
-		return nil, nil //nolint:nilnil
-	}
-
+// resolveSecret retrieves and unseals the secret for the given key version.
+func (p *processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (cryptor.Secret, error) {
 	resp, err := securemem.Run(ctx, func(ctx context.Context, sreq *securemem.HandlerRequest) error {
 		exported, err := p.vault.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:    kv.TenantID,
@@ -218,20 +154,20 @@ func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*se
 		}
 		defer destroySec(exported.KeyMaterial)
 
-		unwrapSec, err := p.parentUnwrap(ctx, kv, exported.KeyMaterial, exported.AAD)
+		parentUnsealed, err := p.parentUnseal(ctx, kv, exported.KeyMaterial, exported.AAD)
 		if err != nil {
 			return err
 		}
-		defer destroySec(unwrapSec)
+		defer destroySec(parentUnsealed)
 
-		unsealSec, err := p.unseal(ctx, kv, unwrapSec, exported.AAD)
+		transUnsealed, err := p.transportUnseal(ctx, kv, parentUnsealed, exported.AAD)
 		if err != nil {
 			return err
 		}
-		defer destroySec(unsealSec)
+		defer destroySec(transUnsealed)
 
 		// copy so that defers can unconditionally destroy all intermediates.
-		sec, err := copySec(unsealSec)
+		sec, err := copySec(transUnsealed)
 		if err != nil {
 			return nil
 		}
@@ -239,20 +175,27 @@ func (p *Processor) resolveSecret(ctx context.Context, kv model.KeyVersion) (*se
 		return sreq.PersistentVault().Import(persistSecName, sec)
 	})
 	if err != nil {
-		return nil, err
+		return cryptor.Secret{}, err
+	}
+	sec, err := getPersistedSec(resp)
+	if err != nil {
+		return cryptor.Secret{}, err
 	}
 
-	return getPersistedSec(resp)
+	return cryptor.Secret{
+		Algorithm: cryptor.KeyAlgorithmAES256,
+		Data:      sec,
+	}, nil
 }
 
-func (p *Processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
-	resp, err := p.transportSealer.Encrypt(ctx, cryptor.EncryptRequest{
+	resp, err := p.transportSealer.Seal(ctx, cryptor.SealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      kv.KeyID,
-		KeyVersion: kv.Version,
+		KeyVersion: &kv.Version,
 		Plaintext:  sec,
 		AAD:        aad,
 	})
@@ -262,14 +205,14 @@ func (p *Processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec 
 	return resp.Ciphertext, nil
 }
 
-func (p *Processor) unseal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+func (p *processor) transportUnseal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
 	if p.transportSealer == nil {
 		return sec, nil
 	}
-	resp, err := p.transportSealer.Decrypt(ctx, cryptor.DecryptRequest{
+	resp, err := p.transportSealer.Unseal(ctx, cryptor.UnsealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      kv.KeyID,
-		KeyVersion: kv.Version,
+		KeyVersion: &kv.Version,
 		Ciphertext: sec,
 		AAD:        aad,
 	})
@@ -279,17 +222,14 @@ func (p *Processor) unseal(ctx context.Context, kv model.KeyVersion, sec *secure
 	return resp.Plaintext, nil
 }
 
-func (p *Processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
-	if p.parent == nil {
-		return sec, nil
+func (p *processor) parentSeal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if kv.ParentKeyID == nil {
+		return nil, ErrMissingParentKey
 	}
-	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
-		return nil, ErrMissingParentKeyVersion
-	}
-	resp, err := p.parent.Encrypt(ctx, cryptor.EncryptRequest{
+	resp, err := p.parent.Seal(ctx, cryptor.SealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      *kv.ParentKeyID,
-		KeyVersion: *kv.ParentKeyVersion,
+		KeyVersion: kv.ParentKeyVersion,
 		Plaintext:  sec,
 		AAD:        aad,
 	})
@@ -299,17 +239,14 @@ func (p *Processor) parentWrap(ctx context.Context, kv model.KeyVersion, sec *se
 	return resp.Ciphertext, nil
 }
 
-func (p *Processor) parentUnwrap(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
-	if p.parent == nil {
-		return sec, nil
+func (p *processor) parentUnseal(ctx context.Context, kv model.KeyVersion, sec *securemem.Data, aad []byte) (*securemem.Data, error) {
+	if kv.ParentKeyID == nil {
+		return nil, ErrMissingParentKey
 	}
-	if kv.ParentKeyID == nil || kv.ParentKeyVersion == nil {
-		return nil, ErrMissingParentKeyVersion
-	}
-	resp, err := p.parent.Decrypt(ctx, cryptor.DecryptRequest{
+	resp, err := p.parent.Unseal(ctx, cryptor.UnsealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      *kv.ParentKeyID,
-		KeyVersion: *kv.ParentKeyVersion,
+		KeyVersion: kv.ParentKeyVersion,
 		Ciphertext: sec,
 		AAD:        aad,
 	})
@@ -344,14 +281,4 @@ func copySec(src *securemem.Data) (*securemem.Data, error) {
 	}
 	copy(dst.SecureBytes(), src.SecureBytes())
 	return dst, nil
-}
-
-func toCryptorSecret(data *securemem.Data) *cryptor.Secret {
-	if data == nil {
-		return nil
-	}
-	return &cryptor.Secret{
-		Algorithm: cryptor.KeyAlgorithmAES256,
-		Data:      data,
-	}
 }

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -195,7 +195,7 @@ func (p *processor) transportSeal(ctx context.Context, kv model.KeyVersion, sec 
 	resp, err := p.transportSealer.Seal(ctx, cryptor.SealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      kv.KeyID,
-		KeyVersion: &kv.Version,
+		KeyVersion: kv.Version,
 		Plaintext:  sec,
 		AAD:        aad,
 	})
@@ -212,7 +212,7 @@ func (p *processor) transportUnseal(ctx context.Context, kv model.KeyVersion, se
 	resp, err := p.transportSealer.Unseal(ctx, cryptor.UnsealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      kv.KeyID,
-		KeyVersion: &kv.Version,
+		KeyVersion: kv.Version,
 		Ciphertext: sec,
 		AAD:        aad,
 	})
@@ -226,10 +226,14 @@ func (p *processor) parentSeal(ctx context.Context, kv model.KeyVersion, sec *se
 	if kv.ParentKeyID == nil {
 		return nil, ErrMissingParentKey
 	}
+	var parentVersion string
+	if kv.ParentKeyVersion != nil {
+		parentVersion = *kv.ParentKeyVersion
+	}
 	resp, err := p.parent.Seal(ctx, cryptor.SealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      *kv.ParentKeyID,
-		KeyVersion: kv.ParentKeyVersion,
+		KeyVersion: parentVersion,
 		Plaintext:  sec,
 		AAD:        aad,
 	})
@@ -243,10 +247,14 @@ func (p *processor) parentUnseal(ctx context.Context, kv model.KeyVersion, sec *
 	if kv.ParentKeyID == nil {
 		return nil, ErrMissingParentKey
 	}
+	var parentVersion string
+	if kv.ParentKeyVersion != nil {
+		parentVersion = *kv.ParentKeyVersion
+	}
 	resp, err := p.parent.Unseal(ctx, cryptor.UnsealRequest{
 		TenantID:   kv.TenantID,
 		KeyID:      *kv.ParentKeyID,
-		KeyVersion: kv.ParentKeyVersion,
+		KeyVersion: parentVersion,
 		Ciphertext: sec,
 		AAD:        aad,
 	})

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -18,16 +18,13 @@ import (
 	"github.com/openkcm/krypton/internal/vault"
 	"github.com/openkcm/krypton/internal/vault/sqlitevault"
 	"github.com/openkcm/krypton/pkg/model"
-	"github.com/openkcm/krypton/pkg/store"
 	storesql "github.com/openkcm/krypton/pkg/store/sql"
 )
 
 type parentSetup struct {
 	tenantID  string
 	parentKey model.Key
-	parentKV  model.KeyVersion
-	manager   *keyprocessor.Manager
-	vault     *vaultWrapper // exposed for error injection in tests
+	sealer    *sealerWrapper // exposed for error injection in tests
 }
 
 func setupParent(t *testing.T) *parentSetup {
@@ -35,46 +32,22 @@ func setupParent(t *testing.T) *parentSetup {
 	db := createDatabase(t)
 	tenantID := createTenant(t, db)
 	keyStore := storesql.NewKeyStore(db)
-	kvStore := storesql.NewKeyVersionStore(db)
 
 	parentKey := model.NewKey(tenantID, "parent-"+uuid.NewString(), "K0", nil, "test", nil)
 	require.NoError(t, keyStore.CreateKey(t.Context(), parentKey))
+	activateKey(t, db, parentKey)
 
-	parentKV := model.NewKeyVersion(tenantID, parentKey.ID, "1", nil, nil)
-	_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: parentKV})
-	require.NoError(t, err)
-
-	v := &vaultWrapper{Vault: newTestVault(t)}
-	parentProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
-	_, err = parentProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: parentKV})
-	require.NoError(t, err)
-
-	mgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{parentKey.Kind: *parentProc})
+	rootMgr := keyprocessor.NewRootManager(keyStore, newTestSealer(t))
+	sw := &sealerWrapper{Sealer: rootMgr}
 
 	return &parentSetup{
 		tenantID:  tenantID,
 		parentKey: parentKey,
-		parentKV:  parentKV,
-		manager:   mgr,
-		vault:     v,
+		sealer:    sw,
 	}
 }
 
 func TestCreateSecret(t *testing.T) {
-	t.Run("should not create if wrapper manages its own decryption key", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
-
-		// when
-		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-	})
-
 	t.Run("should return error if secret generation fails", func(t *testing.T) {
 		// given
 		genErr := errors.New("entropy exhausted")
@@ -83,11 +56,12 @@ func TestCreateSecret(t *testing.T) {
 		gen.generateSecretFn = func(context.Context) (*cryptor.GenerateSecretResponse, error) {
 			return nil, genErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, nil, newTestVault(t))
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, newTestSealer(t), newTestVault(t))
 
+		parentKeyID := uuid.NewString()
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", &parentKeyID, nil),
 		})
 
 		// then
@@ -95,7 +69,7 @@ func TestCreateSecret(t *testing.T) {
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
-	t.Run("should return error if sealing fails", func(t *testing.T) {
+	t.Run("should return error if transport sealing fails", func(t *testing.T) {
 		// given
 		sealErr := errors.New("sealing failed")
 
@@ -112,17 +86,18 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		sealer := &cryptorWrapper{Cryptor: newStaticSecretCryptor(t)}
-		sealer.encryptFn = func(_ context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
+		sealer := &sealerWrapper{Sealer: newTestSealer(t)}
+		sealer.sealFn = func(_ context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
 			assert.Equal(t, tenantID, req.TenantID)
 			assert.Equal(t, keyID, req.KeyID)
-			return &cryptor.EncryptResponse{}, sealErr
+			return cryptor.SealResponse{}, sealErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, nil, newTestVault(t))
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, newTestSealer(t), newTestVault(t))
 
+		parentKeyID := uuid.NewString()
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: model.NewKeyVersion(tenantID, keyID, "1", nil, nil),
+			KeyVersion: model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil),
 		})
 
 		// then
@@ -131,12 +106,12 @@ func TestCreateSecret(t *testing.T) {
 		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should return error if parent wrapping fails", func(t *testing.T) {
+	t.Run("should return error if parent sealing fails", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent vault down")
 		ps := setupParent(t)
-		ps.vault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, parentErr
+		ps.sealer.sealFn = func(_ context.Context, _ cryptor.SealRequest) (cryptor.SealResponse, error) {
+			return cryptor.SealResponse{}, parentErr
 		}
 
 		var genSec *securemem.Data
@@ -149,8 +124,8 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.manager, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.sealer, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -163,12 +138,12 @@ func TestCreateSecret(t *testing.T) {
 		assert.Nil(t, genSec.SecureBytes())
 	})
 
-	t.Run("should return error if parent wrapping fails after sealing", func(t *testing.T) {
+	t.Run("should return error if parent sealing fails after transport sealing", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent vault down")
 		ps := setupParent(t)
-		ps.vault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, parentErr
+		ps.sealer.sealFn = func(_ context.Context, _ cryptor.SealRequest) (cryptor.SealResponse, error) {
+			return cryptor.SealResponse{}, parentErr
 		}
 
 		var genSec *securemem.Data
@@ -181,19 +156,19 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		realSealer := newStaticSecretCryptor(t)
+		realSealer := newTestSealer(t)
 		var sealedSec *securemem.Data
-		sealer := &cryptorWrapper{Cryptor: realSealer}
-		sealer.encryptFn = func(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
-			resp, err := realSealer.Encrypt(ctx, req)
+		sealer := &sealerWrapper{Sealer: realSealer}
+		sealer.sealFn = func(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
+			resp, err := realSealer.Seal(ctx, req)
 			if err == nil {
 				sealedSec = resp.Ciphertext
 			}
 			return resp, err
 		}
 
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, ps.manager, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, ps.sealer, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -224,14 +199,14 @@ func TestCreateSecret(t *testing.T) {
 		}
 
 		childKeyID := uuid.NewString()
-		childKV := model.NewKeyVersion(ps.tenantID, childKeyID, "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		childKV := model.NewKeyVersion(ps.tenantID, childKeyID, "1", &ps.parentKey.ID, nil)
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		v.importKeyFn = func(_ context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
 			assert.Equal(t, ps.tenantID, req.TenantID)
 			assert.Equal(t, childKeyID, req.KeyID)
 			return nil, importErr
 		}
-		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.manager, v)
+		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.sealer, v)
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -248,7 +223,7 @@ func TestCreateSecret(t *testing.T) {
 		// given
 		ps := setupParent(t)
 		orphanKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", nil, nil)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -256,29 +231,15 @@ func TestCreateSecret(t *testing.T) {
 		})
 
 		// then
-		assert.ErrorIs(t, err, keyprocessor.ErrMissingParentKeyVersion)
+		assert.ErrorIs(t, err, keyprocessor.ErrMissingParentKey)
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
-	t.Run("should succeed for processor with sealer", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
-
-		// when
-		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
-	})
-
-	t.Run("should succeed for processor with parent", func(t *testing.T) {
+	t.Run("should succeed", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -290,11 +251,11 @@ func TestCreateSecret(t *testing.T) {
 		assert.Equal(t, keyprocessor.CreateSecretResponse{}, resp)
 	})
 
-	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
+	t.Run("should succeed with transport sealer", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newTestSealer(t), ps.sealer, newTestVault(t))
 
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
@@ -308,28 +269,17 @@ func TestCreateSecret(t *testing.T) {
 }
 
 func TestResolveSecret(t *testing.T) {
-	t.Run("should return nil if wrapper manages its own decryption key", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
-
-		// when
-		sec, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil))
-
-		// then
-		assert.NoError(t, err)
-		assert.Nil(t, sec)
-	})
-
 	t.Run("should return error if key is not found", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), newTestVault(t))
 
+		parentKeyID := uuid.NewString()
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil))
+		sec, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", &parentKeyID, nil))
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.Secret{}, sec)
 	})
 
 	t.Run("should return error if vault export fails", func(t *testing.T) {
@@ -338,10 +288,11 @@ func TestResolveSecret(t *testing.T) {
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		kv := model.NewKeyVersion(tenantID, keyID, "1", nil, nil)
+		parentKeyID := uuid.NewString()
+		kv := model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), v)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
@@ -352,21 +303,21 @@ func TestResolveSecret(t *testing.T) {
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), kv)
+		sec, err := processor.ResolveSecret(t.Context(), kv)
 
 		// then
 		assert.ErrorIs(t, err, exportErr)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.Secret{}, sec)
 	})
 
-	t.Run("should return error if parent unwrap fails", func(t *testing.T) {
+	t.Run("should return error if parent unsealing fails", func(t *testing.T) {
 		// given
 		parentErr := errors.New("parent unavailable")
 		ps := setupParent(t)
 
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, v)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, v)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
@@ -378,34 +329,35 @@ func TestResolveSecret(t *testing.T) {
 			}
 			return resp, err
 		}
-		ps.vault.exportKeyFn = func(_ context.Context, _ vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, parentErr
+		ps.sealer.unsealFn = func(_ context.Context, _ cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
+			return cryptor.UnsealResponse{}, parentErr
 		}
 
 		// when
-		resp, err := processor.ResolveSecret(t.Context(), childKV)
+		sec, err := processor.ResolveSecret(t.Context(), childKV)
 
 		// then
 		assert.ErrorIs(t, err, parentErr)
-		assert.Nil(t, resp)
+		assert.Equal(t, cryptor.Secret{}, sec)
 		assert.NotNil(t, exportSec)
 		assert.Nil(t, exportSec.SecureBytes())
 	})
 
-	t.Run("should return error if unsealing fails", func(t *testing.T) {
+	t.Run("should return error if transport unsealing fails", func(t *testing.T) {
 		// given
 		unsealErr := errors.New("unsealing failed")
 
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
+		parentKeyID := uuid.NewString()
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", &parentKeyID, nil)
 
-		realSealer := newStaticSecretCryptor(t)
-		sealer := &cryptorWrapper{Cryptor: realSealer}
-		sealer.decryptFn = func(_ context.Context, _ cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
-			return &cryptor.DecryptResponse{}, unsealErr
+		realSealer := newTestSealer(t)
+		sealer := &sealerWrapper{Sealer: realSealer}
+		sealer.unsealFn = func(_ context.Context, _ cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
+			return cryptor.UnsealResponse{}, unsealErr
 		}
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), sealer, nil, v)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), sealer, newTestSealer(t), v)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
@@ -417,422 +369,197 @@ func TestResolveSecret(t *testing.T) {
 			}
 			return resp, err
 		}
-
-		// when
-		resp, err := processor.ResolveSecret(t.Context(), kv)
-
-		// then
-		assert.ErrorIs(t, err, unsealErr)
-		assert.Nil(t, resp)
-		assert.NotNil(t, exportSec)
-		assert.Nil(t, exportSec.SecureBytes())
-	})
-
-	t.Run("should succeed for processor with sealer", func(t *testing.T) {
-		// given
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
-
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
-		assert.NoError(t, err)
 
 		// when
 		sec, err := processor.ResolveSecret(t.Context(), kv)
 
 		// then
-		assert.NoError(t, err)
-		assert.NotNil(t, sec)
-		assert.NotNil(t, sec.SecureBytes())
-	})
-
-	t.Run("should succeed for processor with parent", func(t *testing.T) {
-		// given
-		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
-		assert.NoError(t, err)
-
-		// when
-		sec, err := processor.ResolveSecret(t.Context(), childKV)
-
-		// then
-		assert.NoError(t, err)
-		assert.NotNil(t, sec)
-		assert.NotNil(t, sec.SecureBytes())
-	})
-
-	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
-		// given
-		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
-		assert.NoError(t, err)
-
-		// when
-		sec, err := processor.ResolveSecret(t.Context(), childKV)
-
-		// then
-		assert.NoError(t, err)
-		assert.NotNil(t, sec)
-		assert.NotNil(t, sec.SecureBytes())
-	})
-}
-
-func TestWrapSecret(t *testing.T) {
-	t.Run("should return error if resolve fails", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-
-		// when
-		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
-			Secret:     newTestData(t, []byte("data")),
-		})
-
-		// then
-		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
-		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
-	})
-
-	t.Run("should return error if encryption fails", func(t *testing.T) {
-		// given
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
-
-		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
-		assert.NoError(t, err)
-
-		var exportSec *securemem.Data
-		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			resp, err := v.Vault.ExportKey(ctx, req)
-			if err == nil {
-				exportSec = resp.KeyMaterial
-			}
-			return resp, err
-		}
-
-		// when — nil plaintext is rejected by aes256gcm
-		resp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: kv,
-			Secret:     nil,
-		})
-
-		// then
-		assert.Error(t, err)
-		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
-		assert.Nil(t, exportSec.SecureBytes())
-	})
-
-	t.Run("should wrap without resolving if wrapper manages its own decryption key", func(t *testing.T) {
-		// given
-		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, nil)
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
-
-		// when
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: kv,
-			Secret:     newTestData(t, []byte("data")),
-		})
-		assert.NoError(t, err)
-
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    kv,
-			WrappedSecret: wrapResp.WrappedSecret,
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("data"), []byte(unwrapResp.Secret.SecureBytes()))
-	})
-
-	t.Run("should succeed for processor with sealer", func(t *testing.T) {
-		// given
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
-
-		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, v)
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
-		assert.NoError(t, err)
-
-		var exportSec *securemem.Data
-		v.exportKeyFn = func(ctx context.Context, req vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			resp, err := v.Vault.ExportKey(ctx, req)
-			if err == nil {
-				exportSec = resp.KeyMaterial
-			}
-			return resp, err
-		}
-
-		// when
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: kv,
-			Secret:     newTestData(t, []byte("payload")),
-			AAD:        []byte("aad"),
-		})
-		assert.NoError(t, err)
-
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    kv,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("aad"),
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+		assert.ErrorIs(t, err, unsealErr)
+		assert.Equal(t, cryptor.Secret{}, sec)
 		assert.NotNil(t, exportSec)
 		assert.Nil(t, exportSec.SecureBytes())
 	})
 
-	t.Run("should succeed for processor with parent", func(t *testing.T) {
+	t.Run("should succeed", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, newTestVault(t))
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: childKV,
-			Secret:     newTestData(t, []byte("payload")),
-			AAD:        []byte("aad"),
-		})
-		assert.NoError(t, err)
-
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    childKV,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("aad"),
-		})
+		sec, err := processor.ResolveSecret(t.Context(), childKV)
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+		assert.NotNil(t, sec.Data)
+		assert.NotEmpty(t, sec.Data.SecureBytes())
+		assert.Equal(t, cryptor.KeyAlgorithmAES256, sec.Algorithm)
 	})
 
-	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
+	t.Run("should succeed with transport sealer", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newTestSealer(t), ps.sealer, newTestVault(t))
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
 
 		// when
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: childKV,
-			Secret:     newTestData(t, []byte("payload")),
-			AAD:        []byte("aad"),
-		})
-		assert.NoError(t, err)
-
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    childKV,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("aad"),
-		})
+		sec, err := processor.ResolveSecret(t.Context(), childKV)
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+		assert.NotNil(t, sec.Data)
+		assert.NotEmpty(t, sec.Data.SecureBytes())
+		assert.Equal(t, cryptor.KeyAlgorithmAES256, sec.Algorithm)
 	})
 }
 
-func TestUnwrapSecret(t *testing.T) {
-	t.Run("should return error if resolve fails", func(t *testing.T) {
+func TestEncrypt(t *testing.T) {
+	t.Run("should return error if plaintext is nil", func(t *testing.T) {
 		// given
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
+		processor := keyprocessor.NewProcessor(nil, newTestCryptor(), nil, nil, nil)
 
 		// when
-		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
-			WrappedSecret: newTestData(t, []byte("ciphertext")),
+		resp, err := processor.Encrypt(t.Context(), cryptor.EncryptRequest{
+			Secret:    newTestSecret(t),
+			Plaintext: nil,
 		})
 
 		// then
-		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
-		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
+		assert.Error(t, err)
+		assert.Nil(t, resp)
 	})
 
-	t.Run("should return error if decryption fails with tampered ciphertext", func(t *testing.T) {
+	t.Run("should encrypt and decrypt round trip", func(t *testing.T) {
 		// given
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
+		processor := keyprocessor.NewProcessor(nil, newTestCryptor(), nil, nil, nil)
+		sec := newTestSecret(t)
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
-		assert.NoError(t, err)
-
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: kv,
-			Secret:     newTestData(t, []byte("data")),
+		// when
+		encResp, err := processor.Encrypt(t.Context(), cryptor.EncryptRequest{
+			Secret:    sec,
+			Plaintext: newTestData(t, []byte("hello")),
 		})
 		assert.NoError(t, err)
 
-		original := wrapResp.WrappedSecret.SecureBytes()
+		decResp, err := processor.Decrypt(t.Context(), cryptor.DecryptRequest{
+			Secret:     sec,
+			Ciphertext: encResp.Ciphertext,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("hello"), []byte(decResp.Plaintext.SecureBytes()))
+	})
+
+	t.Run("should encrypt and decrypt round trip with AAD", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor(nil, newTestCryptor(), nil, nil, nil)
+		sec := newTestSecret(t)
+
+		// when
+		encResp, err := processor.Encrypt(t.Context(), cryptor.EncryptRequest{
+			Secret:    sec,
+			Plaintext: newTestData(t, []byte("payload")),
+			AAD:       []byte("aad"),
+		})
+		assert.NoError(t, err)
+
+		decResp, err := processor.Decrypt(t.Context(), cryptor.DecryptRequest{
+			Secret:     sec,
+			Ciphertext: encResp.Ciphertext,
+			AAD:        []byte("aad"),
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("payload"), []byte(decResp.Plaintext.SecureBytes()))
+	})
+}
+
+func TestDecrypt(t *testing.T) {
+	t.Run("should return error with tampered ciphertext", func(t *testing.T) {
+		// given
+		processor := keyprocessor.NewProcessor(nil, newTestCryptor(), nil, nil, nil)
+		sec := newTestSecret(t)
+
+		encResp, err := processor.Encrypt(t.Context(), cryptor.EncryptRequest{
+			Secret:    sec,
+			Plaintext: newTestData(t, []byte("data")),
+		})
+		assert.NoError(t, err)
+
+		original := encResp.Ciphertext.SecureBytes()
 		tampered := make([]byte, len(original))
 		copy(tampered, original)
 		tampered[0] ^= 0xFF
 
 		// when
-		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    kv,
-			WrappedSecret: newTestData(t, tampered),
+		resp, err := processor.Decrypt(t.Context(), cryptor.DecryptRequest{
+			Secret:     sec,
+			Ciphertext: newTestData(t, tampered),
 		})
 
 		// then
 		assert.Error(t, err)
-		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
+		assert.Nil(t, resp)
 	})
 
-	t.Run("should return error if decryption fails with wrong AAD", func(t *testing.T) {
+	t.Run("should return error with wrong AAD", func(t *testing.T) {
 		// given
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
+		processor := keyprocessor.NewProcessor(nil, newTestCryptor(), nil, nil, nil)
+		sec := newTestSecret(t)
 
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: kv,
-			AAD:        []byte("create-aad"),
-		})
-		assert.NoError(t, err)
-
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: kv,
-			Secret:     newTestData(t, []byte("data")),
-			AAD:        []byte("wrap-aad"),
+		encResp, err := processor.Encrypt(t.Context(), cryptor.EncryptRequest{
+			Secret:    sec,
+			Plaintext: newTestData(t, []byte("data")),
+			AAD:       []byte("correct-aad"),
 		})
 		assert.NoError(t, err)
 
 		// when
-		resp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    kv,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("wrong-aad"),
+		resp, err := processor.Decrypt(t.Context(), cryptor.DecryptRequest{
+			Secret:     sec,
+			Ciphertext: encResp.Ciphertext,
+			AAD:        []byte("wrong-aad"),
 		})
 
 		// then
 		assert.Error(t, err)
-		assert.Equal(t, keyprocessor.UnwrapSecretResponse{}, resp)
+		assert.Nil(t, resp)
 	})
 
-	t.Run("should succeed for processor with sealer", func(t *testing.T) {
+	t.Run("should return error if ciphertext is nil", func(t *testing.T) {
 		// given
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil)
-
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), nil, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
-		assert.NoError(t, err)
-
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: kv,
-			Secret:     newTestData(t, []byte("payload")),
-			AAD:        []byte("aad"),
-		})
-		assert.NoError(t, err)
+		processor := keyprocessor.NewProcessor(nil, newTestCryptor(), nil, nil, nil)
 
 		// when
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    kv,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("aad"),
+		resp, err := processor.Decrypt(t.Context(), cryptor.DecryptRequest{
+			Secret:     newTestSecret(t),
+			Ciphertext: nil,
 		})
 
 		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
-	})
-
-	t.Run("should succeed for processor with parent", func(t *testing.T) {
-		// given
-		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
-		assert.NoError(t, err)
-
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: childKV,
-			Secret:     newTestData(t, []byte("payload")),
-			AAD:        []byte("aad"),
-		})
-		assert.NoError(t, err)
-
-		// when
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    childKV,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("aad"),
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
-	})
-
-	t.Run("should succeed for processor with sealer and parent", func(t *testing.T) {
-		// given
-		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), ps.manager, newTestVault(t))
-		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
-		assert.NoError(t, err)
-
-		wrapResp, err := processor.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: childKV,
-			Secret:     newTestData(t, []byte("payload")),
-			AAD:        []byte("aad"),
-		})
-		assert.NoError(t, err)
-
-		// when
-		unwrapResp, err := processor.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    childKV,
-			WrappedSecret: wrapResp.WrappedSecret,
-			AAD:           []byte("aad"),
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("payload"), []byte(unwrapResp.Secret.SecureBytes()))
+		assert.Error(t, err)
+		assert.Nil(t, resp)
 	})
 }
 
 func TestDeleteSecret(t *testing.T) {
-	t.Run("should not delete if wrapper manages its own decryption key", func(t *testing.T) {
-		// given
-		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(nil, newStaticSecretCryptor(t), nil, nil, v)
-
-		var called bool
-		v.destroyKeyFn = func(context.Context, vault.DestroyKeyRequest) (*vault.DestroyKeyResponse, error) {
-			called = true
-			return &vault.DestroyKeyResponse{}, nil
-		}
-
-		// when
-		resp, err := processor.DeleteSecret(t.Context(), keyprocessor.DeleteSecretRequest{
-			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", nil, nil),
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, keyprocessor.DeleteSecretResponse{}, resp)
-		assert.False(t, called)
-	})
-
 	t.Run("should return error if key destroy fails", func(t *testing.T) {
 		// given
 		destroyErr := errors.New("vault locked")
 
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		kv := model.NewKeyVersion(tenantID, keyID, "1", nil, nil)
+		parentKeyID := uuid.NewString()
+		kv := model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), v)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
@@ -854,10 +581,11 @@ func TestDeleteSecret(t *testing.T) {
 		// given
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
-		kv := model.NewKeyVersion(tenantID, keyID, "1", nil, nil)
+		parentKeyID := uuid.NewString()
+		kv := model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
-		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, nil, v)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), v)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: kv})
 		assert.NoError(t, err)
 
@@ -873,109 +601,6 @@ func TestDeleteSecret(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, keyprocessor.DeleteSecretResponse{}, resp)
-	})
-}
-
-func TestHierarchy(t *testing.T) {
-	t.Run("should succeed for two-level chain round trip", func(t *testing.T) {
-		// given
-		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
-		_, err := child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
-		assert.NoError(t, err)
-
-		// when
-		wrapResp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: childKV,
-			Secret:     newTestData(t, []byte("classified")),
-		})
-		assert.NoError(t, err)
-
-		unwrapResp, err := child.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    childKV,
-			WrappedSecret: wrapResp.WrappedSecret,
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("classified"), []byte(unwrapResp.Secret.SecureBytes()))
-	})
-
-	t.Run("should succeed for three-level chain round trip", func(t *testing.T) {
-		// given
-		db := createDatabase(t)
-		tenantID := createTenant(t, db)
-		keyStore := storesql.NewKeyStore(db)
-		kvStore := storesql.NewKeyVersionStore(db)
-
-		rootKey := model.NewKey(tenantID, "root-"+uuid.NewString(), "K0", nil, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), rootKey))
-		rootKV := model.NewKeyVersion(tenantID, rootKey.ID, "1", nil, nil)
-		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: rootKV})
-		require.NoError(t, err)
-
-		rootProc := keyprocessor.NewProcessor(newTestSecretGen(), newStaticSecretCryptor(t), nil, nil, newTestVault(t))
-		_, err = rootProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: rootKV})
-		assert.NoError(t, err)
-		rootMgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{rootKey.Kind: *rootProc})
-
-		midKey := model.NewKey(tenantID, "mid-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
-		require.NoError(t, keyStore.CreateKey(t.Context(), midKey))
-		midKV := model.NewKeyVersion(tenantID, midKey.ID, "1", &rootKey.ID, &rootKV.Version)
-		_, err = kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: midKV})
-		require.NoError(t, err)
-
-		midProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newStaticSecretCryptor(t), rootMgr, newTestVault(t))
-		_, err = midProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: midKV})
-		assert.NoError(t, err)
-		midMgr := keyprocessor.NewManager(keyStore, kvStore, map[model.KeyKind]keyprocessor.Processor{midKey.Kind: *midProc})
-
-		leafKV := model.NewKeyVersion(tenantID, uuid.NewString(), "1", &midKey.ID, &midKV.Version)
-		leafProc := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, midMgr, newTestVault(t))
-		_, err = leafProc.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: leafKV})
-		assert.NoError(t, err)
-
-		// when
-		wrapResp, err := leafProc.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: leafKV,
-			Secret:     newTestData(t, []byte("top secret")),
-		})
-		assert.NoError(t, err)
-
-		unwrapResp, err := leafProc.UnwrapSecret(t.Context(), keyprocessor.UnwrapSecretRequest{
-			KeyVersion:    leafKV,
-			WrappedSecret: wrapResp.WrappedSecret,
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("top secret"), []byte(unwrapResp.Secret.SecureBytes()))
-	})
-
-	t.Run("should return error if parent vault fails during child resolve", func(t *testing.T) {
-		// given
-		parentErr := errors.New("parent compromised")
-		ps := setupParent(t)
-
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, &ps.parentKV.Version)
-		child := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.manager, newTestVault(t))
-		_, err := child.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
-		assert.NoError(t, err)
-
-		ps.vault.exportKeyFn = func(context.Context, vault.ExportKeyRequest) (*vault.ExportKeyResponse, error) {
-			return nil, parentErr
-		}
-
-		// when
-		resp, err := child.WrapSecret(t.Context(), keyprocessor.WrapSecretRequest{
-			KeyVersion: childKV,
-			Secret:     newTestData(t, []byte("data")),
-		})
-
-		// then
-		assert.ErrorIs(t, err, parentErr)
-		assert.Equal(t, keyprocessor.WrapSecretResponse{}, resp)
 	})
 }
 
@@ -1029,33 +654,25 @@ func (w *secretGenWrapper) GenerateSecret(ctx context.Context) (*cryptor.Generat
 	return w.SecretGenerator.GenerateSecret(ctx)
 }
 
-type cryptorWrapper struct {
-	cryptor.Cryptor
+type sealerWrapper struct {
+	cryptor.Sealer
 
-	encryptFn func(context.Context, cryptor.EncryptRequest) (*cryptor.EncryptResponse, error)
-	decryptFn func(context.Context, cryptor.DecryptRequest) (*cryptor.DecryptResponse, error)
-	infoFn    func() cryptor.Info
+	sealFn   func(context.Context, cryptor.SealRequest) (cryptor.SealResponse, error)
+	unsealFn func(context.Context, cryptor.UnsealRequest) (cryptor.UnsealResponse, error)
 }
 
-func (w *cryptorWrapper) Encrypt(ctx context.Context, req cryptor.EncryptRequest) (*cryptor.EncryptResponse, error) {
-	if w.encryptFn != nil {
-		return w.encryptFn(ctx, req)
+func (w *sealerWrapper) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
+	if w.sealFn != nil {
+		return w.sealFn(ctx, req)
 	}
-	return w.Cryptor.Encrypt(ctx, req)
+	return w.Sealer.Seal(ctx, req)
 }
 
-func (w *cryptorWrapper) Decrypt(ctx context.Context, req cryptor.DecryptRequest) (*cryptor.DecryptResponse, error) {
-	if w.decryptFn != nil {
-		return w.decryptFn(ctx, req)
+func (w *sealerWrapper) Unseal(ctx context.Context, req cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
+	if w.unsealFn != nil {
+		return w.unsealFn(ctx, req)
 	}
-	return w.Cryptor.Decrypt(ctx, req)
-}
-
-func (w *cryptorWrapper) Info() cryptor.Info {
-	if w.infoFn != nil {
-		return w.infoFn()
-	}
-	return w.Cryptor.Info()
+	return w.Sealer.Unseal(ctx, req)
 }
 
 func newTestVault(t *testing.T) *sqlitevault.Unsafe {
@@ -1074,16 +691,29 @@ func newTestSecretGen() *cryptor.AES256SecretGenerator {
 	return cryptor.NewAES256SecretGenerator()
 }
 
-func newStaticSecretCryptor(t *testing.T) *staticsecret.StaticSecret {
+func newTestSealer(t *testing.T) *staticsecret.StaticSecret {
 	t.Helper()
 	key, err := securemem.NewData("static-key", 32)
 	assert.NoError(t, err)
 	_, err = rand.Read(key.SecureBytes())
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = key.Destroy() })
-	c, err := staticsecret.New("test-static", key)
+	s, err := staticsecret.New("test-static", key)
 	assert.NoError(t, err)
-	return c
+	return s
+}
+
+func newTestSecret(t *testing.T) cryptor.Secret {
+	t.Helper()
+	key, err := securemem.NewData("test-key", 32)
+	assert.NoError(t, err)
+	_, err = rand.Read(key.SecureBytes())
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = key.Destroy() })
+	return cryptor.Secret{
+		Algorithm: cryptor.KeyAlgorithmAES256,
+		Data:      key,
+	}
 }
 
 func newTestData(t *testing.T, content []byte) *securemem.Data {

--- a/internal/keyprocessor/setup_test.go
+++ b/internal/keyprocessor/setup_test.go
@@ -99,3 +99,13 @@ func createTenant(t *testing.T, db *sql.DB) string {
 	require.NoError(t, err)
 	return result.Tenant.ID
 }
+
+func activateKey(t *testing.T, db *sql.DB, key model.Key) {
+	t.Helper()
+	keyStore := storesql.NewKeyStore(db)
+	require.NoError(t, keyStore.UpdateKeyLifeCycleState(t.Context(), store.UpdateKeyLifeCycleStateQuery{
+		ID:       key.ID,
+		TenantID: key.TenantID,
+		NewState: model.KeyLifeCycleActive,
+	}))
+}


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add sealer interface

Following the conventional commits: https://www.conventionalcommits.org
-->
These changes introduce a clear separation between key-version-aware sealing and low-level encryption.

- Sealer interface for key-version-aware seal/unseal operations used by StaticSecret, Manager, and RootManager
- Cryptor.Secret is mandatory, so no more optional pointer or DecryptionSecretRequired flag
- Processor uses Sealer for transport sealing (optional) and parent delegation (mandatory)
- Manager validates key lifecycle, resolves key versions and secrets, then delegates encryption/decryption to processors.
- RootManager validates key lifecycle and delegates to a sealer for root keys that manage their own secret

