### PR TITLE
fix: decouple hierarchy from bindings in key processor manager

### DIFF
--- a/internal/keyprocessor/manager.go
+++ b/internal/keyprocessor/manager.go
@@ -44,6 +44,8 @@ type Manager struct {
 	processors   map[model.KeyKind]processor
 }
 
+var _ cryptor.Sealer = &Manager{}
+
 type GenerateAndSealSecretRequest struct {
 	KeyVersion model.KeyVersion
 	AAD        []byte
@@ -52,8 +54,6 @@ type GenerateAndSealSecretRequest struct {
 
 type GenerateAndSealSecretResponse struct {
 }
-
-var _ cryptor.Sealer = &Manager{}
 
 // NewManager constructs a Manager by resolving the root sealer and building
 // a processor for each non-root key kind defined in the hierarchy.
@@ -68,19 +68,30 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 	mgr := &Manager{
 		store:        cfg.KeyStore,
 		versionStore: cfg.KeyVersionStore,
+		processors:   make(map[model.KeyKind]processor, len(cfg.Bindings)),
 	}
 
-	rootMgr, err := buildRootManager(ctx, cfg.KeyStore, cfg.Bindings, cfg.Hierarchy)
-	if err != nil {
-		return nil, err
+	for kind, binding := range cfg.Bindings {
+		sp, ok := cfg.Hierarchy.FindKeySpec(kind)
+		if !ok {
+			return nil, fmt.Errorf("no key spec found for key kind %s", kind)
+		}
+		if sp.Role == spec.KeyRoleRoot {
+			continue
+		}
+
+		parent, err := resolveParent(ctx, cfg, mgr, kind)
+		if err != nil {
+			return nil, err
+		}
+
+		proc, err := newProcessor(ctx, binding, parent)
+		if err != nil {
+			return nil, fmt.Errorf("building processor for key kind %s: %w", kind, err)
+		}
+		mgr.processors[kind] = *proc
 	}
 
-	processors, err := buildProcessors(ctx, cfg.Hierarchy, cfg.Bindings, rootMgr, mgr)
-	if err != nil {
-		return nil, err
-	}
-
-	mgr.processors = processors
 	return mgr, nil
 }
 
@@ -95,65 +106,6 @@ func (m *Manager) GenerateAndSealSecret(ctx context.Context, req GenerateAndSeal
 		AAD:        req.AAD,
 	})
 	return GenerateAndSealSecretResponse{}, err
-}
-
-func buildRootManager(ctx context.Context, s store.Key, bindings map[model.KeyKind]spec.KeyBinding, hierarchy spec.KeyHierarchy) (*rootManager, error) {
-	for _, ks := range hierarchy.KeySpecs {
-		if ks.Role != spec.KeyRoleRoot {
-			continue
-		}
-
-		binding, ok := bindings[ks.Kind]
-		if !ok {
-			return nil, fmt.Errorf("no binding found for root key kind %s", ks.Kind)
-		}
-		if binding.SealerSpec == nil {
-			return nil, ErrRootMissingSealerSpec
-		}
-
-		sealer, err := sealerprovider.GetSealer(ctx, *binding.SealerSpec)
-		if err != nil {
-			return nil, err
-		}
-
-		return &rootManager{store: s, sealer: sealer}, nil
-	}
-
-	return nil, fmt.Errorf("no root key spec found in hierarchy %q", hierarchy.Name)
-}
-
-func buildProcessors(ctx context.Context, hierarchy spec.KeyHierarchy, bindings map[model.KeyKind]spec.KeyBinding, rootMgr *rootManager, mgr *Manager) (map[model.KeyKind]processor, error) {
-	processors := make(map[model.KeyKind]processor, len(bindings))
-
-	prevRole := spec.KeyRole("")
-	for _, ks := range hierarchy.KeySpecs {
-		if ks.Role == spec.KeyRoleRoot {
-			prevRole = ks.Role
-			continue
-		}
-
-		binding, ok := bindings[ks.Kind]
-		if !ok {
-			return nil, fmt.Errorf("no binding found for key kind %s", ks.Kind)
-		}
-
-		var parent cryptor.Sealer
-		if prevRole == spec.KeyRoleRoot {
-			parent = rootMgr
-		} else {
-			parent = mgr
-		}
-		prevRole = ks.Role
-
-		proc, err := newProcessor(ctx, binding, parent)
-		if err != nil {
-			return nil, fmt.Errorf("building processor for key kind %s: %w", ks.Kind, err)
-		}
-
-		processors[ks.Kind] = *proc
-	}
-
-	return processors, nil
 }
 
 // ExportSecretRequest identifies the key whose plaintext material to export.
