### PR TITLE
feat:make ImportKey idempotent and fix securemem test cleanup

### DIFF
--- a/internal/securemem/data_test.go
+++ b/internal/securemem/data_test.go
@@ -541,6 +541,7 @@ func TestDataCleanup(t *testing.T) {
 		// then
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "cannot allocate memory")
+		securemem.CleanUpFunc(subj).Stop()
 	})
 
 	t.Run("should fail if cleanup ref destroys already-unmapped memory", func(t *testing.T) {
@@ -568,5 +569,6 @@ func TestDataCleanup(t *testing.T) {
 		// then
 		assert.Error(t, err)
 		assert.ErrorContains(t, err, "cannot allocate memory")
+		securemem.CleanUpFunc(subj).Stop()
 	})
 }

--- a/internal/securemem/export_test.go
+++ b/internal/securemem/export_test.go
@@ -1,7 +1,13 @@
 package securemem
 
+import "runtime"
+
 var NewHandlerRequest = newHandlerRequest
 
 func NewDataCleanupRef(name string, data SecureBytes) *dataCleanupRef {
 	return &dataCleanupRef{name: name, data: data}
+}
+
+func CleanUpFunc(d *Data) runtime.Cleanup {
+	return d.cleanup
 }

--- a/internal/securemem/handler_test.go
+++ b/internal/securemem/handler_test.go
@@ -172,9 +172,11 @@ func TestHandlerRequestRun(t *testing.T) {
 	})
 }
 
+// BenchmarkMemVault_Reserve benchmarks the performance of reserving memory in the MemVault.
+// To run this test `go test -count=5  -benchtime=5s -run=^$ -bench=BenchmarkMemVault_Reserve -benchmem ./internal/securemem/`
 func BenchmarkMemVault_Reserve(b *testing.B) {
 	secretBytes := []byte("MYSECRETKEY123458901234567890123")
-	for range b.N {
+	for b.Loop() {
 		b.ReportAllocs()
 		resp, err := securemem.Run(b.Context(), func(ctx context.Context, req *securemem.HandlerRequest) error {
 			secret, err := req.PersistentVault().Reserve("secret", len(secretBytes))
@@ -198,10 +200,9 @@ func BenchmarkMemVault_Reserve(b *testing.B) {
 		})
 
 		assert.NoError(b, err)
-		v, ok := resp.MemVault().Get("secret")
 
+		_, ok := resp.MemVault().Get("secret")
 		assert.True(b, ok)
-		assert.Equal(b, secretBytes, v)
 
 		err = resp.MemVault().DestroyAll()
 		assert.NoError(b, err)

--- a/internal/vault/sqlitevault/unsafesqlite.go
+++ b/internal/vault/sqlitevault/unsafesqlite.go
@@ -104,7 +104,8 @@ func (u *Unsafe) ImportKey(ctx context.Context, req vault.ImportKeyRequest) (*va
 		return nil, vault.ErrInvalidRequest
 	}
 	_, err := u.db.ExecContext(ctx,
-		"INSERT INTO keys (tenant_id, key_id, key_version, key_revision, key_material, aad, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		`INSERT INTO keys (tenant_id, key_id, key_version, key_revision, key_material, aad, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (tenant_id, key_id, key_version, key_revision) DO UPDATE SET key_material = excluded.key_material, aad = excluded.aad, created_at = excluded.created_at `,
 		req.TenantID, req.KeyID, req.KeyVersion, req.KeyRevision, []byte(req.KeyMaterial.SecureBytes()), req.AAD, int64(clock.Now()),
 	)
 	if err != nil {

--- a/internal/vault/sqlitevault/unsafesqlite_test.go
+++ b/internal/vault/sqlitevault/unsafesqlite_test.go
@@ -101,15 +101,6 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "duplicate key version",
-			req: vault.ImportKeyRequest{
-				TenantID:    "tenant-1",
-				KeyID:       "key-1",
-				KeyVersion:  1,
-				KeyMaterial: newTestSecureData(t, []byte("key-material-32-bytes-padding!!")),
-			},
-		},
-		{
 			name: "nil key material",
 			req: vault.ImportKeyRequest{
 				TenantID:   "tenant-1",
@@ -125,6 +116,70 @@ func TestUnsafe_ImportKeyErrors(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestUnsafe_ImportDuplicateKey(t *testing.T) {
+	// given
+	v := newTestUnsafeVault(t)
+	ctx := t.Context()
+
+	keyMaterial1 := newTestSecureData(t, []byte("key-material-1"))
+	keyMaterial2 := newTestSecureData(t, []byte("key-material-2"))
+	aad1 := []byte("aad-1")
+	aad2 := []byte("aad-2")
+
+	_, err := v.ImportKey(ctx, vault.ImportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  1,
+		KeyRevision: 1,
+		KeyMaterial: keyMaterial1,
+		AAD:         aad1,
+	})
+	assert.NoError(t, err)
+
+	key1, err := v.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  1,
+		KeyRevision: 1,
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		_ = key1.KeyMaterial.Destroy()
+	})
+
+	// when - import the same key again
+	_, err = v.ImportKey(ctx, vault.ImportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  1,
+		KeyRevision: 1,
+		KeyMaterial: keyMaterial2,
+		AAD:         aad2,
+	})
+	assert.NoError(t, err) // In this unsafe implementation, importing a duplicate key overwrites the existing one without error.
+
+	key2, err := v.ExportKey(ctx, vault.ExportKeyRequest{
+		TenantID:    "tenant-1",
+		KeyID:       "key-1",
+		KeyVersion:  1,
+		KeyRevision: 1,
+	})
+
+	// then
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = key2.KeyMaterial.Destroy()
+	})
+
+	assert.NotEqual(t, key1.KeyMaterial.SecureBytes(), key2.KeyMaterial.SecureBytes())
+	assert.Equal(t, keyMaterial1.SecureBytes(), key1.KeyMaterial.SecureBytes())
+	assert.Equal(t, keyMaterial2.SecureBytes(), key2.KeyMaterial.SecureBytes())
+	assert.NotEqual(t, key1.AAD, key2.AAD)
+	assert.Equal(t, aad1, key1.AAD)
+	assert.Equal(t, aad2, key2.AAD)
 }
 
 func TestUnsafe_ExportKeyLatestVersion(t *testing.T) {


### PR DESCRIPTION
- Change sqlitevault ImportKey from INSERT to upsert, aligning with openbaovault's existing idempotent behavior.
- Stop runtime cleanup functions in securemem tests to prevent double-free on already-destroyed memory.
