### PR TITLE
feat: add activate-key CLI command and integration tests

### DIFF
--- a/cli/cmd/activate.go
+++ b/cli/cmd/activate.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/openkcm/krypton/cli/output"
+	"github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
+)
+
+func activateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "activate",
+		Short: "Activate a key",
+	}
+	cmd.AddCommand(activateKeyCmd())
+	return cmd
+}
+
+type activatedKeyRow struct {
+	Status bool
+}
+
+func activateKeyCmd() *cobra.Command {
+	var tenantID, keyID string
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   keyCmd,
+		Short: "Activate an existing key by tenant and key ID",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if tenantID == "" {
+				tID, err := selectedTenantID()
+				if err != nil {
+					return fmt.Errorf("failed to get selected tenant: %w", err)
+				}
+				tenantID = tID
+			}
+
+			// TODO: insecure.NewCredentials is a temporary workaround until TLS is configured
+			conn, err := grpc.NewClient(
+				serverAddr,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to connect: %w", err)
+			}
+			defer conn.Close()
+
+			client := keys.NewKeyServiceClient(conn)
+
+			_, err = client.ActivateKey(cmd.Context(), &keys.ActivateKeyRequest{
+				TenantId: tenantID,
+				Id:       keyID,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to activate key: %w", err)
+			}
+
+			builder, err := output.From(activatedKeyRow{Status: true})
+			if err != nil {
+				return fmt.Errorf("failed to format output: %w", err)
+			}
+
+			return formatOutput(builder, asJSON).To(cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVar(&keyID, "key-id", "", "id of the key")
+	cmd.Flags().StringVar(&tenantID, "tenant-id", "", "id of the tenant")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output in JSON format")
+	_ = cmd.MarkFlagRequired("key-id")
+
+	return cmd
+}

--- a/cli/cmd/announce.go
+++ b/cli/cmd/announce.go
@@ -55,7 +55,7 @@ func announceKeyCmd() *cobra.Command {
 	var asJSON bool
 
 	cmd := &cobra.Command{
-		Use:   "key",
+		Use:   keyCmd,
 		Short: "Announce a new key in the selected tenant's hierarchy",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/key.go
+++ b/cli/cmd/key.go
@@ -15,6 +15,8 @@ import (
 	"github.com/openkcm/krypton/pkg/model"
 )
 
+const keyCmd = "key"
+
 type keyRows struct {
 	Keys   []keyRow
 	Cursor string
@@ -80,7 +82,7 @@ func getKeyCmd() *cobra.Command {
 	var asJSON bool
 
 	cmd := &cobra.Command{
-		Use:   "key",
+		Use:   keyCmd,
 		Short: "Get a single key by its tenant ID and key ID",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -24,4 +24,5 @@ func init() {
 	rootCmd.AddCommand(getCmd())
 	rootCmd.AddCommand(selectCmd())
 	rootCmd.AddCommand(announceCmd())
+	rootCmd.AddCommand(activateCmd())
 }

--- a/cmd/root/main.go
+++ b/cmd/root/main.go
@@ -106,6 +106,19 @@ func main() {
 		}
 	}()
 
+	// initialization of keyprocessor manager
+	bindings := make(map[model.KeyKind]spec.KeyBinding, len(cfg.KeyBindings))
+	for kind, binding := range cfg.KeyBindings {
+		bindings[model.KeyKind(kind)] = binding
+	}
+	kpMgr, err := keyprocessor.NewManager(context.Background(), keyprocessor.ManagerConfig{
+		KeyStore:        keyStore,
+		KeyVersionStore: keyVersionStore,
+		Bindings:        bindings,
+		Hierarchy:       cfg.Hierarchy,
+	})
+	handleErr(err, "failed to create key processor manager")
+
 	// gRPC server setup for admin API
 	grpcServer := grpc.NewServer()
 	admin.RegisterTenantServiceServer(grpcServer, admin.NewTenantService(tenantStore))
@@ -114,7 +127,7 @@ func main() {
 	agents.RegisterServiceServer(grpcServer, agents.NewAgentService(agentStore, *cfg))
 
 	// gRPC server setup for keys API
-	keypb.RegisterKeyServiceServer(grpcServer, keypb.NewKeyService(cfg.Name, keyStore, keyVersionStore, keyValidator, reconcilerMgr, nil))
+	keypb.RegisterKeyServiceServer(grpcServer, keypb.NewKeyService(cfg.Name, keyStore, keyVersionStore, keyValidator, reconcilerMgr, kpMgr))
 
 	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", ":"+srvPort)
 	handleErr(err, "failed to listen on gRPC port")
@@ -133,17 +146,6 @@ func main() {
 	// KMIP server (optional) — serves unwrapped DEKs to KMIP clients over mTLS.
 	var kmipSrv *kmip.Server
 	if cfg.KMIP != nil {
-		bindings := make(map[model.KeyKind]spec.KeyBinding, len(cfg.KeyBindings))
-		for kind, binding := range cfg.KeyBindings {
-			bindings[model.KeyKind(kind)] = binding
-		}
-		kpMgr, err := keyprocessor.NewManager(context.Background(), keyprocessor.ManagerConfig{
-			KeyStore:        keyStore,
-			KeyVersionStore: keyVersionStore,
-			Bindings:        bindings,
-			Hierarchy:       cfg.Hierarchy,
-		})
-		handleErr(err, "failed to create key processor manager")
 		kmipSrv, err = kmip.NewServer(*cfg.KMIP, kpMgr)
 		handleErr(err, "failed to create kmip server")
 		go func() {

--- a/integration/activate_key_test.go
+++ b/integration/activate_key_test.go
@@ -1,0 +1,309 @@
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/krypton/pkg/api/v1/proto/admin"
+	keypb "github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
+)
+
+type activatedKeyRow struct {
+	Status bool
+}
+
+func TestActivateKey(t *testing.T) {
+	env := setupEnvironment(t)
+	rootKVStore := newKeyVersionStore(t, env.RootDB)
+	rootKStore := newKeyStore(t, env.RootDB)
+
+	tenantCli := admin.NewTenantServiceClient(env.Conn)
+	keyCli := keypb.NewKeyServiceClient(env.Conn)
+
+	ctx := t.Context()
+
+	t.Run("should activate root key", func(t *testing.T) {
+		// given
+		// Create a tenant
+		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
+			Name: "announce-root-test-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		tenantID := tenantResp.GetTenant().GetId()
+
+		// announce key root key
+		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		keyID := resp.GetKey().GetId()
+
+		// when
+		cmd := newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", keyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err := cmd.CombinedOutput()
+
+		// then
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// checking key status
+		key, err := rootKStore.GetKeyByID(ctx, keyID, tenantID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
+
+		// check key version status
+		kvr, err := rootKVStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID: tenantID,
+			KeyID:    keyID,
+			OrderBy: []store.KeyVersionOrder{
+				store.KeyVersionOrderVersionDesc,
+				store.KeyVersionOrderRevisionDesc,
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, kvr.KeyVersions, 1, "there should be exactly one key version after activation")
+		kv := kvr.KeyVersions[0]
+		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
+		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
+	})
+
+	t.Run("should activate intermediate key", func(t *testing.T) {
+		// given
+		// Create a tenant
+		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
+			Name: "announce-root-test-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		tenantID := tenantResp.GetTenant().GetId()
+
+		// announce key root key
+		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		keyID := resp.GetKey().GetId()
+
+		// activate root key
+		cmd := newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", keyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// announce intermediate key
+		resp, err = keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K1",
+			Name:       "k1-key-" + uuid.NewString(),
+			TargetName: "",
+			ParentId:   keyID,
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		keyID = resp.GetKey().GetId()
+
+		// when
+		// activate intermediate key
+		cmd = newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", keyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err = cmd.CombinedOutput()
+
+		// then
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// checking key status
+		key, err := rootKStore.GetKeyByID(ctx, keyID, tenantID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
+
+		// check key version status
+		kvr, err := rootKVStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID: tenantID,
+			KeyID:    keyID,
+			OrderBy: []store.KeyVersionOrder{
+				store.KeyVersionOrderVersionDesc,
+				store.KeyVersionOrderRevisionDesc,
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, kvr.KeyVersions, 1, "there should be exactly one key version after activation")
+		kv := kvr.KeyVersions[0]
+		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
+		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
+	})
+
+	t.Run("should return error if activate key is called on already activated key", func(t *testing.T) {
+		// given
+		// Create a tenant
+		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
+			Name: "announce-root-test-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		tenantID := tenantResp.GetTenant().GetId()
+
+		// announce key root key
+		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		keyID := resp.GetKey().GetId()
+
+		// activate root key
+		cmd := newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", keyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// when
+		// activate root key
+		cmd = newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", keyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+
+		// then
+		output, err = cmd.CombinedOutput()
+		assert.Error(t, err, "command should fail, output: %s", string(output))
+		assert.Contains(t, string(output), "failed to activate key")
+	})
+
+	t.Run("should return error if activate key is called on non-existent key", func(t *testing.T) {
+		// given
+		// Create a tenant
+		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
+			Name: "announce-root-test-" + uuid.NewString(),
+		})
+		require.NoError(t, err)
+		tenantID := tenantResp.GetTenant().GetId()
+
+		// when
+		cmd := newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", uuid.NewString(),
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+
+		output, err := cmd.CombinedOutput()
+
+		// then
+		assert.Error(t, err, "command should fail, output: %s", string(output))
+		assert.Contains(t, string(output), "failed to activate key")
+	})
+
+	t.Run("should return error", func(t *testing.T) {
+		// given
+		validUUID := uuid.NewString()
+		tts := []struct {
+			name string
+			args []string
+		}{
+			{
+				name: "if the key ID is not provided",
+				args: []string{
+					"activate",
+					"key",
+					"--tenant-id", validUUID,
+					"--json",
+					"--server", "localhost:" + env.RootPort,
+				},
+			},
+			{
+				name: "if the tenant ID is not provided",
+				args: []string{
+					"activate",
+					"key",
+					"--key-id", validUUID,
+					"--json",
+					"--server", "localhost:" + env.RootPort,
+				},
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				// when
+				cmd := newCLICommand(
+					t.Context(),
+					t.TempDir(),
+					tt.args...,
+				)
+
+				output, err := cmd.CombinedOutput()
+
+				// then
+				assert.Error(t, err, "command should fail, output: %s", string(output))
+			})
+		}
+	})
+}
+
+func decodeActivatedKeyRow(t *testing.T, output []byte) activatedKeyRow {
+	t.Helper()
+	var ar []activatedKeyRow
+	err := json.Unmarshal(output, &ar)
+	if err != nil {
+		assert.FailNowf(t, "failed to decode response", "output: %s, error: %v", string(output), err)
+	}
+	require.Len(t, ar, 1, "expected exactly one activated key row in the output")
+	return ar[0]
+}

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,6 +27,12 @@ type testEnvironment struct {
 	Conn      *grpc.ClientConn
 }
 
+// testKey is a 32-byte AES-256 key for testing.
+var testKey = []byte("01234567890123456789012345678901")
+
+// testKeyBase64 is testKey encoded as base64 (standard encoding).
+var testKeyBase64 = base64.StdEncoding.EncodeToString(testKey)
+
 // setupEnvironment builds binaries, writes configs, starts root + agent, and returns
 // a testEnvironment with open DB connections and a gRPC client to root.
 func setupEnvironment(t *testing.T) *testEnvironment {
@@ -46,6 +53,7 @@ func setupEnvironment(t *testing.T) *testEnvironment {
 		"ROOT_CONFIG_PATH=" + rootCfgPath,
 		"DATABASE_URL=" + rootConnStr,
 		"SERVER_PORT=" + rootPort,
+		"KRYPTON_ROOT_KEY=" + testKeyBase64,
 	})
 	require.NoError(t, rootCmd.Start(), "failed to start root server")
 	waitForPort(t, rootPort)

--- a/integration/registration_test.go
+++ b/integration/registration_test.go
@@ -46,6 +46,7 @@ func TestRegistration(t *testing.T) {
 		"ROOT_CONFIG_PATH=" + rootCfgPath,
 		"DATABASE_URL=" + dbConnStr,
 		"SERVER_PORT=" + rootPort,
+		"KRYPTON_ROOT_KEY=" + testKeyBase64,
 	})
 	err := rootCmd.Start()
 	require.NoError(t, err, "failed to start root server process")

--- a/pkg/api/v1/proto/admin/keys/activatekey_test.go
+++ b/pkg/api/v1/proto/admin/keys/activatekey_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openkcm/krypton/internal/vault"
+	"github.com/openkcm/krypton/internal/vault/vaultprovider"
 	keypb "github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
@@ -16,18 +18,18 @@ import (
 func TestActivateKey(t *testing.T) {
 	// given
 	ctx := t.Context()
-	db := createDatabase(t)
-
-	require.NoError(t, storesql.Migrate(ctx, db))
-	tenant := createTenant(t, db)
-
-	keyStore := storesql.NewKeyStore(db)
-	keyVersionStore := storesql.NewKeyVersionStore(db)
 	rootTopology := rootTestTopology()
+
+	db := createDatabase(t)
+	require.NoError(t, storesql.Migrate(ctx, db))
 
 	t.Run("should activate root key version", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		keyVersionStore := setup.keyVersionStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// announcing root key
 		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -72,7 +74,9 @@ func TestActivateKey(t *testing.T) {
 
 	t.Run("should not activate root key version twice", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		// announcing root key
 		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -106,7 +110,11 @@ func TestActivateKey(t *testing.T) {
 
 	t.Run("should activate a intermediate key", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		keyVersionStore := setup.keyVersionStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// announcing root key
 		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -165,11 +173,27 @@ func TestActivateKey(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, keyVersion.KeyVersions, 1)
+
+		// check if the secret is store in the vault
+		kv := keyVersion.KeyVersions[0]
+		vaultK1, err := vaultprovider.GetVault(ctx, *setup.vaultK1)
+		require.NoError(t, err)
+		vaultResp, err := vaultK1.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:    kv.TenantID,
+			KeyID:       keyID,
+			KeyVersion:  kv.Version,
+			KeyRevision: kv.Revision,
+		})
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, vaultResp.KeyMaterial)
 	})
 
 	t.Run("should not activate a intermediate key twice", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		// announcing root key
 		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -219,7 +243,10 @@ func TestActivateKey(t *testing.T) {
 
 	t.Run("should activate all keys in a chain", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		cli := setup.cli
+		keyVersionStore := setup.keyVersionStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// given
 		// announcing root key
@@ -308,11 +335,41 @@ func TestActivateKey(t *testing.T) {
 		})
 		// then
 		require.NoError(t, err)
+
+		// Verify that the keyversion is also created and activated
+		keyVersion, err := keyVersionStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID:        tenant.ID,
+			KeyID:           k3ID,
+			Version:         1,
+			LifeCycleState:  model.KeyLifeCycleActive,
+			ProcessingState: model.KeyVersionUsable,
+			Limit:           100,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, keyVersion.KeyVersions, 1)
+
+		// check if the secret is store in the vault
+		kv := keyVersion.KeyVersions[0]
+		vaultK3, err := vaultprovider.GetVault(ctx, *setup.vaultK3)
+		require.NoError(t, err)
+		vaultResp, err := vaultK3.ExportKey(ctx, vault.ExportKeyRequest{
+			TenantID:    kv.TenantID,
+			KeyID:       k3ID,
+			KeyVersion:  kv.Version,
+			KeyRevision: kv.Revision,
+		})
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, vaultResp.KeyMaterial)
 	})
 
 	t.Run("should return error if there is no parent keyversion", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, &rootTopology)
+		cli := setup.cli
+		keyVersionStore := setup.keyVersionStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// announcing root key
 		announceRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{

--- a/pkg/api/v1/proto/admin/keys/key_service_test.go
+++ b/pkg/api/v1/proto/admin/keys/key_service_test.go
@@ -54,7 +54,7 @@ type keyHierarchy struct {
 // activateKey flips a freshly-announced key into Active so it can serve as a
 // parent in subsequent AnnounceKey calls (per the strict "parent must be
 // Active" rule enforced in KeyService.AnnounceKey).
-func activateKey(t *testing.T, ks *storesql.KeyStore, id, tenantID string) {
+func activateKey(t *testing.T, ks store.Key, id, tenantID string) {
 	t.Helper()
 	require.NoError(t, ks.UpdateKeyLifeCycleState(t.Context(), store.UpdateKeyLifeCycleStateQuery{
 		ID:       id,
@@ -69,13 +69,12 @@ func TestAnnounceKey(t *testing.T) {
 	db := createDatabase(t)
 
 	require.NoError(t, storesql.Migrate(ctx, db))
-	keyStore := storesql.NewKeyStore(db)
-
-	tenant := createTenant(t, db)
 
 	t.Run("should create key successfully", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		// when
 		res, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -102,9 +101,11 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should be idempotent on duplicate (tenant, name)", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
-		name := "idempotent-" + uuid.NewString()
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
+		name := "idempotent-" + uuid.NewString()
 		first, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
 			Kind:       "K0",
@@ -127,6 +128,11 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should succeed when orbital reports job already exists for fresh key", func(t *testing.T) {
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists}, nil)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
+
 		// Pre-seed the key so the lookup-by-name fallback (after orbital
 		// dedupe) finds it.
 		name := "racer-" + uuid.NewString()
@@ -137,7 +143,6 @@ func TestAnnounceKey(t *testing.T) {
 		}
 		require.NoError(t, keyStore.CreateKey(ctx, seed))
 
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists}, nil)
 		// Subsequent call short-circuits via existing in-progress key,
 		// without ever needing PrepareJob.
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -151,13 +156,17 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should surface RETRY on other PrepareJob errors", func(t *testing.T) {
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: errors.New("boom")}, nil)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
+
 		// PrepareJob is only called for non-root-managed keys, so seed an
 		// Active K0 parent and announce a K1 against the agent target.
 		parent := model.NewKey(tenant.ID, "boom-parent-"+uuid.NewString(), "K0", nil, "root", nil)
 		require.NoError(t, keyStore.CreateKey(ctx, parent))
 		activateKey(t, keyStore, parent.ID, tenant.ID)
 
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: errors.New("boom")}, nil)
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
 			Kind:       "K1",
@@ -172,7 +181,10 @@ func TestAnnounceKey(t *testing.T) {
 
 	t.Run("should create key with parent", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		parentRes, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -200,7 +212,8 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject when tenant does not exist", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
 
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   uuid.NewString(),
@@ -214,7 +227,9 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject when kind is not in hierarchy", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -228,7 +243,9 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject non-root kind without parent", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -242,7 +259,10 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject root kind with parent", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// Pre-seed an Active K0 to use as the (illegal) parent.
 		other := model.NewKey(tenant.ID, "other-root-"+uuid.NewString(), "K0", nil, "root", nil)
@@ -262,7 +282,9 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject when parent does not exist in tenant", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -277,7 +299,10 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject when parent is not active", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// Pre-seed a K0 without activating it.
 		parent := model.NewKey(tenant.ID, "inactive-parent-"+uuid.NewString(), "K0", nil, "root", nil)
@@ -296,7 +321,10 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject when child kind is not adjacent to parent kind", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// Pre-seed an Active K0; try announcing K2 directly under it (skipping K1).
 		parent := model.NewKey(tenant.ID, "skip-parent-"+uuid.NewString(), "K0", nil, "root", nil)
@@ -316,7 +344,10 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should retry by preparing a new job when previous job failed", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// Pre-seed a key already in Failed state from a prior attempt.
 		failedJobID := uuid.NewString()
@@ -349,13 +380,16 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("ExternalID is key.ID for fresh agent-managed creation", func(t *testing.T) {
+		spy := &spyJobPreparer{}
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
+
 		// Seed an Active K0 parent so the agent-managed K1 announce passes validation.
 		parent := model.NewKey(tenant.ID, "spy-parent-"+uuid.NewString(), "K0", nil, "root", nil)
 		require.NoError(t, keyStore.CreateKey(ctx, parent))
 		activateKey(t, keyStore, parent.ID, tenant.ID)
-
-		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		name := "spy-fresh-" + uuid.NewString()
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -374,7 +408,9 @@ func TestAnnounceKey(t *testing.T) {
 
 	t.Run("root-managed fresh creation does not call PrepareJob", func(t *testing.T) {
 		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -389,6 +425,12 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("ExternalID is key.ID for failed retry (no suffix)", func(t *testing.T) {
+		spy := &spyJobPreparer{}
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
+
 		failedJobID := uuid.NewString()
 		key := model.NewKey(tenant.ID, "spy-retry-"+uuid.NewString(), "K0", nil, "root", nil)
 		require.NoError(t, keyStore.CreateKey(ctx, key))
@@ -398,9 +440,6 @@ func TestAnnounceKey(t *testing.T) {
 			NewStatus: model.KeyProcessingFailed,
 			NewJobID:  failedJobID,
 		}))
-
-		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		_, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -416,15 +455,18 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("retries when existing key is Pending", func(t *testing.T) {
+		spy := &spyJobPreparer{}
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
+
 		// A key in Pending state (CreateKey succeeded but linkage write didn't,
 		// or the key was created by some other path) should be retried as a
 		// fresh job with ExternalID = key.ID — no :retry: suffix because there
 		// is no previous failed JobID to scope against.
 		key := model.NewKey(tenant.ID, "pending-"+uuid.NewString(), "K0", nil, "root", nil)
 		require.NoError(t, keyStore.CreateKey(ctx, key))
-
-		spy := &spyJobPreparer{}
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), spy, nil)
 
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
@@ -450,6 +492,11 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("concurrent retry collides on deterministic ExternalID", func(t *testing.T) {
+		setup := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists}, nil)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
+
 		// Two simultaneous retries for the same Failed key compute the same
 		// ExternalID and the second PrepareJob should return ErrJobAlreadyExists,
 		// which the service swallows and returns the existing key.
@@ -463,7 +510,6 @@ func TestAnnounceKey(t *testing.T) {
 			NewJobID:  failedJobID,
 		}))
 
-		cli := setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), errJobPreparer{err: orbital.ErrJobAlreadyExists}, nil)
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenant.ID,
 			Kind:       "K0",
@@ -477,15 +523,16 @@ func TestAnnounceKey(t *testing.T) {
 	t.Run("should return internal error on database failure", func(t *testing.T) {
 		// given
 		tmpDB := createDatabase(t)
-
 		require.NoError(t, storesql.Migrate(ctx, tmpDB))
+
+		setup := setupKeyServerAndClient(t, tmpDB)
+		cli := setup.cli
+
 		// Seed a tenant in the temp DB so tenant-existence passes; then drop
 		// the keys table so the downstream lookup fails.
-		tmpTenant := createTenant(t, tmpDB)
+		tmpTenant := createTenant(t, setup.tenantStore)
 		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
-
-		cli := setupKeyServerAndClient(t, tmpDB)
 
 		// when
 		resp, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -503,7 +550,10 @@ func TestAnnounceKey(t *testing.T) {
 	})
 
 	t.Run("should reject conflicting key with same name but different parent", func(t *testing.T) {
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		keyStore := setup.keyStore
+		tenant := createTenant(t, setup.tenantStore)
 
 		// Seed two distinct active K0 parents under this tenant.
 		parentA := model.NewKey(tenant.ID, "conflict-parent-a-"+uuid.NewString(), "K0", nil, "root", nil)
@@ -547,11 +597,11 @@ func TestGetKeyService(t *testing.T) {
 
 	require.NoError(t, storesql.Migrate(ctx, db))
 
-	tenant := createTenant(t, db)
-
 	t.Run("should get key successfully", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		// when
 		created, err := cli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
@@ -578,7 +628,9 @@ func TestGetKeyService(t *testing.T) {
 
 	t.Run("should return not found for nonexistent key", func(t *testing.T) {
 		// given
-		cli := setupKeyServerAndClient(t, db)
+		setup := setupKeyServerAndClient(t, db)
+		cli := setup.cli
+		tenant := createTenant(t, setup.tenantStore)
 
 		// when
 		resp, err := cli.GetKey(ctx, &keypb.GetKeyRequest{
@@ -602,7 +654,8 @@ func TestGetKeyService(t *testing.T) {
 		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
-		cli := setupKeyServerAndClient(t, tmpDB)
+		setup := setupKeyServerAndClient(t, tmpDB)
+		cli := setup.cli
 
 		// when
 		resp, err := cli.GetKey(ctx, &keypb.GetKeyRequest{
@@ -624,13 +677,13 @@ func TestGetParentKeys(t *testing.T) {
 	db := createDatabase(t)
 
 	require.NoError(t, storesql.Migrate(ctx, db))
-	keyStore := storesql.NewKeyStore(db)
 
-	tenant := createTenant(t, db)
+	setup := setupKeyServerAndClient(t, db)
+	cli := setup.cli
+	keyStore := setup.keyStore
+	tenant := createTenant(t, setup.tenantStore)
 
 	ha := createKeyHierarchy(t, keyStore, tenant)
-
-	cli := setupKeyServerAndClient(t, db)
 
 	t.Run("should get parent keys successfully for intermediate", func(t *testing.T) {
 		// when
@@ -686,7 +739,8 @@ func TestGetParentKeys(t *testing.T) {
 		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
-		cli := setupKeyServerAndClient(t, tmpDB)
+		setup := setupKeyServerAndClient(t, tmpDB)
+		cli := setup.cli
 
 		// when
 		resp, err := cli.GetParentKeys(ctx, &keypb.GetParentKeysRequest{
@@ -706,15 +760,14 @@ func TestGetDescendantKeys(t *testing.T) {
 	// given
 	ctx := t.Context()
 	db := createDatabase(t)
-
 	require.NoError(t, storesql.Migrate(ctx, db))
-	keyStore := storesql.NewKeyStore(db)
 
-	tenant := createTenant(t, db)
+	setup := setupKeyServerAndClient(t, db)
+	cli := setup.cli
+	keyStore := setup.keyStore
+	tenant := createTenant(t, setup.tenantStore)
 
 	ha := createKeyHierarchy(t, keyStore, tenant)
-
-	cli := setupKeyServerAndClient(t, db)
 
 	t.Run("should get descendant keys successfully for root", func(t *testing.T) {
 		// when
@@ -803,7 +856,8 @@ func TestGetDescendantKeys(t *testing.T) {
 		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
-		cli := setupKeyServerAndClient(t, tmpDB)
+		setup := setupKeyServerAndClient(t, tmpDB)
+		cli := setup.cli
 
 		// when
 		resp, err := cli.GetDescendantKeys(ctx, &keypb.GetDescendantKeysRequest{
@@ -823,15 +877,14 @@ func TestListKeys(t *testing.T) {
 	// given
 	ctx := t.Context()
 	db := createDatabase(t)
-
 	require.NoError(t, storesql.Migrate(ctx, db))
-	keyStore := storesql.NewKeyStore(db)
 
-	tenant := createTenant(t, db)
+	setup := setupKeyServerAndClient(t, db)
+	cli := setup.cli
+	keyStore := setup.keyStore
+	tenant := createTenant(t, setup.tenantStore)
 
 	ha := createKeyHierarchy(t, keyStore, tenant)
-
-	cli := setupKeyServerAndClient(t, db)
 
 	t.Run("should return all keys for a tenantID", func(t *testing.T) {
 		// when
@@ -980,7 +1033,8 @@ func TestListKeys(t *testing.T) {
 		_, err := tmpDB.ExecContext(ctx, "DROP TABLE keys CASCADE")
 		require.NoError(t, err)
 
-		cli := setupKeyServerAndClient(t, tmpDB)
+		setup := setupKeyServerAndClient(t, tmpDB)
+		cli := setup.cli
 
 		// when
 		resp, err := cli.ListKeys(ctx, &keypb.ListKeysRequest{
@@ -1006,7 +1060,7 @@ func TestListKeys(t *testing.T) {
 //	    F(K2)
 //	    G(K2)
 //	      H(K3)
-func createKeyHierarchy(t *testing.T, keyStore *storesql.KeyStore, tenant model.Tenant) keyHierarchy {
+func createKeyHierarchy(t *testing.T, keyStore store.Key, tenant model.Tenant) keyHierarchy {
 	t.Helper()
 	ctx := t.Context()
 

--- a/pkg/api/v1/proto/admin/keys/setup_test.go
+++ b/pkg/api/v1/proto/admin/keys/setup_test.go
@@ -42,6 +42,16 @@ import (
 	"github.com/openkcm/krypton/pkg/validator"
 )
 
+type testSetup struct {
+	keyStore        store.Key
+	keyVersionStore store.KeyVersion
+	tenantStore     store.Tenant
+	vaultK1         *vaultprovider.Spec
+	vaultK2         *vaultprovider.Spec
+	vaultK3         *vaultprovider.Spec
+	cli             keys.KeyServiceClient
+}
+
 var pgConnStr string
 
 func TestMain(m *testing.M) {
@@ -120,23 +130,41 @@ const (
 // setupKeyServerAndClient wires KeyService against the given DB using the
 // default test hierarchy and a noop job preparer that assigns deterministic
 // job IDs.
-func setupKeyServerAndClient(t *testing.T, db *sql.DB) keys.KeyServiceClient {
+func setupKeyServerAndClient(t *testing.T, db *sql.DB) *testSetup {
 	t.Helper()
 	return setupKeyServerAndClientWith(t, db, defaultTestHierarchy(), &noopJobPreparer{}, nil)
 }
 
-func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHierarchy, preparer keys.JobPreparer, topology *spec.Topology) keys.KeyServiceClient {
+func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHierarchy, preparer keys.JobPreparer, topology *spec.Topology) *testSetup {
 	t.Helper()
+
+	setup := &testSetup{
+		keyStore:        storesql.NewKeyStore(db),
+		keyVersionStore: storesql.NewKeyVersionStore(db),
+		tenantStore:     storesql.NewTenantStore(db),
+		vaultK1: &vaultprovider.Spec{
+			Name:   "vault-k1",
+			Type:   sqlitevault.TypeUnsafe,
+			Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k1.db")},
+		},
+		vaultK2: &vaultprovider.Spec{
+			Name:   "vault-k2",
+			Type:   sqlitevault.TypeUnsafe,
+			Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k2.db")},
+		},
+		vaultK3: &vaultprovider.Spec{
+			Name:   "vault-k3",
+			Type:   sqlitevault.TypeUnsafe,
+			Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k3.db")},
+		},
+	}
 
 	if topology == nil {
 		top := defaultTestTopology()
 		topology = &top
 	}
 
-	keyStore := storesql.NewKeyStore(db)
-	keyVersionStore := storesql.NewKeyVersionStore(db)
-	tenantStore := storesql.NewTenantStore(db)
-	v := validator.NewValidator(testRootSegment, *topology, hierarchy, tenantStore, keyStore)
+	v := validator.NewValidator(testRootSegment, *topology, hierarchy, setup.tenantStore, setup.keyStore)
 
 	// create root secret
 	sealerKey := make([]byte, 32)
@@ -147,8 +175,8 @@ func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHie
 
 	// create manager
 	mgr, err := keyprocessor.NewManager(t.Context(), keyprocessor.ManagerConfig{
-		KeyStore:        keyStore,
-		KeyVersionStore: storesql.NewKeyVersionStore(db),
+		KeyStore:        setup.keyStore,
+		KeyVersionStore: setup.keyVersionStore,
 		Bindings: map[model.KeyKind]spec.KeyBinding{
 			"K0": {
 				SealerSpec: &sealerprovider.Spec{
@@ -168,11 +196,7 @@ func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHie
 					Type:   aes256gcm.TypeAES256GCM,
 					Config: &aes256gcm.Config{},
 				},
-				VaultSpec: &vaultprovider.Spec{
-					Name:   "vault-k1",
-					Type:   sqlitevault.TypeUnsafe,
-					Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k1.db")},
-				},
+				VaultSpec: setup.vaultK1,
 			},
 			"K2": {
 				CryptorSpec: &cryptorprovider.Spec{
@@ -180,11 +204,7 @@ func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHie
 					Type:   aes256gcm.TypeAES256GCM,
 					Config: &aes256gcm.Config{},
 				},
-				VaultSpec: &vaultprovider.Spec{
-					Name:   "vault-k2",
-					Type:   sqlitevault.TypeUnsafe,
-					Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k2.db")},
-				},
+				VaultSpec: setup.vaultK2,
 			},
 			"K3": {
 				CryptorSpec: &cryptorprovider.Spec{
@@ -192,11 +212,7 @@ func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHie
 					Type:   aes256gcm.TypeAES256GCM,
 					Config: &aes256gcm.Config{},
 				},
-				VaultSpec: &vaultprovider.Spec{
-					Name:   "vault-k3",
-					Type:   sqlitevault.TypeUnsafe,
-					Config: &sqlitevault.FileConfig{Path: filepath.Join(t.TempDir(), "vault-k3.db")},
-				},
+				VaultSpec: setup.vaultK3,
 			},
 		},
 		Hierarchy: defaultTestHierarchy(),
@@ -204,7 +220,7 @@ func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHie
 	require.NoError(t, err)
 
 	srv := grpc.NewServer()
-	keys.RegisterKeyServiceServer(srv, keys.NewKeyService(testRootName, keyStore, keyVersionStore, v, preparer, mgr))
+	keys.RegisterKeyServiceServer(srv, keys.NewKeyService(testRootName, setup.keyStore, setup.keyVersionStore, v, preparer, mgr))
 
 	const bufSize = 1024 * 1024
 	lis := bufconn.Listen(bufSize)
@@ -232,7 +248,8 @@ func setupKeyServerAndClientWith(t *testing.T, db *sql.DB, hierarchy spec.KeyHie
 		conn.Close()
 	})
 
-	return keys.NewKeyServiceClient(conn)
+	setup.cli = keys.NewKeyServiceClient(conn)
+	return setup
 }
 
 func createDatabase(t *testing.T) *sql.DB {
@@ -282,12 +299,10 @@ func assertErrorDetails(t *testing.T, expCode proto.Code, actErr error) {
 	assert.Equal(t, expCode, dt.GetCode())
 }
 
-func createTenant(t *testing.T, db *sql.DB) model.Tenant {
+func createTenant(t *testing.T, s store.Tenant) model.Tenant {
 	t.Helper()
-	ctx := t.Context()
-	tenantStore := storesql.NewTenantStore(db)
 	tenant := model.NewTenant("test-tenant-"+uuid.NewString(), nil)
-	result, err := tenantStore.CreateTenant(ctx, store.CreateTenantQuery{Tenant: tenant})
+	result, err := s.CreateTenant(t.Context(), store.CreateTenantQuery{Tenant: tenant})
 	require.NoError(t, err)
 	return result.Tenant
 }


### PR DESCRIPTION
Introduce the  subcommand to the CLI, wiring it to the existing ActivateKey RPC. 
Promote keyprocessor.NewManager initialization to shared infrastructure so it can serve both KMIP and the new CLI path. 
Refactor integration test helpers to return a testSetup struct, giving each test its own tenant for better isolation.