@@ -276,6 +228,32 @@ func (rm *rootManager) Unseal(ctx context.Context, req cryptor.UnsealRequest) (c
 	}
 
 	return rm.sealer.Unseal(ctx, req)
+}
+
+func resolveParent(ctx context.Context, cfg ManagerConfig, mgr *Manager, kind model.KeyKind) (cryptor.Sealer, error) {
+	parentSpec, ok := cfg.Hierarchy.FindParentKeySpec(kind)
+	if !ok {
+		return nil, fmt.Errorf("no parent key spec found for key kind %s", kind)
+	}
+	if parentSpec.Role != spec.KeyRoleRoot {
+		return mgr, nil
+	}
+	rootBinding, ok := cfg.Bindings[parentSpec.Kind]
+	if !ok {
+		return nil, fmt.Errorf("no binding found for root key kind %s", parentSpec.Kind)
+	}
+	return buildRootManager(ctx, cfg.KeyStore, rootBinding)
+}
+
+func buildRootManager(ctx context.Context, s store.Key, binding spec.KeyBinding) (*rootManager, error) {
+	if binding.SealerSpec == nil {
+		return nil, ErrRootMissingSealerSpec
+	}
+	sealer, err := sealerprovider.GetSealer(ctx, *binding.SealerSpec)
+	if err != nil {
+		return nil, err
+	}
+	return &rootManager{store: s, sealer: sealer}, nil
 }
 
 // resolveUsableKeyVersion returns the highest usable revision of version, or

