### PR TITLE
fix: escape sql LIKE/ILIKE wildcards

### DIFF
--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -243,7 +243,7 @@ func (ks *KeyStore) ListKeys(ctx context.Context, query store.ListKeysQuery) (st
 	}
 
 	if query.Name != "" {
-		fmt.Fprintf(&q, "AND name ILIKE %s ", nextParam("%"+query.Name+"%"))
+		fmt.Fprintf(&q, `AND name ILIKE %s ESCAPE '\' `, nextParam("%"+escapeLikePattern(query.Name)+"%"))
 	}
 
 	if query.ManagedBy != "" {
@@ -317,6 +317,14 @@ func (ks *KeyStore) ListKeys(ctx context.Context, query store.ListKeysQuery) (st
 	}
 
 	return store.ListKeysResult{Keys: keys, Cursor: cursor}, nil
+}
+
+// escapeLikePattern escapes LIKE/ILIKE metacharacters so user input is matched literally.
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 func (ks *KeyStore) UpdateKeyLifeCycleState(ctx context.Context, query store.UpdateKeyLifeCycleStateQuery) error {

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -824,6 +824,76 @@ func TestListKeys(t *testing.T) {
 		assert.Equal(t, h.ba.ID, result.Keys[0].ID)   // BA
 	})
 
+	t.Run("should treat % as a literal character in name filter", func(t *testing.T) {
+		// given
+		tenant := createTenant(t, tenantStore)
+		match := model.NewKey(tenant.ID, "50%_off", "K1", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, match))
+		// Negative control: without escaping, ILIKE "%%%" matches any name.
+		decoy := model.NewKey(tenant.ID, "regular-key", "K1", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, decoy))
+
+		query := store.ListKeysQuery{TenantID: tenant.ID, Name: "%"}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, result.Keys, 1)
+		if len(result.Keys) == 1 {
+			assert.Equal(t, match.ID, result.Keys[0].ID)
+		}
+	})
+
+	t.Run("should treat _ as a literal character in name filter", func(t *testing.T) {
+		// given
+		tenant := createTenant(t, tenantStore)
+		match := model.NewKey(tenant.ID, "a_b", "K1", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, match))
+		// Negative control: without escaping, "a_b" (ILIKE, case-insensitive) also matches "aXb".
+		decoy := model.NewKey(tenant.ID, "aXb", "K1", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, decoy))
+
+		query := store.ListKeysQuery{TenantID: tenant.ID, Name: "a_b"}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, result.Keys, 1)
+		if len(result.Keys) == 1 {
+			assert.Equal(t, match.ID, result.Keys[0].ID)
+		}
+	})
+
+	t.Run("should treat \\ as a literal character in name filter", func(t *testing.T) {
+		// given
+		tenant := createTenant(t, tenantStore)
+		match := model.NewKey(tenant.ID, `foo\%bar`, "K1", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, match))
+		// Negative control: if user's `\` were not escaped, the user-supplied `%`
+		// (correctly escaped by us to `\%`) combined with the user's unescaped `\`
+		// would form `\\%` in the pattern. Postgres reads `\\` as a literal `\`
+		// and the following `%` as a wildcard, causing a false-positive match on
+		// `foo\XXXbar`. Escaping user's `\` to `\\` prevents this.
+		decoy := model.NewKey(tenant.ID, `foo\XXXbar`, "K1", nil, "root", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, decoy))
+
+		query := store.ListKeysQuery{TenantID: tenant.ID, Name: `foo\%bar`}
+
+		// when
+		result, err := keyStore.ListKeys(ctx, query)
+
+		// then
+		assert.NoError(t, err)
+		assert.Len(t, result.Keys, 1)
+		if len(result.Keys) == 1 {
+			assert.Equal(t, match.ID, result.Keys[0].ID)
+		}
+	})
+
 	t.Run("should filter by multiple criteria", func(t *testing.T) {
 		// given
 		query := store.ListKeysQuery{


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   escape sql LIKE/ILIKE wildcards

Following the conventional commits: https://www.conventionalcommits.org
-->

This fixes potential LIKE/ILIKE wildcard injection in ListKeys name filter by escaping %, _, and \ so user input is matched as a literal substring