### PR TITLE
feat: add ActivateKey RPC implementation 

### DIFF
--- a/api-specs/v1/proto/admin/keys/key.proto
+++ b/api-specs/v1/proto/admin/keys/key.proto
@@ -7,6 +7,7 @@ option go_package = "github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys";
 
 service KeyService {
   rpc AnnounceKey(AnnounceKeyRequest) returns (AnnounceKeyResponse);
+  rpc ActivateKey(ActivateKeyRequest) returns (ActivateKeyResponse);
   rpc GetKey(GetKeyRequest) returns (GetKeyResponse);
   rpc GetParentKeys(GetParentKeysRequest) returns (GetParentKeysResponse);
   rpc GetDescendantKeys(GetDescendantKeysRequest) returns (GetDescendantKeysResponse);
@@ -27,6 +28,7 @@ message Key {
   KeyProcessingState key_processing_state = 11;
 }
 
+
 message KeyProcessingState {
   string status = 1;
   string job_id = 2;
@@ -43,6 +45,14 @@ message AnnounceKeyRequest {
 
 message AnnounceKeyResponse {
   Key key = 1;
+}
+
+message ActivateKeyRequest {
+  string id = 1;
+  string tenant_id = 2;
+}
+
+message ActivateKeyResponse {
 }
 
 message GetKeyRequest {

--- a/cmd/root/main.go
+++ b/cmd/root/main.go
@@ -68,6 +68,7 @@ func main() {
 	tenantStore := storesql.NewTenantStore(db)
 	agentStore := storesql.NewAgentStore(db)
 	keyStore := storesql.NewKeyStore(db)
+	keyVersionStore := storesql.NewKeyVersionStore(db)
 
 	keyValidator := validator.NewValidator(cfg.Segment, cfg.Topology, cfg.Hierarchy, tenantStore, keyStore)
 
@@ -113,7 +114,7 @@ func main() {
 	agents.RegisterServiceServer(grpcServer, agents.NewAgentService(agentStore, *cfg))
 
 	// gRPC server setup for keys API
-	keypb.RegisterKeyServiceServer(grpcServer, keypb.NewKeyService(cfg.Name, keyStore, keyValidator, reconcilerMgr))
+	keypb.RegisterKeyServiceServer(grpcServer, keypb.NewKeyService(cfg.Name, keyStore, keyVersionStore, keyValidator, reconcilerMgr, nil))
 
 	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", ":"+srvPort)
 	handleErr(err, "failed to listen on gRPC port")
@@ -132,7 +133,6 @@ func main() {
 	// KMIP server (optional) — serves unwrapped DEKs to KMIP clients over mTLS.
 	var kmipSrv *kmip.Server
 	if cfg.KMIP != nil {
-		keyVersionStore := storesql.NewKeyVersionStore(db)
 		bindings := make(map[model.KeyKind]spec.KeyBinding, len(cfg.KeyBindings))
 		for kind, binding := range cfg.KeyBindings {
 			bindings[model.KeyKind(kind)] = binding

--- a/integration/key_test.go
+++ b/integration/key_test.go
@@ -22,6 +22,7 @@ func TestGetKeys(t *testing.T) {
 	testDB, _ := createDatabase(t)
 	tenantStore := newTenantStore(t, testDB)
 	keyStore := newKeyStore(t, testDB)
+	keyVersionStore := newKeyVersionStore(t, testDB)
 
 	hierarchySpec := defaultTestHierarchy()
 	topology := spec.Topology{
@@ -35,7 +36,7 @@ func TestGetKeys(t *testing.T) {
 
 	serverAddr := startGRPCServer(t, func(srv *grpc.Server) {
 		admin.RegisterTenantServiceServer(srv, admin.NewTenantService(tenantStore))
-		keypb.RegisterKeyServiceServer(srv, keypb.NewKeyService("root", keyStore, keyValidator, &noopJobPreparer{}))
+		keypb.RegisterKeyServiceServer(srv, keypb.NewKeyService("root", keyStore, keyVersionStore, keyValidator, &noopJobPreparer{}, nil))
 	})
 
 	// create tenant

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -141,6 +141,15 @@ func newKeyStore(t *testing.T, db *sql.DB) store.Key {
 	return storesql.NewKeyStore(db)
 }
 
+// newKeyVersionStore creates a keyversion store.
+func newKeyVersionStore(t *testing.T, db *sql.DB) store.KeyVersion {
+	t.Helper()
+	if db == nil {
+		db, _ = createDatabase(t)
+	}
+	return storesql.NewKeyVersionStore(db)
+}
+
 // createDatabase creates a new PostgreSQL database for testing and returns a connection to it.
 func createDatabase(t *testing.T) (*sql.DB, string) {
 	t.Helper()

--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -44,6 +44,15 @@ type Manager struct {
 	processors   map[model.KeyKind]processor
 }
 
+type GenerateAndSealSecretRequest struct {
+	KeyVersion model.KeyVersion
+	AAD        []byte
+	KeyKind    model.KeyKind
+}
+
+type GenerateAndSealSecretResponse struct {
+}
+
 var _ cryptor.Sealer = &Manager{}
 
 // NewManager constructs a Manager by resolving the root sealer and building
@@ -73,6 +82,19 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 
 	mgr.processors = processors
 	return mgr, nil
+}
+
+func (m *Manager) GenerateAndSealSecret(ctx context.Context, req GenerateAndSealSecretRequest) (GenerateAndSealSecretResponse, error) {
+	proc, ok := m.processors[req.KeyKind]
+	if !ok {
+		return GenerateAndSealSecretResponse{}, fmt.Errorf("%w: key kind %s", ErrProcessorNotFound, req.KeyKind)
+	}
+
+	_, err := proc.createSecret(ctx, createSecretRequest{
+		KeyVersion: req.KeyVersion,
+		AAD:        req.AAD,
+	})
+	return GenerateAndSealSecretResponse{}, err
 }
 
 func buildRootManager(ctx context.Context, s store.Key, bindings map[model.KeyKind]spec.KeyBinding, hierarchy spec.KeyHierarchy) (*rootManager, error) {

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -1258,6 +1258,28 @@ func TestManagerExportSecret(t *testing.T) {
 	})
 }
 
+func TestGenerateAndSealSecret(t *testing.T) {
+	t.Run("should generate and seal secret with manager", func(t *testing.T) {
+		// given
+		ps := setupParent(t)
+		processor := keyprocessor.NewProcessor(newTestSecretGen(), newTestCryptor(), newTestSealer(t), ps.sealer, newTestVault(t))
+		mgr := keyprocessor.NewTestManager(nil, nil, map[model.KeyKind]keyprocessor.Processor{ps.parentKey.Kind: *processor})
+
+		childKV := model.NewKeyVersion(ps.tenantID, uuid.NewString(), 1, &ps.parentKey.ID, nil)
+
+		// when
+		resp, err := mgr.GenerateAndSealSecret(t.Context(), keyprocessor.GenerateAndSealSecretRequest{
+			KeyVersion: childKV,
+			AAD:        []byte{},
+			KeyKind:    ps.parentKey.Kind,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, keyprocessor.GenerateAndSealSecretResponse{}, resp)
+	})
+}
+
 type exportSetup struct {
 	tenantID string
 	rootKey  model.Key

--- a/pkg/api/v1/proto/admin/keys/activatekey_test.go
+++ b/pkg/api/v1/proto/admin/keys/activatekey_test.go
@@ -1,0 +1,368 @@
+package keys_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	keypb "github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+	storesql "github.com/openkcm/krypton/pkg/store/sql"
+)
+
+func TestActivateKey(t *testing.T) {
+	// given
+	ctx := t.Context()
+	db := createDatabase(t)
+
+	require.NoError(t, storesql.Migrate(ctx, db))
+	tenant := createTenant(t, db)
+
+	keyStore := storesql.NewKeyStore(db)
+	keyVersionStore := storesql.NewKeyVersionStore(db)
+	rootTopology := rootTestTopology()
+
+	t.Run("should activate root key version", func(t *testing.T) {
+		// given
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+
+		// announcing root key
+		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+
+		rootID := announceRes.GetKey().GetId()
+
+		// when
+		activateRes, err := cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       rootID,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, activateRes)
+
+		// then
+		// Verify that the key is activated
+		key, err := keyStore.GetKeyByID(ctx, rootID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
+
+		// Verify that the keyversion is also created and activated
+		keyVersion, err := keyVersionStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:        tenant.ID,
+			KeyID:           rootID,
+			Version:         1,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: model.KeyVersionUsable,
+			Limit:           100,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, keyVersion.KeyVersions, 1)
+	})
+
+	t.Run("should not activate root key version twice", func(t *testing.T) {
+		// given
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+
+		// announcing root key
+		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+
+		rootID := announceRes.GetKey().GetId()
+
+		// when
+		activateRes, err := cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       rootID,
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, activateRes)
+
+		activateRes, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       rootID,
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, activateRes)
+	})
+
+	t.Run("should activate a intermediate key", func(t *testing.T) {
+		// given
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+
+		// announcing root key
+		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		rootKeyID := announceRes.GetKey().GetId()
+
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       rootKeyID,
+		})
+		require.NoError(t, err)
+
+		// announcing k1 key
+		announceRes, err = cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K1",
+			Name:       "k1-key-" + uuid.NewString(),
+			ParentId:   rootKeyID,
+			TargetName: testRootName,
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		keyID := announceRes.GetKey().GetId()
+
+		// when
+		// activating k1 key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       keyID,
+		})
+		require.NoError(t, err)
+
+		// then
+		// Verify that the key is activated
+		key, err := keyStore.GetKeyByID(ctx, keyID, tenant.ID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
+
+		// Verify that the keyversion is also created and activated
+		keyVersion, err := keyVersionStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:        tenant.ID,
+			KeyID:           keyID,
+			Version:         1,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: model.KeyVersionUsable,
+			Limit:           100,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, keyVersion.KeyVersions, 1)
+	})
+
+	t.Run("should not activate a intermediate key twice", func(t *testing.T) {
+		// given
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+
+		// announcing root key
+		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		rootKeyID := announceRes.GetKey().GetId()
+
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       rootKeyID,
+		})
+		require.NoError(t, err)
+
+		// announcing k1 key
+		announceRes, err = cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K1",
+			Name:       "k1-key-" + uuid.NewString(),
+			ParentId:   rootKeyID,
+			TargetName: testRootName,
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		keyID := announceRes.GetKey().GetId()
+
+		// when
+		// activating k1 key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       keyID,
+		})
+		require.NoError(t, err)
+
+		activateRes, err := cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       keyID,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, activateRes)
+	})
+
+	t.Run("should activate all keys in a chain", func(t *testing.T) {
+		// given
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+
+		// given
+		// announcing root key
+		var k0ID, k1ID, k2ID, k3ID string
+		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		k0ID = announceRes.GetKey().GetId()
+
+		// when
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       k0ID,
+		})
+		// then
+		require.NoError(t, err)
+
+		// given
+		// announcing k1 key
+		announceRes, err = cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K1",
+			Name:       "k1-key-" + uuid.NewString(),
+			ParentId:   k0ID,
+			TargetName: testRootName,
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		k1ID = announceRes.GetKey().GetId()
+
+		// when
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       k1ID,
+		})
+		// then
+		require.NoError(t, err)
+
+		// given
+		// announcing k2 key
+		announceRes, err = cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K2",
+			Name:       "k2-key-" + uuid.NewString(),
+			ParentId:   k1ID,
+			TargetName: testRootName,
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		k2ID = announceRes.GetKey().GetId()
+
+		// when
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       k2ID,
+		})
+		// then
+		require.NoError(t, err)
+
+		// given
+		// announcing k3 key
+		announceRes, err = cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K3",
+			Name:       "k3-key-" + uuid.NewString(),
+			ParentId:   k2ID,
+			TargetName: testRootName,
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		k3ID = announceRes.GetKey().GetId()
+
+		// when
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       k3ID,
+		})
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("should return error if there is no parent keyversion", func(t *testing.T) {
+		// given
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+
+		// announcing root key
+		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		rootKeyID := announceRes.GetKey().GetId()
+
+		// activating root key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       rootKeyID,
+		})
+		require.NoError(t, err)
+
+		// making the keyversion to pending to simulate that the parent keyversion is not usable
+		err = keyVersionStore.UpdateKeyVersionStates(ctx, store.UpdateKeyVersionStatesQuery{
+			TenantID:            tenant.ID,
+			KeyID:               rootKeyID,
+			Version:             1,
+			Revision:            1,
+			FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionUsable},
+			ToProcessingState:   model.KeyVersionActivating,
+			FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCycleActive},
+			ToLifeCycleState:    model.KeyLifeCycleCompromised,
+		})
+		require.NoError(t, err)
+
+		// announcing k1 key
+		announceRes, err = cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenant.ID,
+			Kind:       "K1",
+			Name:       "k1-key-" + uuid.NewString(),
+			ParentId:   rootKeyID,
+			TargetName: testRootName,
+			Labels:     map[string]string{"env": "prod"},
+		})
+		require.NoError(t, err)
+		keyID := announceRes.GetKey().GetId()
+
+		// when
+		// activating k1 key
+		_, err = cli.ActivateKey(ctx, &keypb.ActivateKeyRequest{
+			TenantId: tenant.ID,
+			Id:       keyID,
+		})
+		require.Error(t, err)
+	})
+}

