### PR TITLE
feat: add ValidateActivateKey to key validator

### DIFF
--- a/internal/handler/announcekey/job.go
+++ b/internal/handler/announcekey/job.go
@@ -54,7 +54,7 @@ func (h *JobHandler) ConfirmJob(ctx context.Context, job orbital.Job) (orbital.J
 		return orbital.CancelJobConfirmer(fmt.Sprintf("key not in pre-activation: %s", key.LifeCycleState)), nil
 	}
 
-	if vErr := h.keyValidator.ValidateAnnounceKey(ctx, validator.AnnounceInput{
+	if vErr := h.keyValidator.ValidateKeyAnnounce(ctx, validator.AnnounceInput{
 		TenantID:   data.TenantID,
 		KeyKind:    data.Kind,
 		Name:       data.Name,

--- a/internal/handler/announcekey/setup_test.go
+++ b/internal/handler/announcekey/setup_test.go
@@ -122,6 +122,10 @@ func (s *stubValidator) ValidateAnnounceKey(_ context.Context, _ validator.Annou
 	return s.err
 }
 
+func (s *stubValidator) ValidateActivateKey(_ context.Context, _ validator.ActivateInput) *validator.ValidationError {
+	return s.err
+}
+
 // passingValidator returns a stubValidator that accepts every input.
 func passingValidator() *stubValidator {
 	return &stubValidator{}

--- a/internal/handler/announcekey/setup_test.go
+++ b/internal/handler/announcekey/setup_test.go
@@ -112,17 +112,17 @@ func (s *stubProcessingStateUpdater) UpdateKeyProcessingState(_ context.Context,
 }
 
 // stubValidator implements validator.KeyValidator for tests.
-// If err is nil, ValidateAnnounceKey returns nil (valid). Otherwise it
+// If err is nil, ValidateKeyAnnounce returns nil (valid). Otherwise it
 // returns the configured ValidationError.
 type stubValidator struct {
 	err *validator.ValidationError
 }
 
-func (s *stubValidator) ValidateAnnounceKey(_ context.Context, _ validator.AnnounceInput) *validator.ValidationError {
+func (s *stubValidator) ValidateKeyAnnounce(_ context.Context, _ validator.AnnounceInput) *validator.ValidationError {
 	return s.err
 }
 
-func (s *stubValidator) ValidateActivateKey(_ context.Context, _ validator.ActivateInput) *validator.ValidationError {
+func (s *stubValidator) ValidateKeyActivate(_ context.Context, _ validator.ActivateInput) *validator.ValidationError {
 	return s.err
 }
 

--- a/pkg/api/v1/proto/admin/keys/key_service.go
+++ b/pkg/api/v1/proto/admin/keys/key_service.go
@@ -47,7 +47,7 @@ func NewKeyService(rootName string, keyStore store.Key, validator validator.KeyV
 // If the announce operation is for the root we just create it and return it otherwise it creates a job and a new key.
 // If there's a key with the same name we return that key or if the key is in a failed or pending state we retry the job.
 func (s *KeyService) AnnounceKey(ctx context.Context, req *AnnounceKeyRequest) (*AnnounceKeyResponse, error) {
-	vErr := s.validator.ValidateAnnounceKey(ctx, validator.AnnounceInput{
+	vErr := s.validator.ValidateKeyAnnounce(ctx, validator.AnnounceInput{
 		TenantID:   req.GetTenantId(),
 		KeyKind:    req.GetKind(),
 		Name:       req.GetName(),

--- a/pkg/validator/key_validator.go
+++ b/pkg/validator/key_validator.go
@@ -60,7 +60,7 @@ type AnnounceInput struct {
 	TargetName string
 }
 
-func (v *keyValidator) ValidateAnnounceKey(ctx context.Context, input AnnounceInput) *ValidationError {
+func (v *keyValidator) ValidateKeyAnnounce(ctx context.Context, input AnnounceInput) *ValidationError {
 	ve := &ValidationError{
 		code: Invalid,
 	}
@@ -115,8 +115,8 @@ func (v *keyValidator) ValidateAnnounceKey(ctx context.Context, input AnnounceIn
 	return nil
 }
 
-// ValidateActivateKey implements [KeyValidator].
-func (v *keyValidator) ValidateActivateKey(ctx context.Context, input ActivateInput) *ValidationError {
+// ValidateKeyActivate implements [KeyValidator].
+func (v *keyValidator) ValidateKeyActivate(ctx context.Context, input ActivateInput) *ValidationError {
 	ve := &ValidationError{
 		code: Invalid,
 	}

--- a/pkg/validator/key_validator.go
+++ b/pkg/validator/key_validator.go
@@ -66,7 +66,7 @@ func (v *keyValidator) ValidateKeyAnnounce(ctx context.Context, input AnnounceIn
 	}
 
 	switch {
-	case input.TenantID == "":
+	case !isValidUUID(input.TenantID):
 		ve.err = ErrEmptyTenantID
 		return ve
 	case input.KeyKind == "":
@@ -122,10 +122,10 @@ func (v *keyValidator) ValidateKeyActivate(ctx context.Context, input ActivateIn
 	}
 
 	switch {
-	case input.TenantID == "":
+	case !isValidUUID(input.TenantID):
 		ve.err = ErrEmptyTenantID
 		return ve
-	case input.KeyID == "":
+	case !isValidUUID(input.KeyID):
 		ve.err = ErrInvalidKeyID
 		return ve
 	}

--- a/pkg/validator/key_validator.go
+++ b/pkg/validator/key_validator.go
@@ -149,7 +149,7 @@ func (v *keyValidator) ValidateKeyActivate(ctx context.Context, input ActivateIn
 	}
 
 	totalKs := len(parents.Keys)
-	if totalKs < 2 {
+	if totalKs <= 0 {
 		ve.code, ve.err = FailedCondition, ErrFailedToGetParentKeys
 		return ve
 	}

--- a/pkg/validator/key_validator.go
+++ b/pkg/validator/key_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/openkcm/krypton/internal/keylifecycle"
 	"github.com/openkcm/krypton/internal/spec"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
@@ -20,6 +21,7 @@ type keyValidator struct {
 var (
 	ErrEmptyTenantID              = errors.New("tenantId cannot be empty")
 	ErrEmptyKeyKind               = errors.New("key kind canot be empty")
+	ErrInvalidKeyID               = errors.New("keyId is invalid")
 	ErrEmptyName                  = errors.New("name canot be empty")
 	ErrInvalidTenantID            = errors.New("tenantId is invalid")
 	ErrInvalidKeyKind             = errors.New("key kind is invalid")
@@ -30,6 +32,14 @@ var (
 	ErrRootKeyParent              = errors.New("root key cannot have a parent")
 	ErrParentInvalidState         = errors.New("parent key is not in a valid state")
 	ErrParentKeyAdjecency         = errors.New("key is not adjecent to parent key")
+
+	ErrFailedToGetTenant       = errors.New("failed to get tenant")
+	ErrFailedToGetParentKeys   = errors.New("failed to get parent keys")
+	ErrNoParentKeysToActivate  = errors.New("no parent keys to activate, key must have at least one parent key")
+	ErrParentKeyNotInOrder     = errors.New("parent key is not in the correct order")
+	ErrParentKeyTransientState = errors.New("parent key is in a transient state, please wait for the parent key to be completed")
+	ErrKeyTransientState       = errors.New("key is in a transient state, please wait for the key to be completed")
+	ErrNoParentKeyRelation     = errors.New("key has no parent key relation")
 )
 
 func NewValidator(rootSegment spec.HierarchySegment, topology spec.Topology, hierarchy spec.KeyHierarchy, tenants store.Tenant, keys store.Key) KeyValidator {
@@ -102,6 +112,71 @@ func (v *keyValidator) ValidateAnnounceKey(ctx context.Context, input AnnounceIn
 		return ve
 	}
 
+	return nil
+}
+
+// ValidateActivateKey implements [KeyValidator].
+func (v *keyValidator) ValidateActivateKey(ctx context.Context, input ActivateInput) *ValidationError {
+	ve := &ValidationError{
+		code: Invalid,
+	}
+
+	switch {
+	case input.TenantID == "":
+		ve.err = ErrEmptyTenantID
+		return ve
+	case input.KeyID == "":
+		ve.err = ErrInvalidKeyID
+		return ve
+	}
+
+	if _, err := v.tenants.GetTenant(ctx, store.GetTenantQuery{ID: input.TenantID}); err != nil {
+		if errors.Is(err, store.ErrTenantNotFound) {
+			ve.code, ve.err = FailedCondition, ErrInvalidTenantID
+			return ve
+		}
+		ve.code, ve.err = Internal, ErrFailedToGetTenant
+		return ve
+	}
+
+	parents, err := v.keys.GetParentKeys(ctx, store.GetParentKeysQuery{
+		KeyID:    input.KeyID,
+		TenantID: input.TenantID,
+	})
+	if err != nil {
+		ve.code, ve.err = Internal, ErrFailedToGetParentKeys
+		return ve
+	}
+
+	totalKs := len(parents.Keys)
+	if totalKs < 2 {
+		ve.code, ve.err = FailedCondition, ErrFailedToGetParentKeys
+		return ve
+	}
+
+	for index, parent := range parents.Keys {
+		if v.hierarchy.IndexOf(parent.Kind) != index {
+			ve.code, ve.err = FailedCondition, ErrParentKeyNotInOrder
+			return ve
+		}
+		isTargetKey := index+1 == totalKs
+		if !isTargetKey {
+			if parent.LifeCycleState != model.KeyLifeCycleActive || parent.KeyProcessingState.Status != model.KeyProcessingCompleted {
+				ve.code, ve.err = FailedCondition, ErrParentKeyTransientState
+				return ve
+			}
+			continue
+		}
+		// Target key: must be done processing and allow transition to active.
+		if parent.KeyProcessingState.Status != model.KeyProcessingCompleted {
+			ve.code, ve.err = FailedCondition, ErrKeyTransientState
+			return ve
+		}
+		if err := keylifecycle.ValidateTransition(parent.LifeCycleState, model.KeyLifeCycleActive); err != nil {
+			ve.code, ve.err = FailedCondition, err
+			return ve
+		}
+	}
 	return nil
 }
 

--- a/pkg/validator/key_validator_test.go
+++ b/pkg/validator/key_validator_test.go
@@ -84,7 +84,7 @@ func keyStoreReturning(key *model.Key, err error) store.Key {
 	}
 }
 
-func TestValidator_ValidateAnnounceKey(t *testing.T) {
+func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 	storeErr := errors.New("boom")
 
 	activeRootParent := &model.Key{
@@ -262,7 +262,7 @@ func TestValidator_ValidateAnnounceKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tc.tenants, tc.keys)
 
-			ve := v.ValidateAnnounceKey(t.Context(), tc.input)
+			ve := v.ValidateKeyAnnounce(t.Context(), tc.input)
 
 			if tc.wantErr == nil {
 				assert.Nil(t, ve)
@@ -277,7 +277,7 @@ func TestValidator_ValidateAnnounceKey(t *testing.T) {
 	}
 }
 
-func TestValidator_ValidateActivateKey(t *testing.T) {
+func TestValidator_ValidateKeyActivate(t *testing.T) {
 	t.Run("validate input", func(t *testing.T) {
 		// given
 		tts := []struct {
@@ -305,7 +305,7 @@ func TestValidator_ValidateActivateKey(t *testing.T) {
 				v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), &stubTenantStore{}, &stubKeyStore{})
 
 				// when
-				ve := v.ValidateActivateKey(t.Context(), tt.input)
+				ve := v.ValidateKeyActivate(t.Context(), tt.input)
 
 				// then
 				assert.NotNil(t, ve)
@@ -319,7 +319,7 @@ func TestValidator_ValidateActivateKey(t *testing.T) {
 		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantReturning(store.ErrTenantNotFound), &stubKeyStore{})
 
 		// when
-		ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
 
 		// then
 		assert.NotNil(t, ve)
@@ -332,7 +332,7 @@ func TestValidator_ValidateActivateKey(t *testing.T) {
 		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantReturning(assert.AnError), &stubKeyStore{})
 
 		// when
-		ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
 
 		// then
 		assert.NotNil(t, ve)
@@ -350,7 +350,7 @@ func TestValidator_ValidateActivateKey(t *testing.T) {
 		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantFound(), stubKeys)
 
 		// when
-		ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
 
 		// then
 		assert.NotNil(t, ve)
@@ -437,7 +437,7 @@ func TestValidator_ValidateActivateKey(t *testing.T) {
 
 				v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantFound(), stubKeys)
 				// when
-				ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+				ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
 
 				// then
 				if tt.wantErr == nil {

--- a/pkg/validator/key_validator_test.go
+++ b/pkg/validator/key_validator_test.go
@@ -344,7 +344,7 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 		assert.Equal(t, codes.Internal, ve.ToProtoErrCode())
 	})
 
-	t.Run("should return error if getparents returns an error", func(t *testing.T) {
+	t.Run("should return error if GetParentKeys returns an error", func(t *testing.T) {
 		// given
 		stubKeys := &stubKeyStore{
 			getParentKeys: func(_ context.Context, _ store.GetParentKeysQuery) (store.GetParentKeysResult, error) {
@@ -394,7 +394,7 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 				wantCode: codes.FailedPrecondition,
 			},
 			{
-				name: "shoud return error if key to activate is not in completed state",
+				name: "should return error if key to activate is not in completed state",
 				parentKeys: []model.Key{
 					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
 					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingInProgress}, ParentID: new("parent-id")},
@@ -421,12 +421,35 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 				wantCode: codes.FailedPrecondition,
 			},
 			{
+				name: "should return error if key to activate is a root key and processing state is not completed",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingInProgress}},
+				},
+				wantErr:  validator.ErrKeyTransientState,
+				wantCode: codes.FailedPrecondition,
+			},
+			{
 				name: "should return nil if all parent keys are active and adjacent",
 				parentKeys: []model.Key{
 					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
 					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}, ParentID: new("parent-id")},
 				},
 				wantErr: nil,
+			},
+			{
+				name: "should return nil if key to activate is a root key",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+				},
+				wantErr: nil,
+			},
+			{
+				name: "should return error if key to activate is only one and is not a root",
+				parentKeys: []model.Key{
+					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+				},
+				wantErr:  validator.ErrParentKeyNotInOrder,
+				wantCode: codes.FailedPrecondition,
 			},
 		}
 

--- a/pkg/validator/key_validator_test.go
+++ b/pkg/validator/key_validator_test.go
@@ -27,7 +27,12 @@ func (s *stubTenantStore) GetTenant(ctx context.Context, q store.GetTenantQuery)
 type stubKeyStore struct {
 	store.Key
 
-	getKeyByID func(ctx context.Context, id, tenantID string) (*model.Key, error)
+	getParentKeys func(ctx context.Context, query store.GetParentKeysQuery) (store.GetParentKeysResult, error)
+	getKeyByID    func(ctx context.Context, id, tenantID string) (*model.Key, error)
+}
+
+func (s *stubKeyStore) GetParentKeys(ctx context.Context, query store.GetParentKeysQuery) (store.GetParentKeysResult, error) {
+	return s.getParentKeys(ctx, query)
 }
 
 func (s *stubKeyStore) GetKeyByID(ctx context.Context, id, tenantID string) (*model.Key, error) {
@@ -270,4 +275,179 @@ func TestValidator_ValidateAnnounceKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidator_ValidateActivateKey(t *testing.T) {
+	t.Run("validate input", func(t *testing.T) {
+		// given
+		tts := []struct {
+			name     string
+			input    validator.ActivateInput
+			wantErr  error
+			wantCode codes.Code
+		}{
+			{
+				name:     "empty tenantID",
+				input:    validator.ActivateInput{TenantID: "", KeyID: "key-id"},
+				wantErr:  validator.ErrEmptyTenantID,
+				wantCode: codes.InvalidArgument,
+			},
+			{
+				name:     "empty keyID",
+				input:    validator.ActivateInput{TenantID: "tenantID", KeyID: ""},
+				wantErr:  validator.ErrInvalidKeyID,
+				wantCode: codes.InvalidArgument,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), &stubTenantStore{}, &stubKeyStore{})
+
+				// when
+				ve := v.ValidateActivateKey(t.Context(), tt.input)
+
+				// then
+				assert.NotNil(t, ve)
+				assert.EqualError(t, ve, tt.wantErr.Error())
+				assert.Equal(t, tt.wantCode, ve.ToProtoErrCode())
+			})
+		}
+	})
+	t.Run("should return error if tenant not found", func(t *testing.T) {
+		// given
+		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantReturning(store.ErrTenantNotFound), &stubKeyStore{})
+
+		// when
+		ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+
+		// then
+		assert.NotNil(t, ve)
+		assert.EqualError(t, ve, validator.ErrInvalidTenantID.Error())
+		assert.Equal(t, codes.FailedPrecondition, ve.ToProtoErrCode())
+	})
+
+	t.Run("should return error if tenant store internal error", func(t *testing.T) {
+		// given
+		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantReturning(assert.AnError), &stubKeyStore{})
+
+		// when
+		ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+
+		// then
+		assert.NotNil(t, ve)
+		assert.EqualError(t, ve, validator.ErrFailedToGetTenant.Error())
+		assert.Equal(t, codes.Internal, ve.ToProtoErrCode())
+	})
+
+	t.Run("should return error if getparents returns an error", func(t *testing.T) {
+		// given
+		stubKeys := &stubKeyStore{
+			getParentKeys: func(_ context.Context, _ store.GetParentKeysQuery) (store.GetParentKeysResult, error) {
+				return store.GetParentKeysResult{}, errors.New("boom")
+			},
+		}
+		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantFound(), stubKeys)
+
+		// when
+		ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+
+		// then
+		assert.NotNil(t, ve)
+		assert.EqualError(t, ve, validator.ErrFailedToGetParentKeys.Error())
+		assert.Equal(t, codes.Internal, ve.ToProtoErrCode())
+	})
+
+	t.Run("keys hierarchy validation", func(t *testing.T) {
+		tts := []struct {
+			name       string
+			parentKeys []model.Key
+			wantErr    error
+			wantCode   codes.Code
+		}{
+			{
+				name:       "should return error if key has no parent keys",
+				parentKeys: []model.Key{},
+				wantErr:    validator.ErrFailedToGetParentKeys,
+				wantCode:   codes.FailedPrecondition,
+			},
+			{
+				name: "should return error if parent key is not active",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCycleDestroyed, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}, ParentID: new("parent-id")},
+				},
+				wantErr:  validator.ErrParentKeyTransientState,
+				wantCode: codes.FailedPrecondition,
+			},
+			{
+				name: "should return error if parent key is not completed",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingPending}},
+					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}, ParentID: new("parent-id")},
+				},
+				wantErr:  validator.ErrParentKeyTransientState,
+				wantCode: codes.FailedPrecondition,
+			},
+			{
+				name: "shoud return error if key to activate is not in completed state",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingInProgress}, ParentID: new("parent-id")},
+				},
+				wantErr:  validator.ErrKeyTransientState,
+				wantCode: codes.FailedPrecondition,
+			},
+			{
+				name: "should return error if key to activate is not in valid state transition",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+					{Kind: "K1", LifeCycleState: model.KeyLifeCycleDestroyed, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}, ParentID: new("parent-id")},
+				},
+				wantErr:  errors.New("cannot transition from destroyed to active: invalid key state transition"),
+				wantCode: codes.FailedPrecondition,
+			},
+			{
+				name: "should return error if parent keys are not adjacent",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+					{Kind: "K2", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+				},
+				wantErr:  validator.ErrParentKeyNotInOrder,
+				wantCode: codes.FailedPrecondition,
+			},
+			{
+				name: "should return nil if all parent keys are active and adjacent",
+				parentKeys: []model.Key{
+					{Kind: "K0", LifeCycleState: model.KeyLifeCycleActive, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}},
+					{Kind: "K1", LifeCycleState: model.KeyLifeCyclePreActivation, KeyProcessingState: model.KeyProcessingState{Status: model.KeyProcessingCompleted}, ParentID: new("parent-id")},
+				},
+				wantErr: nil,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				stubKeys := &stubKeyStore{
+					getParentKeys: func(_ context.Context, _ store.GetParentKeysQuery) (store.GetParentKeysResult, error) {
+						return store.GetParentKeysResult{Keys: tt.parentKeys}, nil
+					},
+				}
+
+				v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantFound(), stubKeys)
+				// when
+				ve := v.ValidateActivateKey(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+
+				// then
+				if tt.wantErr == nil {
+					assert.Nil(t, ve)
+					return
+				}
+				assert.NotNil(t, ve)
+				assert.EqualError(t, ve, tt.wantErr.Error())
+				assert.Equal(t, tt.wantCode, ve.ToProtoErrCode())
+			})
+		}
+	})
 }

--- a/pkg/validator/key_validator_test.go
+++ b/pkg/validator/key_validator_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 
@@ -13,6 +14,9 @@ import (
 	"github.com/openkcm/krypton/pkg/store"
 	"github.com/openkcm/krypton/pkg/validator"
 )
+
+var validUUID = uuid.NewString()
+var invalidUUID = "invalid-uuid"
 
 type stubTenantStore struct {
 	store.Tenant
@@ -63,7 +67,7 @@ var testRootSegment = spec.HierarchySegment{StartKind: "K0", EndKind: "K0"}
 func tenantFound() store.Tenant {
 	return &stubTenantStore{
 		getTenant: func(_ context.Context, _ store.GetTenantQuery) (store.GetTenantResult, error) {
-			return store.GetTenantResult{Tenant: model.Tenant{ID: "tenant-1"}}, nil
+			return store.GetTenantResult{Tenant: model.Tenant{ID: validUUID}}, nil
 		},
 	}
 }
@@ -89,19 +93,19 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 
 	activeRootParent := &model.Key{
 		ID:             "parent-id",
-		TenantID:       "tenant-1",
+		TenantID:       validUUID,
 		Kind:           "K0",
 		LifeCycleState: model.KeyLifeCycleActive,
 	}
 	suspendedRootParent := &model.Key{
 		ID:             "parent-id",
-		TenantID:       "tenant-1",
+		TenantID:       validUUID,
 		Kind:           "K0",
 		LifeCycleState: model.KeyLifeCycleSuspended,
 	}
 	activeUnknownKindParent := &model.Key{
 		ID:             "parent-id",
-		TenantID:       "tenant-1",
+		TenantID:       validUUID,
 		Kind:           "UNKNOWN",
 		LifeCycleState: model.KeyLifeCycleActive,
 	}
@@ -124,7 +128,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "empty keyKind",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrEmptyKeyKind,
@@ -132,7 +136,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "empty name",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrEmptyName,
@@ -140,7 +144,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "tenant not found",
-			input:    validator.AnnounceInput{TenantID: "missing", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantReturning(store.ErrTenantNotFound),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrInvalidTenantID,
@@ -148,7 +152,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "tenant store internal error",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantReturning(storeErr),
 			keys:     &stubKeyStore{},
 			wantErr:  storeErr,
@@ -156,7 +160,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "key kind not in hierarchy",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "UNKNOWN", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "UNKNOWN", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrInvalidKeyKind,
@@ -164,7 +168,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "target not in topology",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "missing-agent", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "missing-agent", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrTargetNotInTopolgy,
@@ -172,7 +176,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "target does not manage key kind",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K0", Name: "k0", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K0", Name: "k0", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrTargetDoesNotManageKeyKind,
@@ -180,7 +184,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "non-root key with empty parentID",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: ""},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: ""},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrNonRootKey,
@@ -188,7 +192,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "root key with parentID is rejected",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K0", Name: "k0", TargetName: "", ParentID: "some-parent"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K0", Name: "k0", TargetName: "", ParentID: "some-parent"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrRootKeyParent,
@@ -196,7 +200,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "parent key not found",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "missing-parent"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "missing-parent"},
 			tenants:  tenantFound(),
 			keys:     keyStoreReturning(nil, store.ErrKeyNotFound),
 			wantErr:  validator.ErrInvalidParentKey,