--- a/internal/keyprocessor/manager_test.go
+++ b/internal/keyprocessor/manager_test.go
@@ -541,55 +541,6 @@ func TestManagerHierarchy(t *testing.T) {
 }
 
 func TestNewManager(t *testing.T) {
-	t.Run("should return error when hierarchy has no root key", func(t *testing.T) {
-		// given
-		cfg := keyprocessor.ManagerConfig{
-			KeyStore:        &keyStoreWrapper{},
-			KeyVersionStore: &keyVersionStoreWrapper{},
-			Hierarchy: spec.KeyHierarchy{
-				Name: "test",
-				KeySpecs: []spec.KeySpec{
-					{Kind: "K1", Role: spec.KeyRoleKek},
-				},
-			},
-			Bindings: map[model.KeyKind]spec.KeyBinding{
-				"K1": {},
-			},
-		}
-
-		// when
-		mgr, err := keyprocessor.NewManager(t.Context(), cfg)
-
-		// then
-		assert.Nil(t, mgr)
-		assert.ErrorContains(t, err, "no root key spec found in hierarchy")
-	})
-
-	t.Run("should return error when root binding is missing from bindings map", func(t *testing.T) {
-		// given
-		cfg := keyprocessor.ManagerConfig{
-			KeyStore:        &keyStoreWrapper{},
-			KeyVersionStore: &keyVersionStoreWrapper{},
-			Hierarchy: spec.KeyHierarchy{
-				Name: "test",
-				KeySpecs: []spec.KeySpec{
-					{Kind: "K0", Role: spec.KeyRoleRoot},
-					{Kind: "K1", Role: spec.KeyRoleDek},
-				},
-			},
-			Bindings: map[model.KeyKind]spec.KeyBinding{
-				"K1": {},
-			},
-		}
-
-		// when
-		mgr, err := keyprocessor.NewManager(t.Context(), cfg)
-
-		// then
-		assert.Nil(t, mgr)
-		assert.ErrorContains(t, err, "no binding found for root key kind K0")
-	})
-
 	t.Run("should return error when root binding has nil sealer spec", func(t *testing.T) {
 		// given
 		cfg := keyprocessor.ManagerConfig{
@@ -640,31 +591,6 @@ func TestNewManager(t *testing.T) {
 		// then
 		assert.Nil(t, mgr)
 		assert.ErrorIs(t, err, cryptor.ErrUnknownType)
-	})
-
-	t.Run("should return error when non-root binding is missing from bindings map", func(t *testing.T) {
-		// given
-		cfg := keyprocessor.ManagerConfig{
-			KeyStore:        &keyStoreWrapper{},
-			KeyVersionStore: &keyVersionStoreWrapper{},
-			Hierarchy: spec.KeyHierarchy{
-				Name: "test",
-				KeySpecs: []spec.KeySpec{
-					{Kind: "K0", Role: spec.KeyRoleRoot},
-					{Kind: "K1", Role: spec.KeyRoleDek},
-				},
-			},
-			Bindings: map[model.KeyKind]spec.KeyBinding{
-				"K0": {SealerSpec: newTestSealerSpec(t)},
-			},
-		}
-
-		// when
-		mgr, err := keyprocessor.NewManager(t.Context(), cfg)
-
-		// then
-		assert.Nil(t, mgr)
-		assert.ErrorContains(t, err, "no binding found for key kind K1")
 	})
 
 	t.Run("should return error when non-root cryptor provider fails", func(t *testing.T) {
@@ -897,6 +823,76 @@ func TestNewManager(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.NotNil(t, mgr)
+	})
+
+	t.Run("should construct manager for two nodes", func(t *testing.T) {
+		t.Run("with root bindings", func(t *testing.T) {
+			// given
+			cfg := keyprocessor.ManagerConfig{
+				KeyStore:        &keyStoreWrapper{},
+				KeyVersionStore: &keyVersionStoreWrapper{},
+				Hierarchy: spec.KeyHierarchy{
+					Name: "test",
+					KeySpecs: []spec.KeySpec{
+						{Kind: "K0", Role: spec.KeyRoleRoot},
+						{Kind: "K1", Role: spec.KeyRoleDek},
+						{Kind: "K2", Role: spec.KeyRoleTek},
+						{Kind: "K3", Role: spec.KeyRoleDek},
+					},
+				},
+				Bindings: map[model.KeyKind]spec.KeyBinding{
+					"K0": {
+						SealerSpec: newTestSealerSpec(t),
+					},
+					"K1": {
+						CryptorSpec: newTestCryptorSpec(),
+						VaultSpec:   newTestVaultSpec(),
+					},
+				},
+			}
+
+			// when
+			mgr, err := keyprocessor.NewManager(t.Context(), cfg)
+
+			// then
+			assert.NoError(t, err)
+			assert.NotNil(t, mgr)
+		})
+
+		t.Run("with agent bindings", func(t *testing.T) {
+			// given
+			cfg := keyprocessor.ManagerConfig{
+				KeyStore:        &keyStoreWrapper{},
+				KeyVersionStore: &keyVersionStoreWrapper{},
+				Hierarchy: spec.KeyHierarchy{
+					Name: "test",
+					KeySpecs: []spec.KeySpec{
+						{Kind: "K0", Role: spec.KeyRoleRoot},
+						{Kind: "K1", Role: spec.KeyRoleDek},
+						{Kind: "K2", Role: spec.KeyRoleTek},
+						{Kind: "K3", Role: spec.KeyRoleDek},
+					},
+				},
+				Bindings: map[model.KeyKind]spec.KeyBinding{
+					"K2": {
+						CryptorSpec: newTestCryptorSpec(),
+						VaultSpec:   newTestVaultSpec(),
+						SealerSpec:  newTestSealerSpec(t),
+					},
+					"K3": {
+						CryptorSpec: newTestCryptorSpec(),
+						VaultSpec:   newTestVaultSpec(),
+					},
+				},
+			}
+
+			// when
+			mgr, err := keyprocessor.NewManager(t.Context(), cfg)
+
+			// then
+			assert.NoError(t, err)
+			assert.NotNil(t, mgr)
+		})
 	})
 }
 

--- a/internal/spec/keyhierarchy.go
+++ b/internal/spec/keyhierarchy.go
@@ -97,6 +97,16 @@ func (h KeyHierarchy) FindKeySpec(kind model.KeyKind) (KeySpec, bool) {
 	return KeySpec{}, false
 }
 
+// FindParentKeySpec returns the KeySpec immediately preceding kind in the hierarchy.
+// Returns (_, false) if kind is not found or is the first (root) key.
+func (h KeyHierarchy) FindParentKeySpec(kind model.KeyKind) (KeySpec, bool) {
+	idx := h.IndexOf(kind)
+	if idx <= 0 {
+		return KeySpec{}, false
+	}
+	return h.KeySpecs[idx-1], true
+}
+
 // IndexOf returns the position of the given kind in the hierarchy's KeySpecs slice. Returns -1 if not found.
 func (h KeyHierarchy) IndexOf(kind model.KeyKind) int {
 	for i, k := range h.KeySpecs {

--- a/internal/spec/keyhierarchy_test.go
+++ b/internal/spec/keyhierarchy_test.go
@@ -547,6 +547,65 @@ func TestKeyHierarchy(t *testing.T) {
 		}
 	})
 
+	t.Run("FindParentKeySpec", func(t *testing.T) {
+		hierarchy := &spec.KeyHierarchy{
+			Name: "test-hierarchy",
+			KeySpecs: []spec.KeySpec{
+				{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K2", Role: spec.KeyRoleTek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+				{Kind: "K4", Role: spec.KeyRoleDek, Algorithm: cryptor.KeyAlgorithmAES256},
+			},
+		}
+
+		tts := []struct {
+			name       string
+			kind       model.KeyKind
+			expIsFound bool
+			expParent  spec.KeySpec
+		}{
+			{
+				name:       "should return false for the root kind",
+				kind:       "K0",
+				expIsFound: false,
+				expParent:  spec.KeySpec{},
+			},
+			{
+				name:       "should return the root as parent of the first non-root kind",
+				kind:       "K1",
+				expIsFound: true,
+				expParent:  spec.KeySpec{Kind: "K0", Role: spec.KeyRoleRoot, Algorithm: cryptor.KeyAlgorithmAES256},
+			},
+			{
+				name:       "should return the preceding kind for a middle kind",
+				kind:       "K2",
+				expIsFound: true,
+				expParent:  spec.KeySpec{Kind: "K1", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+			},
+			{
+				name:       "should return the preceding kind for the last kind",
+				kind:       "K4",
+				expIsFound: true,
+				expParent:  spec.KeySpec{Kind: "K3", Role: spec.KeyRoleKek, Algorithm: cryptor.KeyAlgorithmAES256},
+			},
+			{
+				name:       "should return false for an unknown kind",
+				kind:       "nonexistent",
+				expIsFound: false,
+				expParent:  spec.KeySpec{},
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				parent, ok := hierarchy.FindParentKeySpec(tt.kind)
+				assert.Equal(t, tt.expIsFound, ok)
+				assert.Equal(t, tt.expParent, parent)
+			})
+		}
+	})
+
 	t.Run("KindsBetween", func(t *testing.T) {
 		hierarchy := &spec.KeyHierarchy{
 			Name: "test-hierarchy",


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       fix
- description:   decouple hierarchy from bindings in key processor manager

Following the conventional commits: https://www.conventionalcommits.org
-->

Decouple hierarchy from bindings in `keyprocessor.NewManager`: root-only and agent-only segments now both construct
