### PR TITLE
feat: add sealer config

### DIFF
--- a/examples/root.config.yaml
+++ b/examples/root.config.yaml
@@ -7,8 +7,8 @@ selector_labels:
   environment: production
 key_bindings:
   K0:
-    crypto:
-      name: root-key-crypto
+    sealer:
+      name: root-key-sealer
       type: aes256gcm-staticsecret
       config:
         secret:
@@ -53,6 +53,14 @@ topology:
         end_kind: K3
       key_bindings:
         K2:
+          sealer:
+            name: tek-sealer
+            type: aes256gcm-staticsecret
+            config:
+              secret:
+                type: envvar
+                config:
+                  name: KRYPTON_TEK_KEY
           crypto:
             name: tek-crypto
             type: aes256gcm

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -89,12 +89,14 @@ selector_labels:
   environment: production
 key_bindings:
   K0:
-    crypto:
-      name: root-crypto
-      type: aes256gcm
-    vault:
-      name: root-hsm-vault
-      type: unsafe-sqlite-memory
+    sealer:
+      name: root-sealer
+      type: aes256gcm-staticsecret
+      config:
+        secret:
+          type: envvar
+          config:
+            name: KRYPTON_ROOT_KEY
   K1:
     crypto:
       name: kek-crypto
@@ -133,6 +135,14 @@ topology:
         end_kind: K3
       key_bindings:
         K2:
+          sealer:
+            name: agent-sealer
+            type: aes256gcm-staticsecret
+            config:
+              secret:
+                type: envvar
+                config:
+                  name: KRYPTON_TEK_KEY
           crypto:
             name: agent-crypto
             type: aes256gcm

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,15 +10,32 @@ import (
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
 	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
+	"github.com/openkcm/krypton/internal/cryptor/sealerprovider"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
 	"github.com/openkcm/krypton/internal/spec"
 	"github.com/openkcm/krypton/pkg/model"
 )
 
