### PR TITLE
feat: add combined life cycle and processing state update for keys

### DIFF
--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -21,6 +21,7 @@ type Key interface {
 	ListKeys(ctx context.Context, query ListKeysQuery) (ListKeysResult, error)
 	UpdateKeyLifeCycleState(ctx context.Context, query UpdateKeyLifeCycleStateQuery) error
 	UpdateKeyProcessingState(ctx context.Context, query UpdateKeyProcessingStateQuery) error
+	UpdateKeyLifeCycleAndProcessingState(ctx context.Context, query UpdateKeyLifeCycleAndProcessingStateQuery) error
 }
 
 type GetKeyByNameQuery struct {
@@ -74,4 +75,13 @@ type UpdateKeyProcessingStateQuery struct {
 	TenantID  string
 	NewStatus model.KeyProcessingStatus
 	NewJobID  string
+}
+
+type UpdateKeyLifeCycleAndProcessingStateQuery struct {
+	ID         string
+	TenantID   string
+	ToState    model.KeyLifeCycleState
+	ToStatus   model.KeyProcessingStatus
+	FromState  []model.KeyLifeCycleState
+	FromStatus []model.KeyProcessingStatus
 }

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -361,6 +361,41 @@ func (ks *KeyStore) UpdateKeyProcessingState(ctx context.Context, query store.Up
 	return nil
 }
 
+func (ks *KeyStore) UpdateKeyLifeCycleAndProcessingState(ctx context.Context, q store.UpdateKeyLifeCycleAndProcessingStateQuery) error {
+	var sb strings.Builder
+	sb.WriteString("UPDATE keys SET life_cycle_state = $1, processing_status = $2, updated_at = $3 WHERE id = $4 AND tenant_id = $5")
+
+	args := []any{q.ToState, q.ToStatus, clock.Now(), q.ID, q.TenantID}
+	argIdx := 6
+
+	if len(q.FromState) > 0 {
+		fmt.Fprintf(&sb, " AND life_cycle_state = ANY($%d)", argIdx)
+		args = append(args, q.FromState)
+		argIdx++
+	}
+
+	if len(q.FromStatus) > 0 {
+		fmt.Fprintf(&sb, " AND processing_status = ANY($%d)", argIdx)
+		args = append(args, q.FromStatus)
+	}
+
+	result, err := ks.db.ExecContext(ctx, sb.String(), args...)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows == 0 {
+		return store.ErrKeyNotFound
+	}
+
+	return nil
+}
+
 func nullableJobID(jobID string) any {
 	if jobID == "" {
 		return nil

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -876,6 +876,169 @@ func TestListKeys(t *testing.T) {
 	})
 }
 
+func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
+	// given
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	tenantStore := storesql.NewTenantStore(db)
+
+	require.NoError(t, storesql.Migrate(ctx, db))
+	keyStore := storesql.NewKeyStore(db)
+
+	tenant := createTenant(t, tenantStore)
+
+	t.Run("should update key life cycle and processing state", func(t *testing.T) {
+		// given
+		key := model.NewKey(tenant.ID, uuid.NewString(), "K0", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+		assert.Equal(t, model.KeyLifeCyclePreActivation, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingPending, key.KeyProcessingState.Status)
+
+		// when
+		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+			ID:         key.ID,
+			TenantID:   tenant.ID,
+			ToState:    model.KeyLifeCycleCompromised,
+			ToStatus:   model.KeyProcessingCompleted,
+			FromState:  []model.KeyLifeCycleState{model.KeyLifeCyclePreActivation, model.KeyLifeCycleActive},
+			FromStatus: []model.KeyProcessingStatus{model.KeyProcessingPending, model.KeyProcessingInProgress},
+		})
+
+		// then
+		require.NoError(t, err)
+
+		got, err := keyStore.GetKeyByID(ctx, key.ID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleCompromised, got.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, got.KeyProcessingState.Status)
+	})
+
+	t.Run("should update when from state guard is not specified", func(t *testing.T) {
+		// given
+		key := model.NewKey(tenant.ID, uuid.NewString(), "K0", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+
+		// when
+		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+			ID:         key.ID,
+			TenantID:   tenant.ID,
+			ToState:    model.KeyLifeCycleCompromised,
+			ToStatus:   model.KeyProcessingCompleted,
+			FromStatus: []model.KeyProcessingStatus{model.KeyProcessingPending},
+		})
+
+		// then
+		require.NoError(t, err)
+
+		got, err := keyStore.GetKeyByID(ctx, key.ID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleCompromised, got.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, got.KeyProcessingState.Status)
+	})
+
+	t.Run("should update when from status guard is not specified", func(t *testing.T) {
+		// given
+		key := model.NewKey(tenant.ID, uuid.NewString(), "K0", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+
+		// when
+		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+			ID:        key.ID,
+			TenantID:  tenant.ID,
+			ToState:   model.KeyLifeCycleCompromised,
+			ToStatus:  model.KeyProcessingCompleted,
+			FromState: []model.KeyLifeCycleState{model.KeyLifeCyclePreActivation},
+		})
+
+		// then
+		require.NoError(t, err)
+
+		got, err := keyStore.GetKeyByID(ctx, key.ID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleCompromised, got.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, got.KeyProcessingState.Status)
+	})
+
+	t.Run("should update when no guards are specified", func(t *testing.T) {
+		// given
+		key := model.NewKey(tenant.ID, uuid.NewString(), "K0", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+
+		// when
+		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+			ID:       key.ID,
+			TenantID: tenant.ID,
+			ToState:  model.KeyLifeCycleCompromised,
+			ToStatus: model.KeyProcessingCompleted,
+		})
+
+		// then
+		require.NoError(t, err)
+
+		got, err := keyStore.GetKeyByID(ctx, key.ID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleCompromised, got.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, got.KeyProcessingState.Status)
+	})
+
+	t.Run("should not update when from status guard does not match", func(t *testing.T) {
+		// given
+		key := model.NewKey(tenant.ID, uuid.NewString(), "K0", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+		assert.Equal(t, model.KeyLifeCyclePreActivation, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingPending, key.KeyProcessingState.Status)
+
+		// when
+		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+			ID:         key.ID,
+			TenantID:   tenant.ID,
+			ToState:    model.KeyLifeCycleCompromised,
+			ToStatus:   model.KeyProcessingCompleted,
+			FromState:  []model.KeyLifeCycleState{model.KeyLifeCyclePreActivation},
+			FromStatus: []model.KeyProcessingStatus{model.KeyProcessingFailed},
+		})
+
+		// then
+		require.Error(t, err)
+		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+
+		got, err := keyStore.GetKeyByID(ctx, key.ID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCyclePreActivation, got.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingPending, got.KeyProcessingState.Status)
+	})
+
+	t.Run("should not update when from state guard does not match", func(t *testing.T) {
+		// given
+		key := model.NewKey(tenant.ID, uuid.NewString(), "K0", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+		assert.Equal(t, model.KeyLifeCyclePreActivation, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingPending, key.KeyProcessingState.Status)
+
+		// when
+		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+			ID:         key.ID,
+			TenantID:   tenant.ID,
+			ToState:    model.KeyLifeCycleCompromised,
+			ToStatus:   model.KeyProcessingCompleted,
+			FromState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+			FromStatus: []model.KeyProcessingStatus{model.KeyProcessingPending},
+		})
+
+		// then
+		require.Error(t, err)
+		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+
+		got, err := keyStore.GetKeyByID(ctx, key.ID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCyclePreActivation, got.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingPending, got.KeyProcessingState.Status)
+	})
+}
+
 // createKeyHierarchy creates a tenant and inserts 10 keys forming the tree documented on [keyHierarchy].
 // Keys are created with varying lifecycle states (active, suspended, pre-activation), managing agents
 // (root, agent-aws, agent-azure, agent-gcp, agent-onprem, agent-onprem-2), and labels (cloud, environment)


### PR DESCRIPTION
This adds the UpdateKeyLifeCycleAndProcessingState method to the key store, which atomically updates both the life cycle state and processing status in a single query with optional guard conditions on current state/status. This is useful for the activation key flow where both fields need to transition together.