--- a/pkg/api/v1/proto/admin/keys/key.pb.go
+++ b/pkg/api/v1/proto/admin/keys/key.pb.go
@@ -326,6 +326,94 @@ func (x *AnnounceKeyResponse) GetKey() *Key {
 	return nil
 }
 
+type ActivateKeyRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActivateKeyRequest) Reset() {
+	*x = ActivateKeyRequest{}
+	mi := &file_key_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActivateKeyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActivateKeyRequest) ProtoMessage() {}
+
+func (x *ActivateKeyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_key_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActivateKeyRequest.ProtoReflect.Descriptor instead.
+func (*ActivateKeyRequest) Descriptor() ([]byte, []int) {
+	return file_key_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ActivateKeyRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ActivateKeyRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+type ActivateKeyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ActivateKeyResponse) Reset() {
+	*x = ActivateKeyResponse{}
+	mi := &file_key_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ActivateKeyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ActivateKeyResponse) ProtoMessage() {}
+
+func (x *ActivateKeyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_key_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ActivateKeyResponse.ProtoReflect.Descriptor instead.
+func (*ActivateKeyResponse) Descriptor() ([]byte, []int) {
+	return file_key_proto_rawDescGZIP(), []int{5}
+}
+
 type GetKeyRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -336,7 +424,7 @@ type GetKeyRequest struct {
 
 func (x *GetKeyRequest) Reset() {
 	*x = GetKeyRequest{}
-	mi := &file_key_proto_msgTypes[4]
+	mi := &file_key_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -348,7 +436,7 @@ func (x *GetKeyRequest) String() string {
 func (*GetKeyRequest) ProtoMessage() {}
 
 func (x *GetKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[4]
+	mi := &file_key_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -361,7 +449,7 @@ func (x *GetKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetKeyRequest.ProtoReflect.Descriptor instead.
 func (*GetKeyRequest) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{4}
+	return file_key_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GetKeyRequest) GetId() string {
@@ -387,7 +475,7 @@ type GetKeyResponse struct {
 
 func (x *GetKeyResponse) Reset() {
 	*x = GetKeyResponse{}
-	mi := &file_key_proto_msgTypes[5]
+	mi := &file_key_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -399,7 +487,7 @@ func (x *GetKeyResponse) String() string {
 func (*GetKeyResponse) ProtoMessage() {}
 
 func (x *GetKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[5]
+	mi := &file_key_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -412,7 +500,7 @@ func (x *GetKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetKeyResponse.ProtoReflect.Descriptor instead.
 func (*GetKeyResponse) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{5}
+	return file_key_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetKeyResponse) GetKey() *Key {
@@ -432,7 +520,7 @@ type GetParentKeysRequest struct {
 
 func (x *GetParentKeysRequest) Reset() {
 	*x = GetParentKeysRequest{}
-	mi := &file_key_proto_msgTypes[6]
+	mi := &file_key_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -444,7 +532,7 @@ func (x *GetParentKeysRequest) String() string {
 func (*GetParentKeysRequest) ProtoMessage() {}
 
 func (x *GetParentKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[6]
+	mi := &file_key_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -457,7 +545,7 @@ func (x *GetParentKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetParentKeysRequest.ProtoReflect.Descriptor instead.
 func (*GetParentKeysRequest) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{6}
+	return file_key_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetParentKeysRequest) GetId() string {
@@ -483,7 +571,7 @@ type GetParentKeysResponse struct {
 
 func (x *GetParentKeysResponse) Reset() {
 	*x = GetParentKeysResponse{}
-	mi := &file_key_proto_msgTypes[7]
+	mi := &file_key_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -495,7 +583,7 @@ func (x *GetParentKeysResponse) String() string {
 func (*GetParentKeysResponse) ProtoMessage() {}
 
 func (x *GetParentKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[7]
+	mi := &file_key_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -508,7 +596,7 @@ func (x *GetParentKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetParentKeysResponse.ProtoReflect.Descriptor instead.
 func (*GetParentKeysResponse) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{7}
+	return file_key_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetParentKeysResponse) GetKeys() []*Key {
@@ -528,7 +616,7 @@ type GetDescendantKeysRequest struct {
 
 func (x *GetDescendantKeysRequest) Reset() {
 	*x = GetDescendantKeysRequest{}
-	mi := &file_key_proto_msgTypes[8]
+	mi := &file_key_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -540,7 +628,7 @@ func (x *GetDescendantKeysRequest) String() string {
 func (*GetDescendantKeysRequest) ProtoMessage() {}
 
 func (x *GetDescendantKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[8]
+	mi := &file_key_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -553,7 +641,7 @@ func (x *GetDescendantKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDescendantKeysRequest.ProtoReflect.Descriptor instead.
 func (*GetDescendantKeysRequest) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{8}
+	return file_key_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetDescendantKeysRequest) GetId() string {
@@ -579,7 +667,7 @@ type KeyTree struct {
 
 func (x *KeyTree) Reset() {
 	*x = KeyTree{}
-	mi := &file_key_proto_msgTypes[9]
+	mi := &file_key_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -591,7 +679,7 @@ func (x *KeyTree) String() string {
 func (*KeyTree) ProtoMessage() {}
 
 func (x *KeyTree) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[9]
+	mi := &file_key_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -604,7 +692,7 @@ func (x *KeyTree) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyTree.ProtoReflect.Descriptor instead.
 func (*KeyTree) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{9}
+	return file_key_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *KeyTree) GetKeys() []*Key {
@@ -623,7 +711,7 @@ type GetDescendantKeysResponse struct {
 
 func (x *GetDescendantKeysResponse) Reset() {
 	*x = GetDescendantKeysResponse{}
-	mi := &file_key_proto_msgTypes[10]
+	mi := &file_key_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -635,7 +723,7 @@ func (x *GetDescendantKeysResponse) String() string {
 func (*GetDescendantKeysResponse) ProtoMessage() {}
 
 func (x *GetDescendantKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[10]
+	mi := &file_key_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -648,7 +736,7 @@ func (x *GetDescendantKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDescendantKeysResponse.ProtoReflect.Descriptor instead.
 func (*GetDescendantKeysResponse) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{10}
+	return file_key_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GetDescendantKeysResponse) GetKeyTree() []*KeyTree {
@@ -675,7 +763,7 @@ type ListKeysRequest struct {
 
 func (x *ListKeysRequest) Reset() {
 	*x = ListKeysRequest{}
-	mi := &file_key_proto_msgTypes[11]
+	mi := &file_key_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -687,7 +775,7 @@ func (x *ListKeysRequest) String() string {
 func (*ListKeysRequest) ProtoMessage() {}
 
 func (x *ListKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[11]
+	mi := &file_key_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -700,7 +788,7 @@ func (x *ListKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKeysRequest.ProtoReflect.Descriptor instead.
 func (*ListKeysRequest) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{11}
+	return file_key_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListKeysRequest) GetTenantId() string {
@@ -776,7 +864,7 @@ type ListKeysResponse struct {
 
 func (x *ListKeysResponse) Reset() {
 	*x = ListKeysResponse{}
-	mi := &file_key_proto_msgTypes[12]
+	mi := &file_key_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -788,7 +876,7 @@ func (x *ListKeysResponse) String() string {
 func (*ListKeysResponse) ProtoMessage() {}
 
 func (x *ListKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_key_proto_msgTypes[12]
+	mi := &file_key_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -801,7 +889,7 @@ func (x *ListKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKeysResponse.ProtoReflect.Descriptor instead.
 func (*ListKeysResponse) Descriptor() ([]byte, []int) {
-	return file_key_proto_rawDescGZIP(), []int{12}
+	return file_key_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ListKeysResponse) GetKeys() []*Key {
@@ -857,7 +945,11 @@ const file_key_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"C\n" +
 	"\x13AnnounceKeyResponse\x12,\n" +
-	"\x03key\x18\x01 \x01(\v2\x1a.krypton.v1.admin.keys.KeyR\x03key\"<\n" +
+	"\x03key\x18\x01 \x01(\v2\x1a.krypton.v1.admin.keys.KeyR\x03key\"A\n" +
+	"\x12ActivateKeyRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"\x15\n" +
+	"\x13ActivateKeyResponse\"<\n" +
 	"\rGetKeyRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\">\n" +
@@ -891,10 +983,11 @@ const file_key_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"Z\n" +
 	"\x10ListKeysResponse\x12.\n" +
 	"\x04keys\x18\x01 \x03(\v2\x1a.krypton.v1.admin.keys.KeyR\x04keys\x12\x16\n" +
-	"\x06cursor\x18\x02 \x01(\tR\x06cursor2\x8a\x04\n" +
+	"\x06cursor\x18\x02 \x01(\tR\x06cursor2\xf0\x04\n" +
 	"\n" +
 	"KeyService\x12d\n" +
-	"\vAnnounceKey\x12).krypton.v1.admin.keys.AnnounceKeyRequest\x1a*.krypton.v1.admin.keys.AnnounceKeyResponse\x12U\n" +
+	"\vAnnounceKey\x12).krypton.v1.admin.keys.AnnounceKeyRequest\x1a*.krypton.v1.admin.keys.AnnounceKeyResponse\x12d\n" +
+	"\vActivateKey\x12).krypton.v1.admin.keys.ActivateKeyRequest\x1a*.krypton.v1.admin.keys.ActivateKeyResponse\x12U\n" +
 	"\x06GetKey\x12$.krypton.v1.admin.keys.GetKeyRequest\x1a%.krypton.v1.admin.keys.GetKeyResponse\x12j\n" +
 	"\rGetParentKeys\x12+.krypton.v1.admin.keys.GetParentKeysRequest\x1a,.krypton.v1.admin.keys.GetParentKeysResponse\x12v\n" +
 	"\x11GetDescendantKeys\x12/.krypton.v1.admin.keys.GetDescendantKeysRequest\x1a0.krypton.v1.admin.keys.GetDescendantKeysResponse\x12[\n" +
@@ -912,48 +1005,52 @@ func file_key_proto_rawDescGZIP() []byte {
 	return file_key_proto_rawDescData
 }
 
-var file_key_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_key_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_key_proto_goTypes = []any{
 	(*Key)(nil),                       // 0: krypton.v1.admin.keys.Key
 	(*KeyProcessingState)(nil),        // 1: krypton.v1.admin.keys.KeyProcessingState
 	(*AnnounceKeyRequest)(nil),        // 2: krypton.v1.admin.keys.AnnounceKeyRequest
 	(*AnnounceKeyResponse)(nil),       // 3: krypton.v1.admin.keys.AnnounceKeyResponse
-	(*GetKeyRequest)(nil),             // 4: krypton.v1.admin.keys.GetKeyRequest
-	(*GetKeyResponse)(nil),            // 5: krypton.v1.admin.keys.GetKeyResponse
-	(*GetParentKeysRequest)(nil),      // 6: krypton.v1.admin.keys.GetParentKeysRequest
-	(*GetParentKeysResponse)(nil),     // 7: krypton.v1.admin.keys.GetParentKeysResponse
-	(*GetDescendantKeysRequest)(nil),  // 8: krypton.v1.admin.keys.GetDescendantKeysRequest
-	(*KeyTree)(nil),                   // 9: krypton.v1.admin.keys.KeyTree
-	(*GetDescendantKeysResponse)(nil), // 10: krypton.v1.admin.keys.GetDescendantKeysResponse
-	(*ListKeysRequest)(nil),           // 11: krypton.v1.admin.keys.ListKeysRequest
-	(*ListKeysResponse)(nil),          // 12: krypton.v1.admin.keys.ListKeysResponse
-	nil,                               // 13: krypton.v1.admin.keys.Key.LabelsEntry
-	nil,                               // 14: krypton.v1.admin.keys.AnnounceKeyRequest.LabelsEntry
-	nil,                               // 15: krypton.v1.admin.keys.ListKeysRequest.LabelsEntry
+	(*ActivateKeyRequest)(nil),        // 4: krypton.v1.admin.keys.ActivateKeyRequest
+	(*ActivateKeyResponse)(nil),       // 5: krypton.v1.admin.keys.ActivateKeyResponse
+	(*GetKeyRequest)(nil),             // 6: krypton.v1.admin.keys.GetKeyRequest
+	(*GetKeyResponse)(nil),            // 7: krypton.v1.admin.keys.GetKeyResponse
+	(*GetParentKeysRequest)(nil),      // 8: krypton.v1.admin.keys.GetParentKeysRequest
+	(*GetParentKeysResponse)(nil),     // 9: krypton.v1.admin.keys.GetParentKeysResponse
+	(*GetDescendantKeysRequest)(nil),  // 10: krypton.v1.admin.keys.GetDescendantKeysRequest
+	(*KeyTree)(nil),                   // 11: krypton.v1.admin.keys.KeyTree
+	(*GetDescendantKeysResponse)(nil), // 12: krypton.v1.admin.keys.GetDescendantKeysResponse
+	(*ListKeysRequest)(nil),           // 13: krypton.v1.admin.keys.ListKeysRequest
+	(*ListKeysResponse)(nil),          // 14: krypton.v1.admin.keys.ListKeysResponse
+	nil,                               // 15: krypton.v1.admin.keys.Key.LabelsEntry
+	nil,                               // 16: krypton.v1.admin.keys.AnnounceKeyRequest.LabelsEntry
+	nil,                               // 17: krypton.v1.admin.keys.ListKeysRequest.LabelsEntry
 }
 var file_key_proto_depIdxs = []int32{
-	13, // 0: krypton.v1.admin.keys.Key.labels:type_name -> krypton.v1.admin.keys.Key.LabelsEntry
+	15, // 0: krypton.v1.admin.keys.Key.labels:type_name -> krypton.v1.admin.keys.Key.LabelsEntry
 	1,  // 1: krypton.v1.admin.keys.Key.key_processing_state:type_name -> krypton.v1.admin.keys.KeyProcessingState
-	14, // 2: krypton.v1.admin.keys.AnnounceKeyRequest.labels:type_name -> krypton.v1.admin.keys.AnnounceKeyRequest.LabelsEntry
+	16, // 2: krypton.v1.admin.keys.AnnounceKeyRequest.labels:type_name -> krypton.v1.admin.keys.AnnounceKeyRequest.LabelsEntry
 	0,  // 3: krypton.v1.admin.keys.AnnounceKeyResponse.key:type_name -> krypton.v1.admin.keys.Key
 	0,  // 4: krypton.v1.admin.keys.GetKeyResponse.key:type_name -> krypton.v1.admin.keys.Key
 	0,  // 5: krypton.v1.admin.keys.GetParentKeysResponse.keys:type_name -> krypton.v1.admin.keys.Key
 	0,  // 6: krypton.v1.admin.keys.KeyTree.keys:type_name -> krypton.v1.admin.keys.Key
-	9,  // 7: krypton.v1.admin.keys.GetDescendantKeysResponse.key_tree:type_name -> krypton.v1.admin.keys.KeyTree
-	15, // 8: krypton.v1.admin.keys.ListKeysRequest.labels:type_name -> krypton.v1.admin.keys.ListKeysRequest.LabelsEntry
+	11, // 7: krypton.v1.admin.keys.GetDescendantKeysResponse.key_tree:type_name -> krypton.v1.admin.keys.KeyTree
+	17, // 8: krypton.v1.admin.keys.ListKeysRequest.labels:type_name -> krypton.v1.admin.keys.ListKeysRequest.LabelsEntry
 	0,  // 9: krypton.v1.admin.keys.ListKeysResponse.keys:type_name -> krypton.v1.admin.keys.Key
 	2,  // 10: krypton.v1.admin.keys.KeyService.AnnounceKey:input_type -> krypton.v1.admin.keys.AnnounceKeyRequest
-	4,  // 11: krypton.v1.admin.keys.KeyService.GetKey:input_type -> krypton.v1.admin.keys.GetKeyRequest
-	6,  // 12: krypton.v1.admin.keys.KeyService.GetParentKeys:input_type -> krypton.v1.admin.keys.GetParentKeysRequest
-	8,  // 13: krypton.v1.admin.keys.KeyService.GetDescendantKeys:input_type -> krypton.v1.admin.keys.GetDescendantKeysRequest
-	11, // 14: krypton.v1.admin.keys.KeyService.ListKeys:input_type -> krypton.v1.admin.keys.ListKeysRequest
-	3,  // 15: krypton.v1.admin.keys.KeyService.AnnounceKey:output_type -> krypton.v1.admin.keys.AnnounceKeyResponse
-	5,  // 16: krypton.v1.admin.keys.KeyService.GetKey:output_type -> krypton.v1.admin.keys.GetKeyResponse
-	7,  // 17: krypton.v1.admin.keys.KeyService.GetParentKeys:output_type -> krypton.v1.admin.keys.GetParentKeysResponse
-	10, // 18: krypton.v1.admin.keys.KeyService.GetDescendantKeys:output_type -> krypton.v1.admin.keys.GetDescendantKeysResponse
-	12, // 19: krypton.v1.admin.keys.KeyService.ListKeys:output_type -> krypton.v1.admin.keys.ListKeysResponse
-	15, // [15:20] is the sub-list for method output_type
-	10, // [10:15] is the sub-list for method input_type
+	4,  // 11: krypton.v1.admin.keys.KeyService.ActivateKey:input_type -> krypton.v1.admin.keys.ActivateKeyRequest
+	6,  // 12: krypton.v1.admin.keys.KeyService.GetKey:input_type -> krypton.v1.admin.keys.GetKeyRequest
+	8,  // 13: krypton.v1.admin.keys.KeyService.GetParentKeys:input_type -> krypton.v1.admin.keys.GetParentKeysRequest
+	10, // 14: krypton.v1.admin.keys.KeyService.GetDescendantKeys:input_type -> krypton.v1.admin.keys.GetDescendantKeysRequest
+	13, // 15: krypton.v1.admin.keys.KeyService.ListKeys:input_type -> krypton.v1.admin.keys.ListKeysRequest
+	3,  // 16: krypton.v1.admin.keys.KeyService.AnnounceKey:output_type -> krypton.v1.admin.keys.AnnounceKeyResponse
+	5,  // 17: krypton.v1.admin.keys.KeyService.ActivateKey:output_type -> krypton.v1.admin.keys.ActivateKeyResponse
+	7,  // 18: krypton.v1.admin.keys.KeyService.GetKey:output_type -> krypton.v1.admin.keys.GetKeyResponse
+	9,  // 19: krypton.v1.admin.keys.KeyService.GetParentKeys:output_type -> krypton.v1.admin.keys.GetParentKeysResponse
+	12, // 20: krypton.v1.admin.keys.KeyService.GetDescendantKeys:output_type -> krypton.v1.admin.keys.GetDescendantKeysResponse
+	14, // 21: krypton.v1.admin.keys.KeyService.ListKeys:output_type -> krypton.v1.admin.keys.ListKeysResponse
+	16, // [16:22] is the sub-list for method output_type
+	10, // [10:16] is the sub-list for method input_type
 	10, // [10:10] is the sub-list for extension type_name
 	10, // [10:10] is the sub-list for extension extendee
 	0,  // [0:10] is the sub-list for field type_name
@@ -970,7 +1067,7 @@ func file_key_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_key_proto_rawDesc), len(file_key_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/api/v1/proto/admin/keys/key_grpc.pb.go
+++ b/pkg/api/v1/proto/admin/keys/key_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	KeyService_AnnounceKey_FullMethodName       = "/krypton.v1.admin.keys.KeyService/AnnounceKey"
+	KeyService_ActivateKey_FullMethodName       = "/krypton.v1.admin.keys.KeyService/ActivateKey"
 	KeyService_GetKey_FullMethodName            = "/krypton.v1.admin.keys.KeyService/GetKey"
 	KeyService_GetParentKeys_FullMethodName     = "/krypton.v1.admin.keys.KeyService/GetParentKeys"
 	KeyService_GetDescendantKeys_FullMethodName = "/krypton.v1.admin.keys.KeyService/GetDescendantKeys"
@@ -32,6 +33,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type KeyServiceClient interface {
 	AnnounceKey(ctx context.Context, in *AnnounceKeyRequest, opts ...grpc.CallOption) (*AnnounceKeyResponse, error)
+	ActivateKey(ctx context.Context, in *ActivateKeyRequest, opts ...grpc.CallOption) (*ActivateKeyResponse, error)
 	GetKey(ctx context.Context, in *GetKeyRequest, opts ...grpc.CallOption) (*GetKeyResponse, error)
 	GetParentKeys(ctx context.Context, in *GetParentKeysRequest, opts ...grpc.CallOption) (*GetParentKeysResponse, error)
 	GetDescendantKeys(ctx context.Context, in *GetDescendantKeysRequest, opts ...grpc.CallOption) (*GetDescendantKeysResponse, error)
@@ -50,6 +52,16 @@ func (c *keyServiceClient) AnnounceKey(ctx context.Context, in *AnnounceKeyReque
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AnnounceKeyResponse)
 	err := c.cc.Invoke(ctx, KeyService_AnnounceKey_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *keyServiceClient) ActivateKey(ctx context.Context, in *ActivateKeyRequest, opts ...grpc.CallOption) (*ActivateKeyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ActivateKeyResponse)
+	err := c.cc.Invoke(ctx, KeyService_ActivateKey_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,6 +113,7 @@ func (c *keyServiceClient) ListKeys(ctx context.Context, in *ListKeysRequest, op
 // for forward compatibility.
 type KeyServiceServer interface {
 	AnnounceKey(context.Context, *AnnounceKeyRequest) (*AnnounceKeyResponse, error)
+	ActivateKey(context.Context, *ActivateKeyRequest) (*ActivateKeyResponse, error)
 	GetKey(context.Context, *GetKeyRequest) (*GetKeyResponse, error)
 	GetParentKeys(context.Context, *GetParentKeysRequest) (*GetParentKeysResponse, error)
 	GetDescendantKeys(context.Context, *GetDescendantKeysRequest) (*GetDescendantKeysResponse, error)
@@ -117,6 +130,9 @@ type UnimplementedKeyServiceServer struct{}
 
 func (UnimplementedKeyServiceServer) AnnounceKey(context.Context, *AnnounceKeyRequest) (*AnnounceKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AnnounceKey not implemented")
+}
+func (UnimplementedKeyServiceServer) ActivateKey(context.Context, *ActivateKeyRequest) (*ActivateKeyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ActivateKey not implemented")
 }
 func (UnimplementedKeyServiceServer) GetKey(context.Context, *GetKeyRequest) (*GetKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetKey not implemented")
@@ -165,6 +181,24 @@ func _KeyService_AnnounceKey_Handler(srv interface{}, ctx context.Context, dec f
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(KeyServiceServer).AnnounceKey(ctx, req.(*AnnounceKeyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _KeyService_ActivateKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ActivateKeyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KeyServiceServer).ActivateKey(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: KeyService_ActivateKey_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KeyServiceServer).ActivateKey(ctx, req.(*ActivateKeyRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -251,6 +285,10 @@ var KeyService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AnnounceKey",
 			Handler:    _KeyService_AnnounceKey_Handler,
+		},
+		{
+			MethodName: "ActivateKey",
+			Handler:    _KeyService_ActivateKey_Handler,
 		},
 		{
 			MethodName: "GetKey",

--- a/pkg/api/v1/proto/admin/keys/key_service.go
+++ b/pkg/api/v1/proto/admin/keys/key_service.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/openkcm/krypton/internal/handler/announcekey"
+	"github.com/openkcm/krypton/internal/keyprocessor"
 	"github.com/openkcm/krypton/pkg/api/v1/proto"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
@@ -28,19 +29,169 @@ type JobPreparer interface {
 type KeyService struct {
 	UnimplementedKeyServiceServer
 
-	rootName    string
-	keyStore    store.Key
-	jobPreparer JobPreparer
-	validator   validator.KeyValidator
+	rootName        string
+	keyStore        store.Key
+	keyVersionStore store.KeyVersion
+	jobPreparer     JobPreparer
+	validator       validator.KeyValidator
+	manager         *keyprocessor.Manager
 }
 
-func NewKeyService(rootName string, keyStore store.Key, validator validator.KeyValidator, jobPreparer JobPreparer) *KeyService {
+func NewKeyService(rootName string, keyStore store.Key, keyVersionStore store.KeyVersion, validator validator.KeyValidator, jobPreparer JobPreparer, manager *keyprocessor.Manager) *KeyService {
 	return &KeyService{
-		rootName:    rootName,
-		keyStore:    keyStore,
-		jobPreparer: jobPreparer,
-		validator:   validator,
+		rootName:        rootName,
+		keyStore:        keyStore,
+		keyVersionStore: keyVersionStore,
+		validator:       validator,
+		jobPreparer:     jobPreparer,
+		manager:         manager,
 	}
+}
+
+func (s *KeyService) ActivateKey(ctx context.Context, req *ActivateKeyRequest) (*ActivateKeyResponse, error) {
+	vErr := s.validator.ValidateKeyActivate(ctx, validator.ActivateInput{
+		TenantID: req.GetTenantId(),
+		KeyID:    req.GetId(),
+	})
+	if vErr != nil {
+		return nil, proto.ErrDetailsWithCode(
+			status.New(vErr.ToProtoErrCode(), vErr.Error()),
+			vErr.ToProtoDetailCode(),
+		)
+	}
+
+	// transaction starts here
+	// if an error happens inside this needs to be reverted
+	key, err := s.keyStore.GetKeyByID(ctx, req.GetId(), req.GetTenantId())
+	if err != nil {
+		return nil, proto.ErrDetailsWithCode(
+			status.New(codes.Internal, "failed to get key"),
+			proto.Code_ERROR_CODE_RETRY,
+		)
+	}
+	isRoot := key.ParentID == nil
+
+	// make the keys ls=active ks=processing
+	err = s.keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
+		ID:       key.ID,
+		TenantID: key.TenantID,
+		FromState: []model.KeyLifeCycleState{
+			model.KeyLifeCyclePreActivation,
+		},
+		ToState: model.KeyLifeCycleActive,
+		FromStatus: []model.KeyProcessingStatus{
+			model.KeyProcessingCompleted,
+		},
+		ToStatus: model.KeyProcessingInProgress,
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, proto.ErrDetailsWithCode(
+				status.New(codes.NotFound, "key is in wrong processing state or life cycle state"),
+				proto.Code_ERROR_CODE_ABORT,
+			)
+		}
+		return nil, proto.ErrDetailsWithCode(
+			status.New(codes.Internal, "failed to update key life cycle and processing state"),
+			proto.Code_ERROR_CODE_RETRY,
+		)
+	}
+
+	var parentKeyVersion *int
+	if !isRoot {
+		pkv, err := s.keyVersionStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:        key.TenantID,
+			KeyID:           *key.ParentID,
+			ProcessingState: model.KeyVersionUsable,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			OrderBy: []store.KeyVersionOrder{
+				store.KeyVersionOrderVersionDesc,
+				store.KeyVersionOrderRevisionDesc,
+			},
+			Limit: 1,
+		})
+		if err != nil {
+			return nil, proto.ErrDetailsWithCode(
+				status.New(codes.Internal, "failed to get parent key version"),
+				proto.Code_ERROR_CODE_RETRY,
+			)
+		}
+		if len(pkv.KeyVersions) == 0 {
+			return nil, proto.ErrDetailsWithCode(
+				status.New(codes.FailedPrecondition, "parent key has no usable version"),
+				proto.Code_ERROR_CODE_ABORT,
+			)
+		}
+		parentKeyVersion = new(pkv.KeyVersions[0].Version)
+	}
+
+	kv := model.NewKeyVersion(key.TenantID, key.ID, 1, key.ParentID, parentKeyVersion)
+	kv.LifeCycleState = model.KeyLifeCyclePreActivation
+	kv.ProcessingState = model.KeyVersionActivating
+
+	// create a kv version with ls=nonactivate ks=processing
+	_, err = s.keyVersionStore.CreateKeyVersion(ctx, store.CreateKeyVersionQuery{
+		KeyVersion: kv,
+	})
+	if err != nil {
+		return nil, proto.ErrDetailsWithCode(
+			status.New(codes.Internal, "failed to create key version"),
+			proto.Code_ERROR_CODE_RETRY,
+		)
+	}
+
+	if !isRoot {
+		aad := fmt.Appendf(nil, "%s:%s:%d:%d:%d", key.TenantID, key.ID, kv.Version, kv.Revision, kv.CreatedAt)
+		_, err = s.manager.GenerateAndSealSecret(ctx, keyprocessor.GenerateAndSealSecretRequest{
+			KeyVersion: kv,
+			AAD:        aad,
+			KeyKind:    key.Kind,
+		})
+		if err != nil {
+			return nil, proto.ErrDetailsWithCode(
+				status.New(codes.Internal, "failed to generate and seal secret"),
+				proto.Code_ERROR_CODE_ABORT,
+			)
+		}
+	}
+
+	err = s.keyStore.UpdateKeyStates(ctx, store.UpdateKeyStatesQuery{
+		ID:       key.ID,
+		TenantID: key.TenantID,
+		FromState: []model.KeyLifeCycleState{
+			model.KeyLifeCycleActive,
+		},
+		ToState: model.KeyLifeCycleActive,
+		FromStatus: []model.KeyProcessingStatus{
+			model.KeyProcessingInProgress,
+		},
+		ToStatus: model.KeyProcessingCompleted,
+	})
+	if err != nil {
+		return nil, proto.ErrDetailsWithCode(
+			status.New(codes.Internal, "failed to update key processing state"),
+			proto.Code_ERROR_CODE_RETRY,
+		)
+	}
+
+	err = s.keyVersionStore.UpdateKeyVersionStates(ctx, store.UpdateKeyVersionStatesQuery{
+		TenantID:            kv.TenantID,
+		KeyID:               kv.KeyID,
+		Version:             kv.Version,
+		Revision:            kv.Revision,
+		FromProcessingState: []model.KeyVersionProcessingState{model.KeyVersionActivating},
+		ToProcessingState:   model.KeyVersionUsable,
+		FromLifeCycleState:  []model.KeyLifeCycleState{model.KeyLifeCyclePreActivation},
+		ToLifeCycleState:    model.KeyLifeCycleActive,
+	})
+	if err != nil {
+		return nil, proto.ErrDetailsWithCode(
+			status.New(codes.Internal, "failed to update key version life cycle and processing state"),
+			proto.Code_ERROR_CODE_RETRY,
+		)
+	}
+
+	return &ActivateKeyResponse{}, nil
 }
 
 // AnnounceKey validates the request and checks for an already esisting key with the same name.

--- a/pkg/api/v1/proto/admin/keys/key_service.go
+++ b/pkg/api/v1/proto/admin/keys/key_service.go
@@ -60,8 +60,7 @@ func (s *KeyService) ActivateKey(ctx context.Context, req *ActivateKeyRequest) (
 		)
 	}
 
-	// transaction starts here
-	// if an error happens inside this needs to be reverted
+	// @TODO: Do all this in a database transaction
 	key, err := s.keyStore.GetKeyByID(ctx, req.GetId(), req.GetTenantId())
 	if err != nil {
 		return nil, proto.ErrDetailsWithCode(

--- a/pkg/api/v1/proto/admin/keys/key_service_test.go
+++ b/pkg/api/v1/proto/admin/keys/key_service_test.go
@@ -137,7 +137,7 @@ func TestAnnounceKey(t *testing.T) {
 		}
 		require.NoError(t, keyStore.CreateKey(ctx, seed))
 
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists})
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists}, nil)
 		// Subsequent call short-circuits via existing in-progress key,
 		// without ever needing PrepareJob.
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -157,7 +157,7 @@ func TestAnnounceKey(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(ctx, parent))
 		activateKey(t, keyStore, parent.ID, tenant.ID)
 
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: errors.New("boom")})
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: errors.New("boom")}, nil)
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
 			Kind:       "K1",
@@ -355,7 +355,7 @@ func TestAnnounceKey(t *testing.T) {
 		activateKey(t, keyStore, parent.ID, tenant.ID)
 
 		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy)
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		name := "spy-fresh-" + uuid.NewString()
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -374,7 +374,7 @@ func TestAnnounceKey(t *testing.T) {
 
 	t.Run("root-managed fresh creation does not call PrepareJob", func(t *testing.T) {
 		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy)
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -400,7 +400,7 @@ func TestAnnounceKey(t *testing.T) {
 		}))
 
 		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy)
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -424,7 +424,7 @@ func TestAnnounceKey(t *testing.T) {
 		require.NoError(t, keyStore.CreateKey(ctx, key))
 
 		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy)
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -463,7 +463,7 @@ func TestAnnounceKey(t *testing.T) {
 			NewJobID:  failedJobID,
 		}))
 
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists})
+		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists}, nil)
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
 			Kind:       "K0",

--- a/pkg/api/v1/proto/admin/keys/setup_test.go
+++ b/pkg/api/v1/proto/admin/keys/setup_test.go
@@ -2,9 +2,12 @@ package keys_test
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,7 +24,16 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/openkcm/krypton/internal/cryptor"
+	"github.com/openkcm/krypton/internal/cryptor/aes256gcm"
+	"github.com/openkcm/krypton/internal/cryptor/cryptorprovider"
+	"github.com/openkcm/krypton/internal/cryptor/sealerprovider"
+	"github.com/openkcm/krypton/internal/cryptor/staticsecret"
+	"github.com/openkcm/krypton/internal/keyprocessor"
+	"github.com/openkcm/krypton/internal/secret/envvar"
+	"github.com/openkcm/krypton/internal/secret/secretprovider"
 	"github.com/openkcm/krypton/internal/spec"
+	"github.com/openkcm/krypton/internal/vault/sqlitevault"
+	"github.com/openkcm/krypton/internal/vault/vaultprovider"
 	"github.com/openkcm/krypton/pkg/api/v1/proto"
 	"github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
 	"github.com/openkcm/krypton/pkg/model"
@@ -90,6 +102,14 @@ func defaultTestTopology() spec.Topology {
 	}
 }
 
+func rootTestTopology() spec.Topology {
+	return spec.Topology{
+		Segments: []spec.TopologySegment{
+			{Name: testRootName, Segment: spec.HierarchySegment{StartKind: "K1", EndKind: "K3"}},
+		},
+	}
+}
+
 var testRootSegment = spec.HierarchySegment{StartKind: "K0", EndKind: "K0"}
 
 const (
@@ -102,18 +122,89 @@ const (
 // job IDs.
 func setupKeyServerAndClient(t *testing.T, db *sql.DB) keys.KeyServiceClient {
 	t.Helper()
-	return setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{})
+	return setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, nil)
 }
 
-func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHierarchy, preparer keys.JobPreparer) keys.KeyServiceClient {
+func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHierarchy, preparer keys.JobPreparer, topology *spec.Topology) keys.KeyServiceClient {
 	t.Helper()
 
+	if topology == nil {
+		top := defaultTestTopology()
+		topology = &top
+	}
+
 	keyStore := storesql.NewKeyStore(db)
+	keyVersionStore := storesql.NewKeyVersionStore(db)
 	tenantStore := storesql.NewTenantStore(db)
-	v := validator.NewValidator(testRootSegment, defaultTestTopology(), hierarchy, tenantStore, keyStore)
+	v := validator.NewValidator(testRootSegment, *topology, hierarchy, tenantStore, keyStore)
+
+	// create root secret
+	sealerKey := make([]byte, 32)
+	_, err := rand.Read(sealerKey)
+	require.NoError(t, err)
+	envName := "TEST_KMIP_SEALER_KEY"
+	t.Setenv(envName, base64.StdEncoding.EncodeToString(sealerKey))
+
+	// create manager
+	mgr, err := keyprocessor.NewManager(t.Context(), keyprocessor.ManagerConfig{
+		KeyStore:        keyStore,
+		KeyVersionStore: storesql.NewKeyVersionStore(db),
+		Bindings: map[model.KeyKind]spec.KeyBinding{
+			"K0": {
+				SealerSpec: &sealerprovider.Spec{
+					Name: "test-sealer",
+					Type: staticsecret.TypeStaticSecret,
+					Config: &staticsecret.Config{
+						Secret: secretprovider.Spec{
+							Type:   envvar.Type,
+							Config: &envvar.Config{Name: envName},
+						},
+					},
+				},
+			},
+			"K1": {
+				CryptorSpec: &cryptorprovider.Spec{
+					Name:   "cryptor-k1",
+					Type:   aes256gcm.TypeAES256GCM,
+					Config: &aes256gcm.Config{},
+				},
+				VaultSpec: &vaultprovider.Spec{
+					Name:   "vault-k1",
+					Type:   sqlitevault.TypeUnsafe,
+					Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k1.db")},
+				},
+			},
+			"K2": {
+				CryptorSpec: &cryptorprovider.Spec{
+					Name:   "cryptor-k2",
+					Type:   aes256gcm.TypeAES256GCM,
+					Config: &aes256gcm.Config{},
+				},
+				VaultSpec: &vaultprovider.Spec{
+					Name:   "vault-k2",
+					Type:   sqlitevault.TypeUnsafe,
+					Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k2.db")},
+				},
+			},
+			"K3": {
+				CryptorSpec: &cryptorprovider.Spec{
+					Name:   "cryptor-k3",
+					Type:   aes256gcm.TypeAES256GCM,
+					Config: &aes256gcm.Config{},
+				},
+				VaultSpec: &vaultprovider.Spec{
+					Name:   "vault-k3",
+					Type:   sqlitevault.TypeUnsafe,
+					Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k3.db")},
+				},
+			},
+		},
+		Hierarchy: defaultTestHierarchy(),
+	})
+	require.NoError(t, err)
 
 	srv := grpc.NewServer()
-	keys.RegisterKeyServiceServer(srv, keys.NewKeyService(testRootName, keyStore, v, preparer))
+	keys.RegisterKeyServiceServer(srv, keys.NewKeyService(testRootName, keyStore, keyVersionStore, v, preparer, mgr))
 
 	const bufSize = 1024 * 1024
 	lis := bufconn.Listen(bufSize)


### PR DESCRIPTION
Implement the ActivateKey gRPC endpoint which transitions a key from PreActivation to Active state and creates its first key version. For non-root keys, the manager seals a secret into the vault using the parent key version. Root keys skip secret generation as they are externally sealed.
Includes unit tests, integration test scaffolding, and proto definition updates for the new ActivateKey request/response messages.
