### PR TITLE
feat(store): add key version state transitions with optimistic locking

### DIFF
--- a/pkg/model/keyversion.go
+++ b/pkg/model/keyversion.go
@@ -8,6 +8,7 @@ type KeyVersionProcessingState string
 const (
 	KeyVersionUsable     KeyVersionProcessingState = "usable"
 	KeyVersionReWrapping KeyVersionProcessingState = "re-wrapping"
+	KeyVersionActivating KeyVersionProcessingState = "activating"
 )
 
 // KeyVersion tracks both the version (which key material is used) and the
@@ -32,7 +33,7 @@ func NewKeyVersion(tenantID, keyID string, version int, parentKeyID *string, par
 		TenantID:         tenantID,
 		KeyID:            keyID,
 		Version:          version,
-		Revision:         0,
+		Revision:         1,
 		ParentKeyID:      parentKeyID,
 		ParentKeyVersion: parentKeyVersion,
 		LifeCycleState:   KeyLifeCycleActive,

--- a/pkg/store/key.go
+++ b/pkg/store/key.go
@@ -21,7 +21,7 @@ type Key interface {
 	ListKeys(ctx context.Context, query ListKeysQuery) (ListKeysResult, error)
 	UpdateKeyLifeCycleState(ctx context.Context, query UpdateKeyLifeCycleStateQuery) error
 	UpdateKeyProcessingState(ctx context.Context, query UpdateKeyProcessingStateQuery) error
-	UpdateKeyLifeCycleAndProcessingState(ctx context.Context, query UpdateKeyLifeCycleAndProcessingStateQuery) error
+	UpdateKeyStates(ctx context.Context, query UpdateKeyStatesQuery) error
 }
 
 type GetKeyByNameQuery struct {
@@ -77,7 +77,7 @@ type UpdateKeyProcessingStateQuery struct {
 	NewJobID  string
 }
 
-type UpdateKeyLifeCycleAndProcessingStateQuery struct {
+type UpdateKeyStatesQuery struct {
 	ID         string
 	TenantID   string
 	ToState    model.KeyLifeCycleState

--- a/pkg/store/keyversion.go
+++ b/pkg/store/keyversion.go
@@ -8,10 +8,12 @@ import (
 )
 
 var ErrKeyVersionNotFound = errors.New("key version not found")
+var ErrKeyVersionQueryInvalid = errors.New("invalid key version query")
 
 type KeyVersion interface {
 	CreateKeyVersion(ctx context.Context, query CreateKeyVersionQuery) (CreateKeyVersionResult, error)
 	ListKeyVersions(ctx context.Context, query ListKeyVersionsQuery) (ListKeyVersionsResult, error)
+	UpdateKeyVersionStates(ctx context.Context, query UpdateKeyVersionStatesQuery) error
 }
 
 type CreateKeyVersionQuery struct {
@@ -46,4 +48,15 @@ type ListKeyVersionsQuery struct {
 
 type ListKeyVersionsResult struct {
 	KeyVersions []model.KeyVersion
+}
+
+type UpdateKeyVersionStatesQuery struct {
+	TenantID            string
+	KeyID               string
+	Version             int
+	Revision            int
+	FromProcessingState []model.KeyVersionProcessingState
+	ToProcessingState   model.KeyVersionProcessingState
+	FromLifeCycleState  []model.KeyLifeCycleState
+	ToLifeCycleState    model.KeyLifeCycleState
 }

--- a/pkg/store/sql/key.go
+++ b/pkg/store/sql/key.go
@@ -369,7 +369,7 @@ func (ks *KeyStore) UpdateKeyProcessingState(ctx context.Context, query store.Up
 	return nil
 }
 
-func (ks *KeyStore) UpdateKeyLifeCycleAndProcessingState(ctx context.Context, q store.UpdateKeyLifeCycleAndProcessingStateQuery) error {
+func (ks *KeyStore) UpdateKeyStates(ctx context.Context, q store.UpdateKeyStatesQuery) error {
 	var sb strings.Builder
 	sb.WriteString("UPDATE keys SET life_cycle_state = $1, processing_status = $2, updated_at = $3 WHERE id = $4 AND tenant_id = $5")
 

--- a/pkg/store/sql/key_test.go
+++ b/pkg/store/sql/key_test.go
@@ -946,7 +946,7 @@ func TestListKeys(t *testing.T) {
 	})
 }
 
-func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
+func TestUpdateKeyStates(t *testing.T) {
 	// given
 	ctx := t.Context()
 	db, err := sql.Open("postgres", pgConnStr)
@@ -968,7 +968,7 @@ func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
 		assert.Equal(t, model.KeyProcessingPending, key.KeyProcessingState.Status)
 
 		// when
-		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+		err := keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
 			ID:         key.ID,
 			TenantID:   tenant.ID,
 			ToState:    model.KeyLifeCycleCompromised,
@@ -992,7 +992,7 @@ func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(ctx, key))
 
 		// when
-		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+		err := keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
 			ID:         key.ID,
 			TenantID:   tenant.ID,
 			ToState:    model.KeyLifeCycleCompromised,
@@ -1015,7 +1015,7 @@ func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(ctx, key))
 
 		// when
-		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+		err := keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
 			ID:        key.ID,
 			TenantID:  tenant.ID,
 			ToState:   model.KeyLifeCycleCompromised,
@@ -1038,7 +1038,7 @@ func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(ctx, key))
 
 		// when
-		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+		err := keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
 			ID:       key.ID,
 			TenantID: tenant.ID,
 			ToState:  model.KeyLifeCycleCompromised,
@@ -1062,7 +1062,7 @@ func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
 		assert.Equal(t, model.KeyProcessingPending, key.KeyProcessingState.Status)
 
 		// when
-		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+		err := keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
 			ID:         key.ID,
 			TenantID:   tenant.ID,
 			ToState:    model.KeyLifeCycleCompromised,
@@ -1089,7 +1089,7 @@ func TestUpdateKeyLifeCycleAndProcessingState(t *testing.T) {
 		assert.Equal(t, model.KeyProcessingPending, key.KeyProcessingState.Status)
 
 		// when
-		err := keyStore.UpdateKeyLifeCycleAndProcessingState(ctx, store.UpdateKeyLifeCycleAndProcessingStateQuery{
+		err := keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
 			ID:         key.ID,
 			TenantID:   tenant.ID,
 			ToState:    model.KeyLifeCycleCompromised,

--- a/pkg/store/sql/keyversion.go
+++ b/pkg/store/sql/keyversion.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openkcm/krypton/internal/clock"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
 )
@@ -123,4 +124,49 @@ func (s *KeyVersionStore) ListKeyVersions(ctx context.Context, query store.ListK
 	}
 
 	return store.ListKeyVersionsResult{KeyVersions: keyVersions}, nil
+}
+
+func (s *KeyVersionStore) UpdateKeyVersionStates(ctx context.Context, query store.UpdateKeyVersionStatesQuery) error {
+	if query.TenantID == "" || query.KeyID == "" || query.Version == 0 ||
+		query.Revision == 0 || len(query.FromProcessingState) == 0 || query.ToProcessingState == "" ||
+		len(query.FromLifeCycleState) == 0 || query.ToLifeCycleState == "" {
+		return fmt.Errorf("missing required fields: %w", store.ErrKeyVersionQueryInvalid)
+	}
+
+	now := clock.Now()
+	result, err := s.db.ExecContext(
+		ctx,
+		`UPDATE key_versions
+		SET processing_state = $1,
+		life_cycle_state = $2,
+		updated_at = $3
+		WHERE tenant_id = $4
+		AND key_id = $5
+		AND version = $6
+		AND revision = $7
+		AND processing_state = ANY($8)
+		AND life_cycle_state = ANY($9)`,
+		query.ToProcessingState,
+		query.ToLifeCycleState,
+		now,
+		query.TenantID,
+		query.KeyID,
+		query.Version,
+		query.Revision,
+		query.FromProcessingState,
+		query.FromLifeCycleState,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows == 0 {
+		return store.ErrKeyVersionNotFound
+	}
+	return nil
 }

--- a/pkg/store/sql/keyversion_test.go
+++ b/pkg/store/sql/keyversion_test.go
@@ -361,3 +361,267 @@ func TestListKeyVersions(t *testing.T) {
 		assert.Empty(t, result.KeyVersions)
 	})
 }
+
+func TestUpdateKeyVersionStates(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("postgres", pgConnStr)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	require.NoError(t, storesql.Migrate(ctx, db))
+	kvStore := storesql.NewKeyVersionStore(db)
+	keyStore := storesql.NewKeyStore(db)
+	tenantStore := storesql.NewTenantStore(db)
+
+	tenant := createTenant(t, tenantStore)
+
+	t.Run("should update processing state", func(t *testing.T) {
+		//given
+		// seed: version "1" with revision 1 (usable)
+		key := model.NewKey(tenant.ID, "kv-update-key-"+uuid.NewString(), "K1", nil, "key-1", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+
+		_, err = kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: model.NewKeyVersion(tenant.ID, key.ID, 1, nil, nil)})
+		require.NoError(t, err)
+
+		// when
+		err := kvStore.UpdateKeyVersionStates(ctx, store.UpdateKeyVersionStatesQuery{
+			TenantID:            tenant.ID,
+			KeyID:               key.ID,
+			Version:             1,
+			Revision:            1,
+			FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+			ToProcessingState:   model.KeyVersionReWrapping,
+			FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+			ToLifeCycleState:    model.KeyLifeCycleCompromised,
+		})
+
+		// then
+		assert.NoError(t, err)
+
+		result, err := kvStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID: tenant.ID,
+			KeyID:    key.ID,
+			Version:  1,
+		})
+		require.NoError(t, err)
+		require.Len(t, result.KeyVersions, 1)
+		assert.Equal(t, model.KeyVersionReWrapping, result.KeyVersions[0].ProcessingState)
+		assert.Equal(t, model.KeyLifeCycleCompromised, result.KeyVersions[0].LifeCycleState)
+	})
+
+	t.Run("should return error if", func(t *testing.T) {
+		//given
+		// seed: version "1" with revision 1 (usable)
+		key := model.NewKey(tenant.ID, "kv-update-key-"+uuid.NewString(), "K1", nil, "key-2", nil)
+		require.NoError(t, keyStore.CreateKey(ctx, key))
+
+		_, err = kvStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{KeyVersion: model.NewKeyVersion(tenant.ID, key.ID, 1, nil, nil)})
+		require.NoError(t, err)
+
+		tts := []struct {
+			name  string
+			query store.UpdateKeyVersionStatesQuery
+		}{
+			{
+				name: "from processing state does not match",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            tenant.ID,
+					KeyID:               key.ID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionActivating},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "from lifecycle state does not match",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            tenant.ID,
+					KeyID:               key.ID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCyclePreActivation},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "key version does not exist",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            tenant.ID,
+					KeyID:               key.ID,
+					Version:             99,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "key version does not exist with given revision",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            tenant.ID,
+					KeyID:               key.ID,
+					Version:             1,
+					Revision:            99,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "key version does not exist with given tenant",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            uuid.NewString(),
+					KeyID:               key.ID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "key version does not exist with given key",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            tenant.ID,
+					KeyID:               uuid.NewString(),
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				err := kvStore.UpdateKeyVersionStates(ctx, tt.query)
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, store.ErrKeyVersionNotFound)
+			})
+		}
+	})
+
+	t.Run("should return error if query input is invalid", func(t *testing.T) {
+		validUUID := uuid.NewString()
+		tts := []struct {
+			name  string
+			query store.UpdateKeyVersionStatesQuery
+		}{
+			{
+				name: "missing tenantID",
+				query: store.UpdateKeyVersionStatesQuery{
+					KeyID:               validUUID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing keyID",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            validUUID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing version",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            validUUID,
+					KeyID:               validUUID,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing revision",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            validUUID,
+					KeyID:               validUUID,
+					Version:             1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing from processing state",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:           validUUID,
+					KeyID:              validUUID,
+					Version:            1,
+					Revision:           1,
+					ToProcessingState:  model.KeyVersionReWrapping,
+					FromLifeCycleState: []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:   model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing to processing state",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            validUUID,
+					KeyID:               validUUID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing from lifecycle state",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            validUUID,
+					KeyID:               validUUID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					ToLifeCycleState:    model.KeyLifeCycleCompromised,
+				},
+			},
+			{
+				name: "missing to lifecycle state",
+				query: store.UpdateKeyVersionStatesQuery{
+					TenantID:            validUUID,
+					KeyID:               validUUID,
+					Version:             1,
+					Revision:            1,
+					FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+					ToProcessingState:   model.KeyVersionReWrapping,
+					FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+				},
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				err := kvStore.UpdateKeyVersionStates(ctx, tt.query)
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, store.ErrKeyVersionQueryInvalid)
+			})
+		}
+	})
+}


### PR DESCRIPTION
1. Rename UpdateKeyLifeCycleAndProcessingState -> UpdateKeyStates (and its query type) across interface, implementation, and tests
2. Add new UpdateKeyVersionStates method to the KeyVersion store interface with implementation and tests
3. Add ErrKeyVersionQueryInvalid sentinel error