@@ -204,7 +208,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "parent key store internal error",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     keyStoreReturning(nil, storeErr),
 			wantErr:  storeErr,
@@ -212,7 +216,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "parent key not active",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     keyStoreReturning(suspendedRootParent, nil),
 			wantErr:  validator.ErrParentInvalidState,
@@ -220,7 +224,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "parent key skips a hierarchy layer",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K2", Name: "k2", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K2", Name: "k2", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     keyStoreReturning(activeRootParent, nil),
 			wantErr:  validator.ErrParentKeyAdjecency,
@@ -228,7 +232,7 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:     "parent key kind unknown to hierarchy",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     keyStoreReturning(activeUnknownKindParent, nil),
 			wantErr:  validator.ErrParentKeyAdjecency,
@@ -236,21 +240,21 @@ func TestValidator_ValidateKeyAnnounce(t *testing.T) {
 		},
 		{
 			name:    "valid non-root key with active adjacent parent",
-			input:   validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
+			input:   validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "agent-derived", ParentID: "parent-id"},
 			tenants: tenantFound(),
 			keys:    keyStoreReturning(activeRootParent, nil),
 			wantErr: nil,
 		},
 		{
 			name:    "valid root key with empty parentID",
-			input:   validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K0", Name: "k0", TargetName: "", ParentID: ""},
+			input:   validator.AnnounceInput{TenantID: validUUID, KeyKind: "K0", Name: "k0", TargetName: "", ParentID: ""},
 			tenants: tenantFound(),
 			keys:    &stubKeyStore{},
 			wantErr: nil,
 		},
 		{
 			name:     "empty target does not manage non-root kind",
-			input:    validator.AnnounceInput{TenantID: "tenant-1", KeyKind: "K1", Name: "k1", TargetName: "", ParentID: "parent-id"},
+			input:    validator.AnnounceInput{TenantID: validUUID, KeyKind: "K1", Name: "k1", TargetName: "", ParentID: "parent-id"},
 			tenants:  tenantFound(),
 			keys:     &stubKeyStore{},
 			wantErr:  validator.ErrTargetDoesNotManageKeyKind,
@@ -287,14 +291,14 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 			wantCode codes.Code
 		}{
 			{
-				name:     "empty tenantID",
-				input:    validator.ActivateInput{TenantID: "", KeyID: "key-id"},
+				name:     "invalid tenantID",
+				input:    validator.ActivateInput{TenantID: invalidUUID, KeyID: validUUID},
 				wantErr:  validator.ErrEmptyTenantID,
 				wantCode: codes.InvalidArgument,
 			},
 			{
-				name:     "empty keyID",
-				input:    validator.ActivateInput{TenantID: "tenantID", KeyID: ""},
+				name:     "invalid keyID",
+				input:    validator.ActivateInput{TenantID: validUUID, KeyID: invalidUUID},
 				wantErr:  validator.ErrInvalidKeyID,
 				wantCode: codes.InvalidArgument,
 			},
@@ -319,7 +323,7 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantReturning(store.ErrTenantNotFound), &stubKeyStore{})
 
 		// when