-func validCryptorSpec() cryptorprovider.Spec {
-	return cryptorprovider.Spec{
+func validCryptorSpec() *cryptorprovider.Spec {
+	return &cryptorprovider.Spec{
 		Name:   "test-crypto",
 		Type:   aes256gcm.TypeAES256GCM,
 		Config: &aes256gcm.Config{},
+	}
+}
+
+func validSealerSpec() *sealerprovider.Spec {
+	return &sealerprovider.Spec{
+		Name: "test-sealer",
+		Type: staticsecret.TypeStaticSecret,
+		Config: &staticsecret.Config{
+			Secret: secretprovider.Spec{
+				Type:   envvar.Type,
+				Config: &envvar.Config{Name: "TEST_KEY"},
+			},
+		},
 	}
 }
 
@@ -32,7 +49,7 @@ func validRootConfig() *RootConfig {
 		},
 		SelectorLabels: spec.SelectorLabels{"env": "prod"},
 		KeyBindings: map[string]spec.KeyBinding{
-			"K0": {CryptorSpec: validCryptorSpec()},
+			"K0": {SealerSpec: validSealerSpec()},
 			"K1": {
 				CryptorSpec:       validCryptorSpec(),
 				ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"},
@@ -194,8 +211,8 @@ func TestValidateRootConfig(t *testing.T) {
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
 				c.KeyBindings = map[string]spec.KeyBinding{
-					"K0": {CryptorSpec: validCryptorSpec()},
-					"K1": {CryptorSpec: validCryptorSpec()},
+					"K0": {SealerSpec: validSealerSpec()},
+					"K1": {SealerSpec: validSealerSpec(), CryptorSpec: validCryptorSpec()},
 				}
 				c.Topology = spec.Topology{}
 			},
@@ -214,7 +231,7 @@ func TestValidateRootConfig(t *testing.T) {
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
 				c.KeyBindings = map[string]spec.KeyBinding{
-					"K0": {CryptorSpec: validCryptorSpec()},
+					"K0": {SealerSpec: validSealerSpec()},
 					"K1": {CryptorSpec: validCryptorSpec(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				}
 				c.Topology = spec.Topology{
@@ -245,7 +262,7 @@ func TestValidateRootConfig(t *testing.T) {
 				}
 				c.Segment = spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
 				c.KeyBindings = map[string]spec.KeyBinding{
-					"K0": {CryptorSpec: validCryptorSpec()},
+					"K0": {SealerSpec: validSealerSpec()},
 					"K1": {CryptorSpec: validCryptorSpec(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				}
 				c.Topology = spec.Topology{
@@ -254,7 +271,7 @@ func TestValidateRootConfig(t *testing.T) {
 							Name:    "agent-aws",
 							Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
 							KeyBindings: map[string]spec.KeyBinding{
-								"K2": {CryptorSpec: validCryptorSpec(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+								"K2": {SealerSpec: validSealerSpec(), CryptorSpec: validCryptorSpec(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 								"K3": {CryptorSpec: validCryptorSpec()},
 							},
 						},
@@ -333,12 +350,14 @@ selector_labels:
   environment: "production"
 key_bindings:
   K0:
-    crypto:
-      name: "root-crypto"
-      type: "aes256gcm"
-    vault:
-      name: "root-hsm-vault"
-      type: "unsafe-sqlite-memory"
+    sealer:
+      name: "root-sealer"
+      type: "aes256gcm-staticsecret"
+      config:
+        secret:
+          type: envvar
+          config:
+            name: KRYPTON_ROOT_KEY
   K1:
     crypto:
       name: "kek-crypto"
@@ -393,6 +412,14 @@ topology:
         end_kind: "K3"
       key_bindings:
         K2:
+          sealer:
+            name: "tek-sealer"
+            type: "aes256gcm-staticsecret"
+            config:
+              secret:
+                type: envvar
+                config:
+                  name: KRYPTON_TEK_KEY
           crypto:
             name: "tek-crypto"
             type: "aes256gcm"
@@ -435,8 +462,8 @@ reconciler:
 				assert.Equal(t, "K1", cfg.Segment.EndKind)
 				assert.Equal(t, "production", cfg.SelectorLabels["environment"])
 				assert.Len(t, cfg.KeyBindings, 2)
-				assert.Equal(t, "root-crypto", cfg.KeyBindings["K0"].CryptorSpec.Name)
-				assert.Equal(t, "root-hsm-vault", cfg.KeyBindings["K0"].VaultSpec.Name)
+				assert.Equal(t, "root-sealer", cfg.KeyBindings["K0"].SealerSpec.Name)
+				assert.Nil(t, cfg.KeyBindings["K0"].CryptorSpec)
 				assert.Equal(t, "root-vault", cfg.KeyBindings["K1"].VaultSpec.Name)
 				assert.Equal(t, "root", cfg.KeyBindings["K1"].ParentKeyProvider.AgentName)
 				assert.Equal(t, "production-hierarchy", cfg.Hierarchy.Name)

--- a/internal/cryptor/sealer.go
+++ b/internal/cryptor/sealer.go
@@ -39,3 +39,8 @@ type Sealer interface {
 	Seal(context.Context, SealRequest) (SealResponse, error)
 	Unseal(context.Context, UnsealRequest) (UnsealResponse, error)
 }
+
+// SealerConfig is implemented by sealer-specific configuration structs to support validation.
+type SealerConfig interface {
+	ValidateSealerConfig() error
+}

--- a/internal/cryptor/sealerprovider/provider.go
+++ b/internal/cryptor/sealerprovider/provider.go
@@ -1,0 +1,106 @@
+package sealerprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
+)
+
+var ErrSealerNameEmpty = errors.New("sealer name is empty")
+
+// Spec describes which sealer implementation to use and how to configure it.
+type Spec struct {
+	Name string       `yaml:"name"`
+	Type cryptor.Type `yaml:"type"`
+	// Config is marshaled/unmarshaled via custom MarshalYAML/UnmarshalYAML, not by the default YAML codec.
+	Config cryptor.SealerConfig `yaml:"-"`
+}
+
+var (
+	_ yaml.Unmarshaler = (*Spec)(nil)
+	_ yaml.Marshaler   = (*Spec)(nil)
+)
+
+// MarshalYAML implements [yaml.Marshaler].
+func (s *Spec) MarshalYAML() (any, error) {
+	type alias Spec
+	return struct {
+		alias `yaml:",inline"`
+
+		Config cryptor.SealerConfig `yaml:"config,omitempty"`
+	}{
+		alias:  alias(*s),
+		Config: s.Config,
+	}, nil
+}
+
+// UnmarshalYAML implements [yaml.Unmarshaler].
+func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
+	type alias Spec
+	var raw struct {
+		alias `yaml:",inline"`
+
+		Config yaml.Node `yaml:"config"`
+	}
+	if err := node.Decode(&raw); err != nil {
+		return fmt.Errorf("failed to decode sealer spec: %w", err)
+	}
+
+	cfg, err := newSealerConfig(raw.Type)
+	if err != nil {
+		return err
+	}
+
+	if raw.Config.Kind != 0 {
+		if err := raw.Config.Decode(cfg); err != nil {
+			return fmt.Errorf("failed to decode sealer config: %w", err)
+		}
+	}
+
+	*s = Spec(raw.alias)
+	s.Config = cfg
+	return nil
+}
+
+// Validate checks the Spec for structural correctness.
+func (s *Spec) Validate() error {
+	if s.Name == "" {
+		return ErrSealerNameEmpty
+	}
+	if s.Config != nil {
+		if err := s.Config.ValidateSealerConfig(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetSealer constructs a ready-to-use cryptor.Sealer from the given Spec.
+func GetSealer(ctx context.Context, spec Spec) (cryptor.Sealer, error) {
+	switch cfg := spec.Config.(type) {
+	case *staticsecret.Config:
+		secret, err := secretprovider.GetSecret(ctx, cfg.Secret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load secret for sealer %q: %w", spec.Name, err)
+		}
+		return staticsecret.New(spec.Name, secret)
+	default:
+		return nil, fmt.Errorf("%w: %T", cryptor.ErrUnknownType, spec.Config)
+	}
+}
+
+// newSealerConfig is a factory that creates the correct SealerConfig struct by sealer type.
+func newSealerConfig(t cryptor.Type) (cryptor.SealerConfig, error) {
+	switch t {
+	case staticsecret.TypeStaticSecret:
+		return &staticsecret.Config{}, nil
+	default:
+		return nil, fmt.Errorf("%w: %q", cryptor.ErrUnknownType, t)
+	}
+}

--- a/internal/cryptor/sealerprovider/provider_test.go
+++ b/internal/cryptor/sealerprovider/provider_test.go
@@ -1,0 +1,122 @@
+package sealerprovider_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/cryptor/sealerprovider"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
+)
+
+func TestSpec_Validate(t *testing.T) {
+	tts := []struct {
+		name   string
+		spec   sealerprovider.Spec
+		expErr error
+	}{
+		{
+			name: "should fail for empty name",
+			spec: sealerprovider.Spec{
+				Name: "",
+				Type: staticsecret.TypeStaticSecret,
+				Config: &staticsecret.Config{
+					Secret: secretprovider.Spec{
+						Type:   envvar.Type,
+						Config: &envvar.Config{Name: "TEST_KEY"},
+					},
+				},
+			},
+			expErr: sealerprovider.ErrSealerNameEmpty,
+		},
+		{
+			name: "should pass for valid staticsecret spec",
+			spec: sealerprovider.Spec{
+				Name: "my-sealer",
+				Type: staticsecret.TypeStaticSecret,
+				Config: &staticsecret.Config{
+					Secret: secretprovider.Spec{
+						Type:   envvar.Type,
+						Config: &envvar.Config{Name: "MY_SECRET"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// when
+			err := tt.spec.Validate()
+
+			// then
+			if tt.expErr != nil {
+				assert.ErrorIs(t, err, tt.expErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSpec_UnmarshalYAML(t *testing.T) {
+	t.Run("should unmarshal staticsecret spec", func(t *testing.T) {
+		// given
+		input := `
+name: root-sealer
+type: aes256gcm-staticsecret
+config:
+  secret:
+    type: envvar
+    config:
+      name: KRYPTON_ROOT_KEY
+`
+		// when
+		var spec sealerprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "root-sealer", spec.Name)
+		assert.Equal(t, staticsecret.TypeStaticSecret, spec.Type)
+		assert.IsType(t, &staticsecret.Config{}, spec.Config)
+	})
+
+	t.Run("should return error for unknown sealer type", func(t *testing.T) {
+		// given
+		input := `
+name: bad-sealer
+type: unknown-type
+config: {}
+`
+		// when
+		var spec sealerprovider.Spec
+		err := yaml.Unmarshal([]byte(input), &spec)
+
+		// then
+		assert.ErrorIs(t, err, cryptor.ErrUnknownType)
+	})
+}
+
+func TestGetSealer(t *testing.T) {
+	t.Run("should return error for unknown config type", func(t *testing.T) {
+		// given
+		ctx := t.Context()
+		spec := sealerprovider.Spec{
+			Name: "bad",
+			Type: "unknown",
+		}
+
+		// when
+		sealer, err := sealerprovider.GetSealer(ctx, spec)
+
+		// then
+		assert.ErrorIs(t, err, cryptor.ErrUnknownType)
+		assert.Nil(t, sealer)
+	})
+}

--- a/internal/cryptor/staticsecret/staticsecret.go
+++ b/internal/cryptor/staticsecret/staticsecret.go
@@ -21,9 +21,9 @@ type Config struct {
 	Secret secretprovider.Spec `yaml:"secret"`
 }
 
-var _ cryptor.Config = (*Config)(nil)
+var _ cryptor.SealerConfig = (*Config)(nil)
 
-func (c *Config) ValidateCryptorConfig() error {
+func (c *Config) ValidateSealerConfig() error {
 	return c.Secret.Validate()
 }
 

--- a/internal/spec/hierarchy_validation.go
+++ b/internal/spec/hierarchy_validation.go
@@ -17,12 +17,18 @@ var (
 	ErrRootSegmentStartNotFirst        = errors.New("root segment must start at hierarchy's first key")
 	ErrRootSegmentEndIsTek             = errors.New("root segment end kind must not have role tek")
 	ErrRootBindingHasParentKeyProvider = errors.New("root key binding must not have a parent key provider")
+	ErrRootBindingMissingSealer        = errors.New("root key binding must have a sealer")
+	ErrRootBindingHasCryptor           = errors.New("root key binding must not have a cryptor")
 
 	ErrAgentSegmentStartNotTek                   = errors.New("agent segment must start with a tek role key")
 	ErrAgentSegmentEndIsTek                      = errors.New("agent segment end kind must not have role tek unless single-key segment")
 	ErrAgentSegmentEndIsRoot                     = errors.New("agent segment end kind must not have role root")
 	ErrAgentSegmentContainsRoot                  = errors.New("agent segment must not contain the root role key")
 	ErrAgentSegmentStartMissingParentKeyProvider = errors.New("agent segment tek start key must have a parent key provider")
+
+	ErrTekBindingMissingSealer      = errors.New("tek key binding must have a sealer")
+	ErrTekBindingMissingCryptor     = errors.New("tek key binding must have a cryptor")
+	ErrNonRootBindingMissingCryptor = errors.New("non-root key binding must have a cryptor")
 
 	ErrTopologyDuplicateSegmentName           = errors.New("duplicate topology segment name")
 	ErrParentKeyProviderNotResolvable         = errors.New("parent key provider agent name does not resolve to root or any topology segment")
@@ -80,8 +86,29 @@ func ValidateRootSegment(h KeyHierarchy, seg HierarchySegment, bindings map[stri
 	}
 
 	rootBinding, exists := bindings[seg.StartKind]
-	if exists && rootBinding.ParentKeyProvider != nil {
+	if !exists {
+		return fmt.Errorf("%w: %q", ErrSegmentBindingsMissing, seg.StartKind)
+	}
+	if rootBinding.ParentKeyProvider != nil {
 		return ErrRootBindingHasParentKeyProvider
+	}
+	if rootBinding.SealerSpec == nil {
+		return ErrRootBindingMissingSealer
+	}
+	if rootBinding.CryptorSpec != nil {
+		return ErrRootBindingHasCryptor
+	}
+
+	// Non-root keys in root segment must have a cryptor
+	kindsInRange := h.KeySpecs[startIdx : h.IndexOf(model.KeyKind(seg.EndKind))+1]
+	for _, ks := range kindsInRange {
+		if ks.Role == KeyRoleRoot {
+			continue
+		}
+		binding := bindings[string(ks.Kind)]
+		if binding.CryptorSpec == nil {
+			return fmt.Errorf("%w: %q", ErrNonRootBindingMissingCryptor, ks.Kind)
+		}
 	}
 
 	return nil
@@ -117,8 +144,28 @@ func ValidateAgentSegment(h KeyHierarchy, seg HierarchySegment, bindings map[str
 	}
 
 	startBinding, exists := bindings[seg.StartKind]
-	if !exists || startBinding.ParentKeyProvider == nil {
+	if !exists {
+		return fmt.Errorf("%w: %q", ErrSegmentBindingsMissing, seg.StartKind)
+	}
+	if startBinding.ParentKeyProvider == nil {
 		return ErrAgentSegmentStartMissingParentKeyProvider
+	}
+	if startBinding.SealerSpec == nil {
+		return ErrTekBindingMissingSealer
+	}
+	if startBinding.CryptorSpec == nil {
+		return ErrTekBindingMissingCryptor
+	}
+
+	// Non-TEK keys in agent segment must have a cryptor
+	for _, ks := range kindsInRange {
+		if ks.Role == KeyRoleTek {
+			continue
+		}
+		binding := bindings[string(ks.Kind)]
+		if binding.CryptorSpec == nil {
+			return fmt.Errorf("%w: %q", ErrNonRootBindingMissingCryptor, ks.Kind)
+		}
 	}
 
 	return nil

--- a/internal/spec/hierarchy_validation.go
+++ b/internal/spec/hierarchy_validation.go
@@ -26,9 +26,8 @@ var (
 	ErrAgentSegmentContainsRoot                  = errors.New("agent segment must not contain the root role key")
 	ErrAgentSegmentStartMissingParentKeyProvider = errors.New("agent segment tek start key must have a parent key provider")
 
-	ErrTekBindingMissingSealer      = errors.New("tek key binding must have a sealer")
-	ErrTekBindingMissingCryptor     = errors.New("tek key binding must have a cryptor")
-	ErrNonRootBindingMissingCryptor = errors.New("non-root key binding must have a cryptor")
+	ErrTekBindingMissingSealer = errors.New("tek key binding must have a sealer")
+	ErrBindingMissingCryptor   = errors.New("key binding must have a cryptor")
 
 	ErrTopologyDuplicateSegmentName           = errors.New("duplicate topology segment name")
 	ErrParentKeyProviderNotResolvable         = errors.New("parent key provider agent name does not resolve to root or any topology segment")
@@ -100,14 +99,17 @@ func ValidateRootSegment(h KeyHierarchy, seg HierarchySegment, bindings map[stri
 	}
 
 	// Non-root keys in root segment must have a cryptor
-	kindsInRange := h.KeySpecs[startIdx : h.IndexOf(model.KeyKind(seg.EndKind))+1]
+	kindsInRange, err := h.KindsBetween(model.KeyKind(seg.StartKind), model.KeyKind(seg.EndKind))
+	if err != nil {
+		return err
+	}
 	for _, ks := range kindsInRange {
 		if ks.Role == KeyRoleRoot {
 			continue
 		}
 		binding := bindings[string(ks.Kind)]
 		if binding.CryptorSpec == nil {
-			return fmt.Errorf("%w: %q", ErrNonRootBindingMissingCryptor, ks.Kind)
+			return fmt.Errorf("%w: %q", ErrBindingMissingCryptor, ks.Kind)
 		}
 	}
 
@@ -153,18 +155,12 @@ func ValidateAgentSegment(h KeyHierarchy, seg HierarchySegment, bindings map[str
 	if startBinding.SealerSpec == nil {
 		return ErrTekBindingMissingSealer
 	}
-	if startBinding.CryptorSpec == nil {
-		return ErrTekBindingMissingCryptor
-	}
 
-	// Non-TEK keys in agent segment must have a cryptor
+	// All keys in agent segment must have a cryptor
 	for _, ks := range kindsInRange {
-		if ks.Role == KeyRoleTek {
-			continue
-		}
 		binding := bindings[string(ks.Kind)]
 		if binding.CryptorSpec == nil {
-			return fmt.Errorf("%w: %q", ErrNonRootBindingMissingCryptor, ks.Kind)
+			return fmt.Errorf("%w: %q", ErrBindingMissingCryptor, ks.Kind)
 		}
 	}
 

--- a/internal/spec/hierarchy_validation_test.go
+++ b/internal/spec/hierarchy_validation_test.go
@@ -258,7 +258,7 @@ func TestValidateRootSegment(t *testing.T) {
 				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K1": {SealerSpec: validSealer(), VaultSpec: validVault()},
 			},
-			wantErr: spec.ErrNonRootBindingMissingCryptor,
+			wantErr: spec.ErrBindingMissingCryptor,
 		},
 	}
 
@@ -367,7 +367,7 @@ func TestValidateAgentSegment(t *testing.T) {
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
-			wantErr: spec.ErrTekBindingMissingCryptor,
+			wantErr: spec.ErrBindingMissingCryptor,
 		},
 		{
 			name: "non-tek key in agent segment missing cryptor",
@@ -377,7 +377,7 @@ func TestValidateAgentSegment(t *testing.T) {
 				"K3": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
-			wantErr: spec.ErrNonRootBindingMissingCryptor,
+			wantErr: spec.ErrBindingMissingCryptor,
 		},
 		{
 			name: "agent segment with missing binding fails generic check",

--- a/internal/spec/hierarchy_validation_test.go
+++ b/internal/spec/hierarchy_validation_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/openkcm/krypton/internal/cryptor"
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
 	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
+	"github.com/openkcm/krypton/internal/cryptor/sealerprovider"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
 	"github.com/openkcm/krypton/internal/spec"
 	"github.com/openkcm/krypton/internal/vault/sqlitevault"
 	"github.com/openkcm/krypton/internal/vault/vaultprovider"
@@ -31,11 +35,24 @@ func validVault() *vaultprovider.Spec {
 	return &vaultprovider.Spec{Name: "v", Type: sqlitevault.TypeUnsafeMemory}
 }
 
-func validCryptor() cryptorprovider.Spec {
-	return cryptorprovider.Spec{
+func validCryptor() *cryptorprovider.Spec {
+	return &cryptorprovider.Spec{
 		Name:   "test-crypto",
 		Type:   aes256gcm.TypeAES256GCM,
 		Config: &aes256gcm.Config{},
+	}
+}
+
+func validSealer() *sealerprovider.Spec {
+	return &sealerprovider.Spec{
+		Name: "test-sealer",
+		Type: staticsecret.TypeStaticSecret,
+		Config: &staticsecret.Config{
+			Secret: secretprovider.Spec{
+				Type:   envvar.Type,
+				Config: &envvar.Config{Name: "TEST_KEY"},
+			},
+		},
 	}
 }
 
@@ -141,7 +158,7 @@ func TestValidateRootSegment(t *testing.T) {
 			name: "valid root segment K0-K1",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 			},
 			wantErr: nil,
@@ -150,9 +167,9 @@ func TestValidateRootSegment(t *testing.T) {
 			name: "valid root segment covers everything (0-agent deploy)",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K4"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
@@ -163,7 +180,7 @@ func TestValidateRootSegment(t *testing.T) {
 			seg:  spec.HierarchySegment{StartKind: "K1", EndKind: "K2"},
 			bindings: map[string]spec.KeyBinding{
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			wantErr: spec.ErrRootSegmentStartNotFirst,
 		},
@@ -171,9 +188,9 @@ func TestValidateRootSegment(t *testing.T) {
 			name: "root end kind is tek",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K2"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			wantErr: spec.ErrRootSegmentEndIsTek,
 		},
@@ -181,18 +198,36 @@ func TestValidateRootSegment(t *testing.T) {
 			name: "root key binding has parent key provider",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "someone"}},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "someone"}},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			wantErr: spec.ErrRootBindingHasParentKeyProvider,
 		},
 		{
-			name: "root end is dek valid for 0-agent deployment",
-			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K4"},
+			name: "root key binding missing sealer",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
 			bindings: map[string]spec.KeyBinding{
 				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+			},
+			wantErr: spec.ErrRootBindingMissingSealer,
+		},
+		{
+			name: "root key binding has cryptor",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+			},
+			wantErr: spec.ErrRootBindingHasCryptor,
+		},
+		{
+			name: "root end is dek valid for 0-agent deployment",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
+				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
@@ -202,7 +237,7 @@ func TestValidateRootSegment(t *testing.T) {
 			name: "non-root key in root segment has parent key provider referencing root is valid",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 			},
 			wantErr: nil,
@@ -211,10 +246,19 @@ func TestValidateRootSegment(t *testing.T) {
 			name: "root segment with missing binding fails generic check",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				// K1 missing
 			},
 			wantErr: spec.ErrSegmentBindingsMissing,
+		},
+		{
+			name: "non-root key in root segment missing cryptor",
+			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
+			bindings: map[string]spec.KeyBinding{
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
+				"K1": {SealerSpec: validSealer(), VaultSpec: validVault()},
+			},
+			wantErr: spec.ErrNonRootBindingMissingCryptor,
 		},
 	}
 
@@ -244,7 +288,7 @@ func TestValidateAgentSegment(t *testing.T) {
 			name: "valid agent segment K2-K4 (tek to dek)",
 			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 			bindings: map[string]spec.KeyBinding{
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
@@ -254,7 +298,7 @@ func TestValidateAgentSegment(t *testing.T) {
 			name: "valid agent segment K2-K3 (tek to kek)",
 			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
 			bindings: map[string]spec.KeyBinding{
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			wantErr: nil,
@@ -263,7 +307,7 @@ func TestValidateAgentSegment(t *testing.T) {
 			name: "valid single-key agent segment (tek only)",
 			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K2"},
 			bindings: map[string]spec.KeyBinding{
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 			},
 			wantErr: nil,
 		},
@@ -272,7 +316,7 @@ func TestValidateAgentSegment(t *testing.T) {
 			seg:  spec.HierarchySegment{StartKind: "K1", EndKind: "K3"},
 			bindings: map[string]spec.KeyBinding{
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			wantErr: spec.ErrAgentSegmentStartNotTek,
@@ -289,7 +333,7 @@ func TestValidateAgentSegment(t *testing.T) {
 			name: "agent segment contains root key",
 			seg:  spec.HierarchySegment{StartKind: "K0", EndKind: "K1"},
 			bindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			// Root key is not tek, so this fails on start-not-tek first
@@ -299,17 +343,47 @@ func TestValidateAgentSegment(t *testing.T) {
 			name: "agent start binding missing parent key provider",
 			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 			bindings: map[string]spec.KeyBinding{
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()}, // no ParentKeyProvider
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()}, // no ParentKeyProvider
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
 			wantErr: spec.ErrAgentSegmentStartMissingParentKeyProvider,
 		},
 		{
-			name: "agent segment with missing binding fails generic check",
+			name: "tek binding missing sealer",
 			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 			bindings: map[string]spec.KeyBinding{
 				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+			},
+			wantErr: spec.ErrTekBindingMissingSealer,
+		},
+		{
+			name: "tek binding missing cryptor",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {SealerSpec: validSealer(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+			},
+			wantErr: spec.ErrTekBindingMissingCryptor,
+		},
+		{
+			name: "non-tek key in agent segment missing cryptor",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K3": {SealerSpec: validSealer(), VaultSpec: validVault()},
+				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+			},
+			wantErr: spec.ErrNonRootBindingMissingCryptor,
+		},
+		{
+			name: "agent segment with missing binding fails generic check",
+			seg:  spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
+			bindings: map[string]spec.KeyBinding{
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				// K3 missing
 			},
@@ -335,7 +409,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 
 	rootSeg := spec.HierarchySegment{StartKind: "K0", EndKind: "K1"}
 	rootBindings := map[string]spec.KeyBinding{
-		"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+		"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 		"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 	}
 
@@ -344,7 +418,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 			Name:    name,
 			Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 			KeyBindings: map[string]spec.KeyBinding{
-				"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+				"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 				"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 				"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 			},
@@ -404,7 +478,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Name:    "agent-aws",
 						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 						KeyBindings: map[string]spec.KeyBinding{
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "nonexistent"}},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "nonexistent"}},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 							"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
@@ -423,7 +497,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Name:    "agent-aws",
 						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 						KeyBindings: map[string]spec.KeyBinding{
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 							"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
@@ -442,7 +516,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Name:    "agent-mid",
 						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
 						KeyBindings: map[string]spec.KeyBinding{
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
 					},
@@ -450,7 +524,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Name:    "agent-leaf",
 						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 						KeyBindings: map[string]spec.KeyBinding{
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 							"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
@@ -470,7 +544,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Segment: spec.HierarchySegment{StartKind: "K1", EndKind: "K3"}, // K1 is kek, not tek
 						KeyBindings: map[string]spec.KeyBinding{
 							"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault()},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
 					},
@@ -489,7 +563,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K3"},
 						KeyBindings: map[string]spec.KeyBinding{
 							// K2's parent is K1, which is in root segment K0-K1 — referencing agent-leaf which manages K2-K4
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "agent-leaf"}},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "agent-leaf"}},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
 					},
@@ -497,7 +571,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 						Name:    "agent-leaf",
 						Segment: spec.HierarchySegment{StartKind: "K2", EndKind: "K4"},
 						KeyBindings: map[string]spec.KeyBinding{
-							"K2": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
+							"K2": {SealerSpec: validSealer(), CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "root"}},
 							"K3": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 							"K4": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
 						},
@@ -515,7 +589,7 @@ func TestValidateTopologyAgainstHierarchy(t *testing.T) {
 			},
 			rootSeg: rootSeg,
 			rootBindings: map[string]spec.KeyBinding{
-				"K0": {CryptorSpec: validCryptor(), VaultSpec: validVault()},
+				"K0": {SealerSpec: validSealer(), VaultSpec: validVault()},
 				"K1": {CryptorSpec: validCryptor(), VaultSpec: validVault(), ParentKeyProvider: &spec.ParentKeyProviderRef{AgentName: "nonexistent"}},
 			},
 			wantErr: spec.ErrParentKeyProviderNotResolvable,

--- a/internal/spec/topology.go
+++ b/internal/spec/topology.go
@@ -5,15 +5,17 @@ import (
 	"fmt"
 
 	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
+	"github.com/openkcm/krypton/internal/cryptor/sealerprovider"
 	"github.com/openkcm/krypton/internal/vault/vaultprovider"
 )
 
 var (
-	ErrStartKindEmpty              = errors.New("start kind cannot be empty")
-	ErrEndKindEmpty                = errors.New("end kind cannot be empty")
-	ErrParentKeyProviderAgentEmpty = errors.New("parent key provider agent name cannot be empty")
-	ErrAgentNameEmpty              = errors.New("agent name cannot be empty")
-	ErrKeyBindingsEmpty            = errors.New("key bindings cannot be empty")
+	ErrStartKindEmpty                = errors.New("start kind cannot be empty")
+	ErrEndKindEmpty                  = errors.New("end kind cannot be empty")
+	ErrParentKeyProviderAgentEmpty   = errors.New("parent key provider agent name cannot be empty")
+	ErrAgentNameEmpty                = errors.New("agent name cannot be empty")
+	ErrKeyBindingsEmpty              = errors.New("key bindings cannot be empty")
+	ErrBindingMissingSealerOrCryptor = errors.New("key binding must have at least a sealer or cryptor")
 )
 
 // SelectorLabels is a key-value map for metadata
@@ -25,16 +27,17 @@ type HierarchySegment struct {
 	EndKind   string `yaml:"end_kind"`   // Last key kind in segment (e.g., "K3") - inclusive
 }
 
-// ParentKeyProviderRef specifies which agent provides parent keys for unwrapping
+// ParentKeyProviderRef specifies which agent provides parent keys for sealing/unsealing
 type ParentKeyProviderRef struct {
 	AgentName string `yaml:"agent_name"` // Agent name that provides parent keys
 }
 
 // KeyBinding encapsulates all dependencies needed to implement a key kind
 type KeyBinding struct {
-	CryptorSpec       cryptorprovider.Spec  `yaml:"crypto"`
+	SealerSpec        *sealerprovider.Spec  `yaml:"sealer,omitempty"`              // Seals with externally provided secret
+	CryptorSpec       *cryptorprovider.Spec `yaml:"crypto,omitempty"`              // Encrypts/decrypts with generated and stored secret
 	VaultSpec         *vaultprovider.Spec   `yaml:"vault,omitempty"`               // Storage backend configuration
-	ParentKeyProvider *ParentKeyProviderRef `yaml:"parent_key_provider,omitempty"` // Where to get parent keys for unwrapping
+	ParentKeyProvider *ParentKeyProviderRef `yaml:"parent_key_provider,omitempty"` // Where to get parent keys for sealing/unsealing
 }
 
 // TopologySegment defines an agent's portion of the hierarchy
@@ -74,8 +77,20 @@ func (hs *HierarchySegment) Validate() error {
 }
 
 func (kb *KeyBinding) Validate() error {
-	if err := kb.CryptorSpec.Validate(); err != nil {
-		return err
+	if kb.SealerSpec == nil && kb.CryptorSpec == nil {
+		return ErrBindingMissingSealerOrCryptor
+	}
+
+	if kb.SealerSpec != nil {
+		if err := kb.SealerSpec.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if kb.CryptorSpec != nil {
+		if err := kb.CryptorSpec.Validate(); err != nil {
+			return err
+		}
 	}
 
 	if kb.VaultSpec != nil {

--- a/internal/spec/topology_test.go
+++ b/internal/spec/topology_test.go
@@ -7,16 +7,33 @@ import (
 
 	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
 	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
+	"github.com/openkcm/krypton/internal/cryptor/sealerprovider"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
 	"github.com/openkcm/krypton/internal/vault"
 	"github.com/openkcm/krypton/internal/vault/sqlitevault"
 	"github.com/openkcm/krypton/internal/vault/vaultprovider"
 )
 
-func validCryptorSpec() cryptorprovider.Spec {
-	return cryptorprovider.Spec{
+func validCryptorSpec() *cryptorprovider.Spec {
+	return &cryptorprovider.Spec{
 		Name:   "test-crypto",
 		Type:   aes256gcm.TypeAES256GCM,
 		Config: &aes256gcm.Config{},
+	}
+}
+
+func validSealerSpec() *sealerprovider.Spec {
+	return &sealerprovider.Spec{
+		Name: "test-sealer",
+		Type: staticsecret.TypeStaticSecret,
+		Config: &staticsecret.Config{
+			Secret: secretprovider.Spec{
+				Type:   envvar.Type,
+				Config: &envvar.Config{Name: "TEST_KEY"},
+			},
+		},
 	}
 }
 
@@ -87,7 +104,7 @@ func TestValidateKeyBinding(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "valid binding with all fields",
+			name: "valid binding with cryptor and all fields",
 			binding: KeyBinding{
 				CryptorSpec: validCryptorSpec(),
 				VaultSpec: &vaultprovider.Spec{
@@ -96,6 +113,25 @@ func TestValidateKeyBinding(t *testing.T) {
 				},
 				ParentKeyProvider: &ParentKeyProviderRef{
 					AgentName: "root",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid binding with sealer only",
+			binding: KeyBinding{
+				SealerSpec: validSealerSpec(),
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid binding with both sealer and cryptor",
+			binding: KeyBinding{
+				SealerSpec:  validSealerSpec(),
+				CryptorSpec: validCryptorSpec(),
+				VaultSpec: &vaultprovider.Spec{
+					Name: "my-vault",
+					Type: sqlitevault.TypeUnsafeMemory,
 				},
 			},
 			wantErr: nil,
@@ -119,9 +155,19 @@ func TestValidateKeyBinding(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "missing both sealer and cryptor",
+			binding: KeyBinding{
+				VaultSpec: &vaultprovider.Spec{
+					Name: "my-vault",
+					Type: sqlitevault.TypeUnsafeMemory,
+				},
+			},
+			wantErr: ErrBindingMissingSealerOrCryptor,
+		},
+		{
 			name: "empty cryptor spec name",
 			binding: KeyBinding{
-				CryptorSpec: cryptorprovider.Spec{
+				CryptorSpec: &cryptorprovider.Spec{
 					Name:   "",
 					Type:   aes256gcm.TypeAES256GCM,
 					Config: &aes256gcm.Config{},
@@ -132,6 +178,22 @@ func TestValidateKeyBinding(t *testing.T) {
 				},
 			},
 			wantErr: cryptorprovider.ErrCryptorNameEmpty,
+		},
+		{
+			name: "empty sealer spec name",
+			binding: KeyBinding{
+				SealerSpec: &sealerprovider.Spec{
+					Name: "",
+					Type: staticsecret.TypeStaticSecret,
+					Config: &staticsecret.Config{
+						Secret: secretprovider.Spec{
+							Type:   envvar.Type,
+							Config: &envvar.Config{Name: "TEST_KEY"},
+						},
+					},
+				},
+			},
+			wantErr: sealerprovider.ErrSealerNameEmpty,
 		},
 		{
 			name: "empty vault name",
@@ -189,7 +251,7 @@ func TestValidateTopologySegment(t *testing.T) {
 			CryptorSpec: validCryptorSpec(),
 			VaultSpec: &vaultprovider.Spec{
 				Name: "vault-k2",
-				Type: "aws-kms",
+				Type: sqlitevault.TypeUnsafeMemory,
 			},
 		},
 	}
@@ -304,7 +366,7 @@ func TestValidateTopology(t *testing.T) {
 			CryptorSpec: validCryptorSpec(),
 			VaultSpec: &vaultprovider.Spec{
 				Name: "vault-k2",
-				Type: "aws-kms",
+				Type: sqlitevault.TypeUnsafeMemory,
 			},
 		},
 	}

--- a/pkg/api/v1/proto/agents/setup_test.go
+++ b/pkg/api/v1/proto/agents/setup_test.go
@@ -134,8 +134,8 @@ func createDatabase(t *testing.T) *sql.DB {
 	return sqlDB
 }
 
-func validCryptorSpec() cryptorprovider.Spec {
-	return cryptorprovider.Spec{
+func validCryptorSpec() *cryptorprovider.Spec {
+	return &cryptorprovider.Spec{
 		Name:   "test-crypto",
 		Type:   aes256gcm.TypeAES256GCM,
 		Config: &aes256gcm.Config{},


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   add sealer config

Following the conventional commits: https://www.conventionalcommits.org
-->

This change separates sealer and cryptor into distinct configuration fields on KeyBinding, introduces a sealerprovider package, and validates that root keys only have a sealer, TEK keys have both, and all other keys have a cryptor.
