### PR TITLE
feat: change key version from string to int and add ORDER BY in Listkeyversion

### DIFF
--- a/internal/cryptor/sealer.go
+++ b/internal/cryptor/sealer.go
@@ -10,7 +10,7 @@ import (
 type SealRequest struct {
 	TenantID   string
 	KeyID      string
-	KeyVersion string
+	KeyVersion int
 	Plaintext  *securemem.Data
 	AAD        []byte
 }
@@ -24,7 +24,7 @@ type SealResponse struct {
 type UnsealRequest struct {
 	TenantID   string
 	KeyID      string
-	KeyVersion string
+	KeyVersion int
 	Ciphertext *securemem.Data
 	AAD        []byte
 }

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -138,7 +138,7 @@ func buildProcessors(ctx context.Context, hierarchy spec.KeyHierarchy, bindings 
 type ExportSecretRequest struct {
 	TenantID   string
 	KeyID      string
-	KeyVersion string
+	KeyVersion int
 }
 
 // ExportSecret returns the plaintext key material for an active key's usable
@@ -150,7 +150,7 @@ func (km *Manager) ExportSecret(ctx context.Context, req ExportSecretRequest) (c
 
 // resolveProcessorAndSecret resolves a usable key version, checks the key
 // lifecycle, and unseals its secret via the processor for the key's kind.
-func (km *Manager) resolveProcessorAndSecret(ctx context.Context, tenantID, keyID, version string) (processor, cryptor.Secret, error) {
+func (km *Manager) resolveProcessorAndSecret(ctx context.Context, tenantID, keyID string, version int) (processor, cryptor.Secret, error) {
 	kv, err := km.resolveUsableKeyVersion(ctx, tenantID, keyID, version)
 	if err != nil {
 		return processor{}, cryptor.Secret{}, err
@@ -177,7 +177,7 @@ func (km *Manager) resolveProcessorAndSecret(ctx context.Context, tenantID, keyI
 
 // Seal validates the key lifecycle, resolves the key version and its secret to encrypt the plaintext.
 func (km *Manager) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.SealResponse, error) {
-	if req.KeyVersion == "" {
+	if req.KeyVersion == 0 {
 		return cryptor.SealResponse{}, ErrKeyVersionRequired
 	}
 	proc, sec, err := km.resolveProcessorAndSecret(ctx, req.TenantID, req.KeyID, req.KeyVersion)
@@ -202,7 +202,7 @@ func (km *Manager) Seal(ctx context.Context, req cryptor.SealRequest) (cryptor.S
 
 // Unseal validates the key lifecycle, resolves the key version and its secret to decrypt the ciphertext.
 func (km *Manager) Unseal(ctx context.Context, req cryptor.UnsealRequest) (cryptor.UnsealResponse, error) {
-	if req.KeyVersion == "" {
+	if req.KeyVersion == 0 {
 		return cryptor.UnsealResponse{}, ErrKeyVersionRequired
 	}
 	proc, sec, err := km.resolveProcessorAndSecret(ctx, req.TenantID, req.KeyID, req.KeyVersion)
@@ -259,9 +259,9 @@ func (rm *rootManager) Unseal(ctx context.Context, req cryptor.UnsealRequest) (c
 // resolveUsableKeyVersion returns the highest usable revision of version, or
 // the most recently created usable version when version is empty. Rotation
 // work must replace the latter with an explicit current-version marker.
-func (km *Manager) resolveUsableKeyVersion(ctx context.Context, tenantID, keyID, version string) (model.KeyVersion, error) {
+func (km *Manager) resolveUsableKeyVersion(ctx context.Context, tenantID, keyID string, version int) (model.KeyVersion, error) {
 	orderBy := []store.KeyVersionOrder{store.KeyVersionOrderRevisionDesc}
-	if version == "" {
+	if version == 0 {
 		orderBy = []store.KeyVersionOrder{
 			store.KeyVersionOrderCreatedAtDesc,
 			store.KeyVersionOrderRevisionDesc,
@@ -279,7 +279,7 @@ func (km *Manager) resolveUsableKeyVersion(ctx context.Context, tenantID, keyID,
 		return model.KeyVersion{}, err
 	}
 	if len(result.KeyVersions) == 0 {
-		return model.KeyVersion{}, fmt.Errorf("%w: key %s version %s", ErrNoUsableKeyVersion, keyID, version)
+		return model.KeyVersion{}, fmt.Errorf("%w: key %s version %d", ErrNoUsableKeyVersion, keyID, version)
 	}
 	return result.KeyVersions[0], nil
 }

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -62,7 +62,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -86,7 +86,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -104,7 +104,7 @@ func TestManagerSeal(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -119,7 +119,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -140,7 +140,7 @@ func TestManagerSeal(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -153,7 +153,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -174,7 +174,7 @@ func TestManagerSeal(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -187,7 +187,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("data")),
 		})
 
@@ -212,7 +212,7 @@ func TestManagerSeal(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(t.Context(), key))
 		activateKey(t, db, key)
 
-		kv := model.NewKeyVersion(tenantID, key.ID, "1", &rootKey.ID, nil)
+		kv := model.NewKeyVersion(tenantID, key.ID, 1, &rootKey.ID, nil)
 		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: kv})
 		require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestManagerSeal(t *testing.T) {
 		resp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("secret payload")),
 			AAD:        []byte("aad"),
 		})
@@ -273,7 +273,7 @@ func TestManagerUnseal(t *testing.T) {
 		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -291,7 +291,7 @@ func TestManagerUnseal(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -304,7 +304,7 @@ func TestManagerUnseal(t *testing.T) {
 		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -325,7 +325,7 @@ func TestManagerUnseal(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -338,7 +338,7 @@ func TestManagerUnseal(t *testing.T) {
 		resp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Ciphertext: newTestData(t, []byte("data")),
 		})
 
@@ -363,7 +363,7 @@ func TestManagerUnseal(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(t.Context(), key))
 		activateKey(t, db, key)
 
-		kv := model.NewKeyVersion(tenantID, key.ID, "1", &rootKey.ID, nil)
+		kv := model.NewKeyVersion(tenantID, key.ID, 1, &rootKey.ID, nil)
 		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: kv})
 		require.NoError(t, err)
 
@@ -376,7 +376,7 @@ func TestManagerUnseal(t *testing.T) {
 		sealResp, err := c.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("round trip data")),
 			AAD:        []byte("aad"),
 		})
@@ -386,7 +386,7 @@ func TestManagerUnseal(t *testing.T) {
 		unsealResp, err := c.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Ciphertext: sealResp.Ciphertext,
 			AAD:        []byte("aad"),
 		})
@@ -496,7 +496,7 @@ func TestManagerHierarchy(t *testing.T) {
 		midKey := model.NewKey(tenantID, "mid-"+uuid.NewString(), "K1", &rootKey.ID, "test", nil)
 		require.NoError(t, keyStore.CreateKey(t.Context(), midKey))
 		activateKey(t, db, midKey)
-		midKV := model.NewKeyVersion(tenantID, midKey.ID, "1", &rootKey.ID, nil)
+		midKV := model.NewKeyVersion(tenantID, midKey.ID, 1, &rootKey.ID, nil)
 		_, err := kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: midKV})
 		require.NoError(t, err)
 
@@ -509,7 +509,7 @@ func TestManagerHierarchy(t *testing.T) {
 		leafKey := model.NewKey(tenantID, "leaf-"+uuid.NewString(), "K2", &midKey.ID, "test", nil)
 		require.NoError(t, keyStore.CreateKey(t.Context(), leafKey))
 		activateKey(t, db, leafKey)
-		leafKV := model.NewKeyVersion(tenantID, leafKey.ID, "1", &midKey.ID, &midKV.Version)
+		leafKV := model.NewKeyVersion(tenantID, leafKey.ID, 1, &midKey.ID, &midKV.Version)
 		_, err = kvStore.CreateKeyVersion(t.Context(), store.CreateKeyVersionQuery{KeyVersion: leafKV})
 		require.NoError(t, err)
 
@@ -522,7 +522,7 @@ func TestManagerHierarchy(t *testing.T) {
 		sealResp, err := leafMgr.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   tenantID,
 			KeyID:      leafKey.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("top secret")),
 		})
 		assert.NoError(t, err)
@@ -530,7 +530,7 @@ func TestManagerHierarchy(t *testing.T) {
 		unsealResp, err := leafMgr.Unseal(t.Context(), cryptor.UnsealRequest{
 			TenantID:   tenantID,
 			KeyID:      leafKey.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Ciphertext: sealResp.Ciphertext,
 		})
 
@@ -981,7 +981,7 @@ func TestManagerExportSecret(t *testing.T) {
 		sec, err := c.ExportSecret(t.Context(), keyprocessor.ExportSecretRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -992,10 +992,10 @@ func TestManagerExportSecret(t *testing.T) {
 	t.Run("should return error if no usable key version found", func(t *testing.T) {
 		tests := []struct {
 			name       string
-			keyVersion string
+			keyVersion int
 		}{
-			{name: "explicit version", keyVersion: "1"},
-			{name: "empty version", keyVersion: ""},
+			{name: "explicit version", keyVersion: 1},
+			{name: "empty version", keyVersion: 0},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -1023,11 +1023,11 @@ func TestManagerExportSecret(t *testing.T) {
 	t.Run("should resolve key version with expected query", func(t *testing.T) {
 		tests := []struct {
 			name                   string
-			keyVersion             string
+			keyVersion             int
 			wantOrderByCreatedDesc bool
 		}{
-			{name: "empty version orders by created_at desc", keyVersion: "", wantOrderByCreatedDesc: true},
-			{name: "explicit version does not order by created_at", keyVersion: "1", wantOrderByCreatedDesc: false},
+			{name: "empty version orders by created_at desc", keyVersion: 0, wantOrderByCreatedDesc: true},
+			{name: "explicit version does not order by created_at", keyVersion: 1, wantOrderByCreatedDesc: false},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -1073,7 +1073,7 @@ func TestManagerExportSecret(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: tenantID, KeyID: keyID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -1088,7 +1088,7 @@ func TestManagerExportSecret(t *testing.T) {
 		sec, err := c.ExportSecret(t.Context(), keyprocessor.ExportSecretRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -1108,7 +1108,7 @@ func TestManagerExportSecret(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -1121,7 +1121,7 @@ func TestManagerExportSecret(t *testing.T) {
 		sec, err := c.ExportSecret(t.Context(), keyprocessor.ExportSecretRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -1141,7 +1141,7 @@ func TestManagerExportSecret(t *testing.T) {
 		kvs := &keyVersionStoreWrapper{}
 		kvs.listKeyVersionsFn = func(_ context.Context, _ store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
 			return store.ListKeyVersionsResult{
-				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: "1", ProcessingState: model.KeyVersionUsable}},
+				KeyVersions: []model.KeyVersion{{TenantID: key.TenantID, KeyID: key.ID, Version: 1, ProcessingState: model.KeyVersionUsable}},
 			}, nil
 		}
 		ks := &keyStoreWrapper{}
@@ -1154,7 +1154,7 @@ func TestManagerExportSecret(t *testing.T) {
 		sec, err := c.ExportSecret(t.Context(), keyprocessor.ExportSecretRequest{
 			TenantID:   key.TenantID,
 			KeyID:      key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -1165,14 +1165,14 @@ func TestManagerExportSecret(t *testing.T) {
 	t.Run("should succeed with explicit version", func(t *testing.T) {
 		// given
 		es := setupExportStack(t)
-		kv := model.NewKeyVersion(es.tenantID, es.key.ID, "1", &es.rootKey.ID, nil)
+		kv := model.NewKeyVersion(es.tenantID, es.key.ID, 1, &es.rootKey.ID, nil)
 		es.addKeyVersionWithSecret(t, kv)
 
 		// when
 		sec, err := es.mgr.ExportSecret(t.Context(), keyprocessor.ExportSecretRequest{
 			TenantID:   es.tenantID,
 			KeyID:      es.key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -1185,7 +1185,7 @@ func TestManagerExportSecret(t *testing.T) {
 		sealResp, err := es.mgr.Seal(t.Context(), cryptor.SealRequest{
 			TenantID:   es.tenantID,
 			KeyID:      es.key.ID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 			Plaintext:  newTestData(t, []byte("sealed with manager")),
 			AAD:        []byte("aad"),
 		})
@@ -1208,30 +1208,30 @@ func TestManagerExportSecret(t *testing.T) {
 		// given
 		es := setupExportStack(t)
 
-		kv1 := model.NewKeyVersion(es.tenantID, es.key.ID, "1", &es.rootKey.ID, nil)
+		kv1 := model.NewKeyVersion(es.tenantID, es.key.ID, 1, &es.rootKey.ID, nil)
 		es.addKeyVersionWithSecret(t, kv1)
 
-		kv2 := model.NewKeyVersion(es.tenantID, es.key.ID, "2", &es.rootKey.ID, nil)
+		kv2 := model.NewKeyVersion(es.tenantID, es.key.ID, 2, &es.rootKey.ID, nil)
 		kv2.CreatedAt = kv1.CreatedAt + 1 // strictly later than version "1"
 		kv2.UpdatedAt = kv2.CreatedAt
 		es.addKeyVersionWithSecret(t, kv2)
 
 		// when
-		latest := es.exportSecretBytes(t, "")
+		latest := es.exportSecretBytes(t, 0)
 
 		// then
-		assert.Equal(t, es.exportSecretBytes(t, "2"), latest)
-		assert.NotEqual(t, es.exportSecretBytes(t, "1"), latest)
+		assert.Equal(t, es.exportSecretBytes(t, 2), latest)
+		assert.NotEqual(t, es.exportSecretBytes(t, 1), latest)
 	})
 
 	t.Run("should skip non-usable versions when resolving latest", func(t *testing.T) {
 		// given
 		es := setupExportStack(t)
 
-		kv1 := model.NewKeyVersion(es.tenantID, es.key.ID, "1", &es.rootKey.ID, nil)
+		kv1 := model.NewKeyVersion(es.tenantID, es.key.ID, 1, &es.rootKey.ID, nil)
 		es.addKeyVersionWithSecret(t, kv1)
 
-		kv2 := model.NewKeyVersion(es.tenantID, es.key.ID, "2", &es.rootKey.ID, nil)
+		kv2 := model.NewKeyVersion(es.tenantID, es.key.ID, 2, &es.rootKey.ID, nil)
 		kv2.CreatedAt = kv1.CreatedAt + 1 // strictly later than version "1"
 		kv2.UpdatedAt = kv2.CreatedAt
 		es.addKeyVersionWithSecret(t, kv2)
@@ -1240,7 +1240,7 @@ func TestManagerExportSecret(t *testing.T) {
 		kv3 := model.KeyVersion{
 			TenantID:        es.tenantID,
 			KeyID:           es.key.ID,
-			Version:         "3",
+			Version:         3,
 			Revision:        0,
 			ParentKeyID:     &es.rootKey.ID,
 			LifeCycleState:  model.KeyLifeCycleActive,
@@ -1251,10 +1251,10 @@ func TestManagerExportSecret(t *testing.T) {
 		es.addKeyVersionWithSecret(t, kv3)
 
 		// when
-		latest := es.exportSecretBytes(t, "")
+		latest := es.exportSecretBytes(t, 0)
 
 		// then
-		assert.Equal(t, es.exportSecretBytes(t, "2"), latest)
+		assert.Equal(t, es.exportSecretBytes(t, 2), latest)
 	})
 }
 
@@ -1304,7 +1304,7 @@ func (es *exportSetup) addKeyVersionWithSecret(t *testing.T, kv model.KeyVersion
 	require.NoError(t, err)
 }
 
-func (es *exportSetup) exportSecretBytes(t *testing.T, version string) []byte {
+func (es *exportSetup) exportSecretBytes(t *testing.T, version int) []byte {
 	t.Helper()
 	sec, err := es.mgr.ExportSecret(t.Context(), keyprocessor.ExportSecretRequest{
 		TenantID:   es.tenantID,

--- a/internal/keyprocessor/processor.go
+++ b/internal/keyprocessor/processor.go
@@ -263,7 +263,7 @@ func (p *processor) parentSeal(ctx context.Context, kv model.KeyVersion, sec *se
 	if kv.ParentKeyID == nil {
 		return nil, ErrMissingParentKey
 	}
-	var parentVersion string
+	var parentVersion int
 	if kv.ParentKeyVersion != nil {
 		parentVersion = *kv.ParentKeyVersion
 	}
@@ -284,7 +284,7 @@ func (p *processor) parentUnseal(ctx context.Context, kv model.KeyVersion, sec *
 	if kv.ParentKeyID == nil {
 		return nil, ErrMissingParentKey
 	}
-	var parentVersion string
+	var parentVersion int
 	if kv.ParentKeyVersion != nil {
 		parentVersion = *kv.ParentKeyVersion
 	}

--- a/internal/keyprocessor/processor_test.go
+++ b/internal/keyprocessor/processor_test.go
@@ -61,7 +61,7 @@ func TestCreateSecret(t *testing.T) {
 		parentKeyID := uuid.NewString()
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", &parentKeyID, nil),
+			KeyVersion: model.NewKeyVersion(uuid.NewString(), uuid.NewString(), 1, &parentKeyID, nil),
 		})
 
 		// then
@@ -97,7 +97,7 @@ func TestCreateSecret(t *testing.T) {
 		parentKeyID := uuid.NewString()
 		// when
 		resp, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{
-			KeyVersion: model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil),
+			KeyVersion: model.NewKeyVersion(tenantID, keyID, 1, &parentKeyID, nil),
 		})
 
 		// then
@@ -124,7 +124,7 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), nil, ps.sealer, newTestVault(t))
 
 		// when
@@ -167,7 +167,7 @@ func TestCreateSecret(t *testing.T) {
 			return resp, err
 		}
 
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		processor := keyprocessor.NewProcessor(gen, newTestCryptor(), sealer, ps.sealer, newTestVault(t))
 
 		// when
@@ -199,7 +199,7 @@ func TestCreateSecret(t *testing.T) {
 		}
 
 		childKeyID := uuid.NewString()
-		childKV := model.NewKeyVersion(ps.tenantID, childKeyID, "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, childKeyID, 1, &ps.parentKey.ID, nil)
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		v.importKeyFn = func(_ context.Context, req vault.ImportKeyRequest) (*vault.ImportKeyResponse, error) {
 			assert.Equal(t, ps.tenantID, req.TenantID)
@@ -222,7 +222,7 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should return error if parent set but key version has no parent key version", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		orphanKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", nil, nil)
+		orphanKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, nil, nil)
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, newTestVault(t))
 
 		// when
@@ -238,7 +238,7 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should succeed", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, newTestVault(t))
 
 		// when
@@ -254,7 +254,7 @@ func TestCreateSecret(t *testing.T) {
 	t.Run("should succeed with transport sealer", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newTestSealer(t), ps.sealer, newTestVault(t))
 
 		// when
@@ -275,7 +275,7 @@ func TestResolveSecret(t *testing.T) {
 
 		parentKeyID := uuid.NewString()
 		// when
-		sec, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", &parentKeyID, nil))
+		sec, err := processor.ResolveSecret(t.Context(), model.NewKeyVersion(uuid.NewString(), uuid.NewString(), 1, &parentKeyID, nil))
 
 		// then
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -289,7 +289,7 @@ func TestResolveSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentKeyID := uuid.NewString()
-		kv := model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil)
+		kv := model.NewKeyVersion(tenantID, keyID, 1, &parentKeyID, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), v)
@@ -315,7 +315,7 @@ func TestResolveSecret(t *testing.T) {
 		parentErr := errors.New("parent unavailable")
 		ps := setupParent(t)
 
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, v)
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
@@ -348,7 +348,7 @@ func TestResolveSecret(t *testing.T) {
 		unsealErr := errors.New("unsealing failed")
 
 		parentKeyID := uuid.NewString()
-		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), "1", &parentKeyID, nil)
+		kv := model.NewKeyVersion(uuid.NewString(), uuid.NewString(), 1, &parentKeyID, nil)
 
 		realSealer := newTestSealer(t)
 		sealer := &sealerWrapper{Sealer: realSealer}
@@ -383,7 +383,7 @@ func TestResolveSecret(t *testing.T) {
 	t.Run("should succeed", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, ps.sealer, newTestVault(t))
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
@@ -401,7 +401,7 @@ func TestResolveSecret(t *testing.T) {
 	t.Run("should succeed with transport sealer", func(t *testing.T) {
 		// given
 		ps := setupParent(t)
-		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), "1", &ps.parentKey.ID, nil)
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newTestSealer(t), ps.sealer, newTestVault(t))
 		_, err := processor.CreateSecret(t.Context(), keyprocessor.CreateSecretRequest{KeyVersion: childKV})
 		assert.NoError(t, err)
@@ -556,7 +556,7 @@ func TestDeleteSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentKeyID := uuid.NewString()
-		kv := model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil)
+		kv := model.NewKeyVersion(tenantID, keyID, 1, &parentKeyID, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), v)
@@ -582,7 +582,7 @@ func TestDeleteSecret(t *testing.T) {
 		tenantID := uuid.NewString()
 		keyID := uuid.NewString()
 		parentKeyID := uuid.NewString()
-		kv := model.NewKeyVersion(tenantID, keyID, "1", &parentKeyID, nil)
+		kv := model.NewKeyVersion(tenantID, keyID, 1, &parentKeyID, nil)
 
 		v := &vaultWrapper{Vault: newTestVault(t)}
 		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), nil, newTestSealer(t), v)

--- a/internal/kmip/auth.go
+++ b/internal/kmip/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/ovh/kmip-go"
@@ -34,7 +35,7 @@ var peerCertsFn = func(ctx context.Context) []*x509.Certificate {
 type keyIdentifier struct {
 	TenantID string
 	KeyID    string
-	Version  string
+	Version  int
 }
 
 // keyIdentifierKey is the context key for the authorized keyIdentifier.
@@ -66,7 +67,11 @@ func (a *authorizer) authorizeIdentifier(ctx context.Context, uniqueIdentifier s
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return keyIdentifier{}, ErrInvalidKeyIdentifier
 	}
-	id := keyIdentifier{TenantID: parts[0], KeyID: parts[1], Version: parts[2]}
+	version, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return keyIdentifier{}, ErrInvalidKeyIdentifier
+	}
+	id := keyIdentifier{TenantID: parts[0], KeyID: parts[1], Version: version}
 
 	certs := peerCertsFn(ctx)
 	if len(certs) == 0 || certs[0] == nil || certs[0].Subject.CommonName == "" {

--- a/internal/kmip/auth_test.go
+++ b/internal/kmip/auth_test.go
@@ -30,10 +30,10 @@ func TestAuthorize(t *testing.T) {
 			in          string
 			wantTenant  string
 			wantKey     string
-			wantVersion string
+			wantVersion int
 		}{
-			{"tenant-a:dek-1:1", "tenant-a", "dek-1", "1"},
-			{"acme-corp:dek-mongodb-001:42", "acme-corp", "dek-mongodb-001", "42"},
+			{"tenant-a:dek-1:1", "tenant-a", "dek-1", 1},
+			{"acme-corp:dek-mongodb-001:42", "acme-corp", "dek-mongodb-001", 42},
 		}
 		for _, tt := range tests {
 			t.Run(tt.in, func(t *testing.T) {
@@ -58,6 +58,7 @@ func TestAuthorize(t *testing.T) {
 			"tenant:key:",
 			"",
 			"::",
+			"tenant-a:dek-1:not-valid-int",
 		} {
 			t.Run(in, func(t *testing.T) {
 				_, err := kmip.Authorize(context.Background(), in)

--- a/internal/kmip/setup_test.go
+++ b/internal/kmip/setup_test.go
@@ -105,13 +105,13 @@ func newTestEnv(t *testing.T, tenantID, keyID string) *testEnv {
 		}
 	}}
 	env.kvs = &keyVersionStoreStub{listKeyVersionsFn: func(_ context.Context, q store.ListKeyVersionsQuery) (store.ListKeyVersionsResult, error) {
-		if q.TenantID != tenantID || q.KeyID != dekKey.ID || (q.Version != "" && q.Version != "1") {
+		if q.TenantID != tenantID || q.KeyID != dekKey.ID || (q.Version != 0 && q.Version != 1) {
 			return store.ListKeyVersionsResult{}, nil
 		}
 		return store.ListKeyVersionsResult{KeyVersions: []model.KeyVersion{{
 			TenantID:        tenantID,
 			KeyID:           dekKey.ID,
-			Version:         "1",
+			Version:         1,
 			Revision:        0,
 			ParentKeyID:     &rootKey.ID,
 			LifeCycleState:  model.KeyLifeCycleActive,
@@ -185,7 +185,7 @@ func (env *testEnv) seedSecret(t *testing.T, material []byte) {
 	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    env.tenantID,
 		KeyID:       env.keyID,
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 0,
 		KeyMaterial: sealed.Ciphertext,
 	})

--- a/internal/vault/openbaovault/openbao.go
+++ b/internal/vault/openbaovault/openbao.go
@@ -246,8 +246,8 @@ func kvMountPath(tenantID string) string {
 	return fmt.Sprintf("%s/%s", tenantID, kvSecretName)
 }
 
-func kvPath(keyID, keyVersion string, keyRevision int) string {
-	return fmt.Sprintf("%s/%s/%d", keyID, keyVersion, keyRevision)
+func kvPath(keyID string, keyVersion, keyRevision int) string {
+	return fmt.Sprintf("%s/%d/%d", keyID, keyVersion, keyRevision)
 }
 
 func kvSecretPath(tenantID string) string {

--- a/internal/vault/openbaovault/openbao_test.go
+++ b/internal/vault/openbaovault/openbao_test.go
@@ -211,7 +211,7 @@ func TestImportKey(t *testing.T) {
 		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 			AAD:         []byte{4, 3, 2, 1},
 		})
@@ -235,7 +235,7 @@ func TestImportKey(t *testing.T) {
 		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 		})
 
@@ -250,7 +250,7 @@ func TestImportKey(t *testing.T) {
 		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:   uuid.NewString(),
 			KeyID:      uuid.NewString(),
-			KeyVersion: "1",
+			KeyVersion: 1,
 			AAD:        []byte{4, 3, 2, 1},
 		})
 
@@ -274,7 +274,7 @@ func TestImportKey(t *testing.T) {
 		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 			AAD:         []byte{4, 3, 2, 1},
 		})
@@ -286,7 +286,7 @@ func TestImportKey(t *testing.T) {
 		resp, err = cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 			AAD:         []byte{4, 3, 2, 1},
 		})
@@ -305,7 +305,7 @@ func TestImportKey(t *testing.T) {
 		resp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 			AAD:         []byte{4, 3, 2, 1},
 		})
@@ -354,7 +354,7 @@ func TestExportKey(t *testing.T) {
 		iResp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 			AAD:         []byte{4, 3, 2, 1},
 		})
@@ -365,7 +365,7 @@ func TestExportKey(t *testing.T) {
 		resp, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -389,7 +389,7 @@ func TestExportKey(t *testing.T) {
 		iResp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 		})
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestExportKey(t *testing.T) {
 		resp, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -418,7 +418,7 @@ func TestExportKey(t *testing.T) {
 		resp, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -441,7 +441,7 @@ func TestExportKey(t *testing.T) {
 		resp, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -489,7 +489,7 @@ func TestDestroyKey(t *testing.T) {
 		iResp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       keyID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: secretData,
 			AAD:         []byte{4, 3, 2, 1},
 		})
@@ -500,7 +500,7 @@ func TestDestroyKey(t *testing.T) {
 		eResp, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, eResp)
@@ -510,7 +510,7 @@ func TestDestroyKey(t *testing.T) {
 		resp, err := cli.DestroyKey(ctx, vault.DestroyKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -521,7 +521,7 @@ func TestDestroyKey(t *testing.T) {
 		eResp, err = cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -537,7 +537,7 @@ func TestDestroyKey(t *testing.T) {
 		resp, err := cli.DestroyKey(ctx, vault.DestroyKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -559,7 +559,7 @@ func TestDestroyKey(t *testing.T) {
 		resp, err := cli.DestroyKey(ctx, vault.DestroyKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      keyID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 
 		// then
@@ -628,7 +628,7 @@ func TestDestroyTenant(t *testing.T) {
 		iResp, err := cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID,
 			KeyID:       kID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: km,
 			AAD:         []byte{},
 		})
@@ -648,7 +648,7 @@ func TestDestroyTenant(t *testing.T) {
 		_, err = cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID,
 			KeyID:      kID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -715,7 +715,7 @@ func TestDestroyTenant(t *testing.T) {
 		_, err = cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID1,
 			KeyID:       kID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: km,
 			AAD:         []byte{},
 		})
@@ -730,7 +730,7 @@ func TestDestroyTenant(t *testing.T) {
 		_, err = cli.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    tenantID2,
 			KeyID:       kID,
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: km,
 			AAD:         []byte{},
 		})
@@ -749,7 +749,7 @@ func TestDestroyTenant(t *testing.T) {
 		eRep, err := cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID1,
 			KeyID:      kID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -759,7 +759,7 @@ func TestDestroyTenant(t *testing.T) {
 		eRep, err = cli.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   tenantID2,
 			KeyID:      kID,
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, eRep)

--- a/internal/vault/sqlitevault/unsafesqlite.go
+++ b/internal/vault/sqlitevault/unsafesqlite.go
@@ -20,7 +20,7 @@ const initDB = `
 CREATE TABLE IF NOT EXISTS keys (
 	tenant_id TEXT NOT NULL CHECK(tenant_id != ''),
 	key_id TEXT NOT NULL CHECK(key_id != ''),
-	key_version TEXT NOT NULL,
+	key_version INTEGER NOT NULL DEFAULT 0,
 	key_revision INTEGER NOT NULL DEFAULT 0,
 	key_material BLOB NOT NULL,
 	aad BLOB,

--- a/internal/vault/sqlitevault/unsafesqlite_test.go
+++ b/internal/vault/sqlitevault/unsafesqlite_test.go
@@ -43,7 +43,7 @@ func TestUnsafe_ImportAndExportKey(t *testing.T) {
 	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyMaterial: newTestSecureData(t, keyBytes),
 		AAD:         aad,
 	})
@@ -55,7 +55,7 @@ func TestUnsafe_ImportAndExportKey(t *testing.T) {
 	resp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "1",
+		KeyVersion: 1,
 	})
 
 	// then
@@ -73,7 +73,7 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyMaterial: newTestSecureData(t, []byte("key-material-32-bytes-padding!!")),
 	})
 	assert.NoError(t, err)
@@ -87,7 +87,7 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 			req: vault.ImportKeyRequest{
 				TenantID:    "",
 				KeyID:       "key-1",
-				KeyVersion:  "1",
+				KeyVersion:  1,
 				KeyMaterial: newTestSecureData(t, []byte("key-material-32-bytes-padding!!")),
 			},
 		},
@@ -96,7 +96,7 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 			req: vault.ImportKeyRequest{
 				TenantID:    "tenant-1",
 				KeyID:       "",
-				KeyVersion:  "1",
+				KeyVersion:  1,
 				KeyMaterial: newTestSecureData(t, []byte("key-material-32-bytes-padding!!")),
 			},
 		},
@@ -105,7 +105,7 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 			req: vault.ImportKeyRequest{
 				TenantID:    "tenant-1",
 				KeyID:       "key-1",
-				KeyVersion:  "1",
+				KeyVersion:  1,
 				KeyMaterial: newTestSecureData(t, []byte("key-material-32-bytes-padding!!")),
 			},
 		},
@@ -114,7 +114,7 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 			req: vault.ImportKeyRequest{
 				TenantID:   "tenant-1",
 				KeyID:      "key-2",
-				KeyVersion: "1",
+				KeyVersion: 1,
 			},
 		},
 	}
@@ -133,12 +133,12 @@ func TestUnsafe_ExportKeyLatestVersion(t *testing.T) {
 	ctx := t.Context()
 
 	versions := []struct {
-		version string
+		version int
 		data    []byte
 	}{
-		{"1", []byte("key-material-version-1-padding!")},
-		{"2", []byte("key-material-version-2-padding!")},
-		{"3", []byte("key-material-version-3-padding!")},
+		{1, []byte("key-material-version-1-padding!")},
+		{2, []byte("key-material-version-2-padding!")},
+		{3, []byte("key-material-version-3-padding!")},
 	}
 
 	for _, ver := range versions {
@@ -176,7 +176,7 @@ func TestUnsafe_ExportKeySpecificVersion(t *testing.T) {
 	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyMaterial: newTestSecureData(t, v1Data),
 		AAD:         []byte("aad-v1"),
 	})
@@ -185,7 +185,7 @@ func TestUnsafe_ExportKeySpecificVersion(t *testing.T) {
 	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "2",
+		KeyVersion:  2,
 		KeyMaterial: newTestSecureData(t, v2Data),
 		AAD:         []byte("aad-v2"),
 	})
@@ -195,7 +195,7 @@ func TestUnsafe_ExportKeySpecificVersion(t *testing.T) {
 	resp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "1",
+		KeyVersion: 1,
 	})
 
 	// then
@@ -214,7 +214,7 @@ func TestUnsafe_ExportKeyNotFound(t *testing.T) {
 	resp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "1",
+		KeyVersion: 1,
 	})
 
 	// then
@@ -233,7 +233,7 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyMaterial: newTestSecureData(t, v1Data),
 	})
 	assert.NoError(t, err)
@@ -241,7 +241,7 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "2",
+		KeyVersion:  2,
 		KeyMaterial: newTestSecureData(t, v2Data),
 	})
 	assert.NoError(t, err)
@@ -250,7 +250,7 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	_, err = v.DestroyKey(ctx, vault.DestroyKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "1",
+		KeyVersion: 1,
 	})
 
 	// then
@@ -259,7 +259,7 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	resp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "1",
+		KeyVersion: 1,
 	})
 	assert.ErrorIs(t, err, vault.ErrKeyNotFound)
 	assert.Nil(t, resp)
@@ -268,7 +268,7 @@ func TestUnsafe_DestroyKey(t *testing.T) {
 	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "2",
+		KeyVersion: 2,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, v2Data, []byte(resp.KeyMaterial.SecureBytes()))
@@ -286,7 +286,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 0,
 		KeyMaterial: newTestSecureData(t, rev0Data),
 		AAD:         []byte("aad-rev-0"),
@@ -296,7 +296,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 1,
 		KeyMaterial: newTestSecureData(t, rev1Data),
 		AAD:         []byte("aad-rev-1"),
@@ -307,7 +307,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	resp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 0,
 	})
 
@@ -321,7 +321,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 1,
 	})
 
@@ -335,7 +335,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	_, err = v.DestroyKey(ctx, vault.DestroyKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 0,
 	})
 	assert.NoError(t, err)
@@ -344,7 +344,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 0,
 	})
 	assert.ErrorIs(t, err, vault.ErrKeyNotFound)
@@ -354,7 +354,7 @@ func TestUnsafe_RevisionCoexistence(t *testing.T) {
 	resp, err = v.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyRevision: 1,
 	})
 	assert.NoError(t, err)
@@ -406,7 +406,7 @@ func TestUnsafe_FileSourcePersistence(t *testing.T) {
 	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
 		TenantID:    "tenant-1",
 		KeyID:       "key-1",
-		KeyVersion:  "1",
+		KeyVersion:  1,
 		KeyMaterial: newTestSecureData(t, keyBytes),
 		AAD:         aad,
 	})
@@ -424,7 +424,7 @@ func TestUnsafe_FileSourcePersistence(t *testing.T) {
 	resp, err := v2.ExportKey(ctx, vault.ExportKeyRequest{
 		TenantID:   "tenant-1",
 		KeyID:      "key-1",
-		KeyVersion: "1",
+		KeyVersion: 1,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, keyBytes, []byte(resp.KeyMaterial.SecureBytes()))
@@ -458,7 +458,7 @@ func TestDestroyTenant(t *testing.T) {
 		_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    "tenant-1",
 			KeyID:       "key-1",
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: newTestSecureData(t, []byte("key-material")),
 		})
 		assert.NoError(t, err)
@@ -476,7 +476,7 @@ func TestDestroyTenant(t *testing.T) {
 		exportResp, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
 		assert.Nil(t, exportResp)
@@ -498,7 +498,7 @@ func TestDestroyTenant(t *testing.T) {
 		_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    "tenant-1",
 			KeyID:       "key-1",
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: newTestSecureData(t, []byte("key-material-1")),
 		})
 		assert.NoError(t, err)
@@ -506,7 +506,7 @@ func TestDestroyTenant(t *testing.T) {
 		_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
 			TenantID:    "tenant-2",
 			KeyID:       "key-2",
-			KeyVersion:  "1",
+			KeyVersion:  1,
 			KeyMaterial: newTestSecureData(t, []byte("key-material-2")),
 		})
 		assert.NoError(t, err)
@@ -524,7 +524,7 @@ func TestDestroyTenant(t *testing.T) {
 		exportResp1, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   "tenant-1",
 			KeyID:      "key-1",
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		assert.ErrorIs(t, err, vault.ErrKeyNotFound)
 		assert.Nil(t, exportResp1)
@@ -533,7 +533,7 @@ func TestDestroyTenant(t *testing.T) {
 		exportResp2, err := v.ExportKey(ctx, vault.ExportKeyRequest{
 			TenantID:   "tenant-2",
 			KeyID:      "key-2",
-			KeyVersion: "1",
+			KeyVersion: 1,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("key-material-2"), []byte(exportResp2.KeyMaterial.SecureBytes()))

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -48,7 +48,7 @@ type PrepareTenantResponse struct {
 type ImportKeyRequest struct {
 	TenantID    string
 	KeyID       string
-	KeyVersion  string
+	KeyVersion  int
 	KeyRevision int
 	KeyMaterial *securemem.Data
 	AAD         []byte
@@ -63,7 +63,7 @@ type ImportKeyResponse struct {
 type ExportKeyRequest struct {
 	TenantID    string
 	KeyID       string
-	KeyVersion  string
+	KeyVersion  int
 	KeyRevision int
 }
 
@@ -77,7 +77,7 @@ type ExportKeyResponse struct {
 type DestroyKeyRequest struct {
 	TenantID    string
 	KeyID       string
-	KeyVersion  string
+	KeyVersion  int
 	KeyRevision int
 }
 

--- a/pkg/model/keyversion.go
+++ b/pkg/model/keyversion.go
@@ -16,17 +16,17 @@ const (
 type KeyVersion struct {
 	TenantID         string                    `json:"tenant_id"`
 	KeyID            string                    `json:"key_id"`
-	Version          string                    `json:"version"`
+	Version          int                       `json:"version"`
 	Revision         int                       `json:"revision"`
 	ParentKeyID      *string                   `json:"parent_key_id,omitempty"`
-	ParentKeyVersion *string                   `json:"parent_key_version,omitempty"`
+	ParentKeyVersion *int                      `json:"parent_key_version,omitempty"`
 	LifeCycleState   KeyLifeCycleState         `json:"life_cycle_state"`
 	ProcessingState  KeyVersionProcessingState `json:"processing_state"`
 	CreatedAt        clock.UnixNano            `json:"created_at"`
 	UpdatedAt        clock.UnixNano            `json:"updated_at"`
 }
 
-func NewKeyVersion(tenantID, keyID, version string, parentKeyID, parentKeyVersion *string) KeyVersion {
+func NewKeyVersion(tenantID, keyID string, version int, parentKeyID *string, parentKeyVersion *int) KeyVersion {
 	now := clock.Now()
 	return KeyVersion{
 		TenantID:         tenantID,

--- a/pkg/store/keyversion.go
+++ b/pkg/store/keyversion.go
@@ -28,6 +28,7 @@ type KeyVersionOrder int
 
 const (
 	KeyVersionOrderUnspecified KeyVersionOrder = iota
+	KeyVersionOrderVersionDesc
 	KeyVersionOrderCreatedAtDesc
 	KeyVersionOrderRevisionDesc
 )
@@ -35,7 +36,8 @@ const (
 type ListKeyVersionsQuery struct {
 	TenantID        string
 	KeyID           string
-	Version         string
+	Version         int
+	LifeCycleState  model.KeyLifeCycleState
 	ProcessingState model.KeyVersionProcessingState
 	// OrderBy applies the sort keys in the given order.
 	OrderBy []KeyVersionOrder

--- a/pkg/store/sql/keyversion.go
+++ b/pkg/store/sql/keyversion.go
@@ -17,6 +17,7 @@ type KeyVersionStore struct {
 var _ store.KeyVersion = &KeyVersionStore{}
 
 var keyVersionOrderSQL = map[store.KeyVersionOrder]string{
+	store.KeyVersionOrderVersionDesc:   "version DESC",
 	store.KeyVersionOrderCreatedAtDesc: "created_at DESC",
 	store.KeyVersionOrderRevisionDesc:  "revision DESC",
 }
@@ -65,11 +66,14 @@ func (s *KeyVersionStore) ListKeyVersions(ctx context.Context, query store.ListK
 	if query.KeyID != "" {
 		fmt.Fprintf(&q, "AND key_id = %s ", nextParam(query.KeyID))
 	}
-	if query.Version != "" {
+	if query.Version != 0 {
 		fmt.Fprintf(&q, "AND version = %s ", nextParam(query.Version))
 	}
 	if query.ProcessingState != "" {
 		fmt.Fprintf(&q, "AND processing_state = %s ", nextParam(query.ProcessingState))
+	}
+	if query.LifeCycleState != "" {
+		fmt.Fprintf(&q, "AND life_cycle_state = %s ", nextParam(query.LifeCycleState))
 	}
 
 	if len(query.OrderBy) > 0 {

--- a/pkg/store/sql/keyversion_test.go
+++ b/pkg/store/sql/keyversion_test.go
@@ -37,7 +37,7 @@ func TestCreateKeyVersion(t *testing.T) {
 		kv := model.KeyVersion{
 			TenantID:        tenant.ID,
 			KeyID:           key.ID,
-			Version:         "1",
+			Version:         1,
 			Revision:        0,
 			LifeCycleState:  model.KeyLifeCycleActive,
 			ProcessingState: model.KeyVersionUsable,
@@ -56,12 +56,12 @@ func TestCreateKeyVersion(t *testing.T) {
 	t.Run("should create key version with parent references", func(t *testing.T) {
 		// given
 		parentKeyID := uuid.NewString()
-		parentKeyVersion := "2"
+		parentKeyVersion := 2
 		now := clock.Now()
 		kv := model.KeyVersion{
 			TenantID:         tenant.ID,
 			KeyID:            key.ID,
-			Version:          "2",
+			Version:          2,
 			Revision:         0,
 			ParentKeyID:      &parentKeyID,
 			ParentKeyVersion: &parentKeyVersion,
@@ -86,7 +86,7 @@ func TestCreateKeyVersion(t *testing.T) {
 		kv := model.KeyVersion{
 			TenantID:        tenant.ID,
 			KeyID:           key.ID,
-			Version:         "3",
+			Version:         3,
 			Revision:        0,
 			LifeCycleState:  model.KeyLifeCycleActive,
 			ProcessingState: model.KeyVersionUsable,
@@ -109,7 +109,7 @@ func TestCreateKeyVersion(t *testing.T) {
 		kv := model.KeyVersion{
 			TenantID:        uuid.NewString(),
 			KeyID:           key.ID,
-			Version:         "1",
+			Version:         1,
 			Revision:        0,
 			LifeCycleState:  model.KeyLifeCycleActive,
 			ProcessingState: model.KeyVersionUsable,
@@ -141,42 +141,28 @@ func TestListKeyVersions(t *testing.T) {
 	require.NoError(t, keyStore.CreateKey(ctx, key))
 
 	// seed: version "1" with revisions 0, 1 (usable), 2 (re-wrapping)
-	now := clock.Now()
 	seeds := []struct {
+		version         int
 		revision        int
 		processingState model.KeyVersionProcessingState
+		lifeCycleState  model.KeyLifeCycleState
 	}{
-		{0, model.KeyVersionUsable},
-		{1, model.KeyVersionUsable},
-		{2, model.KeyVersionReWrapping},
+		{1, 1, model.KeyVersionUsable, model.KeyLifeCycleCompromised},
+		{1, 2, model.KeyVersionUsable, model.KeyLifeCyclePreActivation},
+		{2, 1, model.KeyVersionReWrapping, model.KeyLifeCycleActive},
+		{2, 3, model.KeyVersionReWrapping, model.KeyLifeCycleActive},
 	}
-	for _, s := range seeds {
+	for i, s := range seeds {
+		now := clock.Now() + clock.UnixNano(i) // ensure unique timestamps
 		kv := model.KeyVersion{
 			TenantID:        tenant.ID,
 			KeyID:           key.ID,
-			Version:         "1",
+			Version:         s.version,
 			Revision:        s.revision,
-			LifeCycleState:  model.KeyLifeCycleActive,
+			LifeCycleState:  s.lifeCycleState,
 			ProcessingState: s.processingState,
 			CreatedAt:       now,
 			UpdatedAt:       now,
-		}
-		_, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
-		require.NoError(t, err)
-	}
-
-	// seed: version "2" with revisions 0, 1 (usable), created strictly after version "1"
-	later := now + 1
-	for _, revision := range []int{0, 1} {
-		kv := model.KeyVersion{
-			TenantID:        tenant.ID,
-			KeyID:           key.ID,
-			Version:         "2",
-			Revision:        revision,
-			LifeCycleState:  model.KeyLifeCycleActive,
-			ProcessingState: model.KeyVersionUsable,
-			CreatedAt:       later,
-			UpdatedAt:       later,
 		}
 		_, err := kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: kv})
 		require.NoError(t, err)
@@ -187,12 +173,12 @@ func TestListKeyVersions(t *testing.T) {
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID: tenant.ID,
 			KeyID:    key.ID,
-			Version:  "1",
+			Version:  1,
 		})
 
 		// then
 		assert.NoError(t, err)
-		assert.Len(t, result.KeyVersions, 3)
+		assert.Len(t, result.KeyVersions, 2)
 	})
 
 	t.Run("should filter by processing state", func(t *testing.T) {
@@ -200,7 +186,7 @@ func TestListKeyVersions(t *testing.T) {
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID:        tenant.ID,
 			KeyID:           key.ID,
-			Version:         "1",
+			Version:         1,
 			ProcessingState: model.KeyVersionUsable,
 		})
 
@@ -214,16 +200,15 @@ func TestListKeyVersions(t *testing.T) {
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID: tenant.ID,
 			KeyID:    key.ID,
-			Version:  "1",
+			Version:  1,
 			OrderBy:  []store.KeyVersionOrder{store.KeyVersionOrderRevisionDesc},
 		})
 
 		// then
 		assert.NoError(t, err)
-		require.Len(t, result.KeyVersions, 3)
+		require.Len(t, result.KeyVersions, 2)
 		assert.Equal(t, 2, result.KeyVersions[0].Revision)
 		assert.Equal(t, 1, result.KeyVersions[1].Revision)
-		assert.Equal(t, 0, result.KeyVersions[2].Revision)
 	})
 
 	t.Run("should limit results", func(t *testing.T) {
@@ -231,7 +216,7 @@ func TestListKeyVersions(t *testing.T) {
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID: tenant.ID,
 			KeyID:    key.ID,
-			Version:  "1",
+			Version:  1,
 			OrderBy:  []store.KeyVersionOrder{store.KeyVersionOrderRevisionDesc},
 			Limit:    1,
 		})
@@ -244,13 +229,13 @@ func TestListKeyVersions(t *testing.T) {
 
 	t.Run("should resolve highest usable revision", func(t *testing.T) {
 		// given
-		expRevision := 1
+		expRevision := 2
 
 		// when
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID:        tenant.ID,
 			KeyID:           key.ID,
-			Version:         "1",
+			Version:         1,
 			ProcessingState: model.KeyVersionUsable,
 			OrderBy:         []store.KeyVersionOrder{store.KeyVersionOrderRevisionDesc},
 			Limit:           1,
@@ -273,14 +258,22 @@ func TestListKeyVersions(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		require.Len(t, result.KeyVersions, 5)
+		require.Len(t, result.KeyVersions, 4)
+
+		time := clock.UnixNano(0)
 		for _, kv := range result.KeyVersions[:2] {
-			assert.Equal(t, "2", kv.Version)
-			assert.Equal(t, later, kv.CreatedAt)
+			assert.Equal(t, 2, kv.Version)
+			if time != 0 {
+				assert.Greater(t, time, kv.CreatedAt)
+			}
+			time = kv.CreatedAt
 		}
 		for _, kv := range result.KeyVersions[2:] {
-			assert.Equal(t, "1", kv.Version)
-			assert.Equal(t, now, kv.CreatedAt)
+			assert.Equal(t, 1, kv.Version)
+			if time != 0 {
+				assert.Greater(t, time, kv.CreatedAt)
+			}
+			time = kv.CreatedAt
 		}
 	})
 
@@ -300,8 +293,8 @@ func TestListKeyVersions(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		require.Len(t, result.KeyVersions, 1)
-		assert.Equal(t, "2", result.KeyVersions[0].Version)
-		assert.Equal(t, 1, result.KeyVersions[0].Revision)
+		assert.Equal(t, 1, result.KeyVersions[0].Version)
+		assert.Equal(t, 2, result.KeyVersions[0].Revision)
 		assert.Equal(t, model.KeyVersionUsable, result.KeyVersions[0].ProcessingState)
 	})
 
@@ -310,7 +303,7 @@ func TestListKeyVersions(t *testing.T) {
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID:        tenant.ID,
 			KeyID:           key.ID,
-			Version:         "1",
+			Version:         1,
 			ProcessingState: model.KeyVersionUsable,
 			OrderBy:         []store.KeyVersionOrder{store.KeyVersionOrderRevisionDesc},
 			Limit:           1,
@@ -319,8 +312,40 @@ func TestListKeyVersions(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		require.Len(t, result.KeyVersions, 1)
-		assert.Equal(t, "1", result.KeyVersions[0].Version)
-		assert.Equal(t, 1, result.KeyVersions[0].Revision)
+		assert.Equal(t, 1, result.KeyVersions[0].Version)
+		assert.Equal(t, 2, result.KeyVersions[0].Revision)
+	})
+
+	t.Run("should return keyversion based on the lifecycle state filter", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:       tenant.ID,
+			KeyID:          key.ID,
+			LifeCycleState: model.KeyLifeCycleCompromised,
+		})
+
+		// then
+		assert.NoError(t, err)
+		require.Len(t, result.KeyVersions, 1)
+		assert.Equal(t, model.KeyLifeCycleCompromised, result.KeyVersions[0].LifeCycleState)
+	})
+
+	t.Run("should get the latest keyversion based on the lifecycle state filter", func(t *testing.T) {
+		// when
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:       tenant.ID,
+			KeyID:          key.ID,
+			LifeCycleState: model.KeyLifeCycleActive,
+			OrderBy:        []store.KeyVersionOrder{store.KeyVersionOrderVersionDesc, store.KeyVersionOrderRevisionDesc},
+			Limit:          1,
+		})
+
+		// then
+		assert.NoError(t, err)
+		require.Len(t, result.KeyVersions, 1)
+		assert.Equal(t, model.KeyLifeCycleActive, result.KeyVersions[0].LifeCycleState)
+		assert.Equal(t, 2, result.KeyVersions[0].Version)
+		assert.Equal(t, 3, result.KeyVersions[0].Revision)
 	})
 
 	t.Run("should return empty slice when no matches", func(t *testing.T) {
@@ -328,7 +353,7 @@ func TestListKeyVersions(t *testing.T) {
 		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID: tenant.ID,
 			KeyID:    key.ID,
-			Version:  "99",
+			Version:  99,
 		})
 
 		// then

--- a/pkg/store/sql/migrate.go
+++ b/pkg/store/sql/migrate.go
@@ -52,10 +52,10 @@ const createKeyVersionsTable = `
 CREATE TABLE IF NOT EXISTS key_versions (
 	tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
 	key_id UUID NOT NULL,
-	version TEXT NOT NULL,
+	version INT NOT NULL,
 	revision INT NOT NULL,
 	parent_key_id UUID NULL,
-	parent_key_version TEXT NULL,
+	parent_key_version INT NULL,
 	life_cycle_state TEXT NOT NULL,
 	processing_state TEXT NOT NULL,
 	created_at BIGINT NOT NULL,


### PR DESCRIPTION
feat: change key version from string to int and add ORDER BY in ListKeyVersions

This covers the two main changes:
* Refactoring Version/ParentKeyVersion from string to int across the entire stack (model, store, vault, cryptor, migrations, tests)
* Adding the ORDER BY clause so DESC applies to each column individually, and adding IsOrderByVersionDesc + LifeCycleState filter support to ListKeyVersions