-		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: validUUID, KeyID: validUUID})
 
 		// then
 		assert.NotNil(t, ve)
@@ -332,7 +336,7 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantReturning(assert.AnError), &stubKeyStore{})
 
 		// when
-		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: validUUID, KeyID: validUUID})
 
 		// then
 		assert.NotNil(t, ve)
@@ -350,7 +354,7 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 		v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantFound(), stubKeys)
 
 		// when
-		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+		ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: validUUID, KeyID: validUUID})
 
 		// then
 		assert.NotNil(t, ve)
@@ -437,7 +441,7 @@ func TestValidator_ValidateKeyActivate(t *testing.T) {
 
 				v := validator.NewValidator(testRootSegment, testTopology(), testHierarchy(), tenantFound(), stubKeys)
 				// when
-				ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: "tenant-1", KeyID: "key-id"})
+				ve := v.ValidateKeyActivate(t.Context(), validator.ActivateInput{TenantID: validUUID, KeyID: validUUID})
 
 				// then
 				if tt.wantErr == nil {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 
 	"github.com/openkcm/krypton/pkg/api/v1/proto"
@@ -29,6 +30,11 @@ type ValidationError struct {
 type ActivateInput struct {
 	TenantID string
 	KeyID    string
+}
+
+func isValidUUID(id string) bool {
+	_, err := uuid.Parse(id)
+	return err == nil
 }
 
 // NewValidationError constructs a ValidationError. Useful for tests that

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -10,6 +10,7 @@ import (
 
 type KeyValidator interface {
 	ValidateAnnounceKey(context.Context, AnnounceInput) *ValidationError
+	ValidateActivateKey(context.Context, ActivateInput) *ValidationError
 }
 
 type ErrorKind int
@@ -23,6 +24,11 @@ const (
 type ValidationError struct {
 	code ErrorKind
 	err  error
+}
+
+type ActivateInput struct {
+	TenantID string
+	KeyID    string
 }
 
 // NewValidationError constructs a ValidationError. Useful for tests that
@@ -57,4 +63,8 @@ func (ve *ValidationError) Error() string {
 	}
 
 	return ve.err.Error()
+}
+
+func (ve *ValidationError) Unwrap() error {
+	return ve.err
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -9,8 +9,8 @@ import (
 )
 
 type KeyValidator interface {
-	ValidateAnnounceKey(context.Context, AnnounceInput) *ValidationError
-	ValidateActivateKey(context.Context, ActivateInput) *ValidationError
+	ValidateKeyAnnounce(context.Context, AnnounceInput) *ValidationError
+	ValidateKeyActivate(context.Context, ActivateInput) *ValidationError
 }
 
 type ErrorKind int


### PR DESCRIPTION
This adds activation validation that checks the key hierarchy order, parent key states, processing status, and lifecycle transition validity before allowing a key to be activated.
