### PR TITLE
feat: add KMIP verification to activate-key integration tests

### DIFF
--- a/integration/activate_key_test.go
+++ b/integration/activate_key_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openkcm/krypton/pkg/api/v1/proto/admin"
+	ovhkmip "github.com/ovh/kmip-go"
+
 	keypb "github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
 	"github.com/openkcm/krypton/pkg/model"
 	"github.com/openkcm/krypton/pkg/store"
@@ -19,24 +20,17 @@ type activatedKeyRow struct {
 }
 
 func TestActivateKey(t *testing.T) {
-	env := setupEnvironment(t)
+	// K0(root) -> K1(kek) -> K2(dek)
+	env := setupRootEnvWithKMIP(t)
 	rootKVStore := newKeyVersionStore(t, env.RootDB)
 	rootKStore := newKeyStore(t, env.RootDB)
-
-	tenantCli := admin.NewTenantServiceClient(env.Conn)
+	tenantID := env.PreConfiguredTenant.ID
 	keyCli := keypb.NewKeyServiceClient(env.Conn)
 
 	ctx := t.Context()
 
-	t.Run("should activate root key", func(t *testing.T) {
+	t.Run("should activate root key (K0)", func(t *testing.T) {
 		// given
-		// Create a tenant
-		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
-			Name: "announce-root-test-" + uuid.NewString(),
-		})
-		require.NoError(t, err)
-		tenantID := tenantResp.GetTenant().GetId()
-
 		// announce key root key
 		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenantID,
@@ -46,7 +40,7 @@ func TestActivateKey(t *testing.T) {
 			Labels:     map[string]string{"cloud": "aws"},
 		})
 		require.NoError(t, err)
-		keyID := resp.GetKey().GetId()
+		rootKeyID := resp.GetKey().GetId()
 
 		// when
 		cmd := newCLICommand(
@@ -55,7 +49,7 @@ func TestActivateKey(t *testing.T) {
 			"activate",
 			"key",
 			"--tenant-id", tenantID,
-			"--key-id", keyID,
+			"--key-id", rootKeyID,
 			"--json",
 			"--server", "localhost:"+env.RootPort)
 		output, err := cmd.CombinedOutput()
@@ -65,7 +59,7 @@ func TestActivateKey(t *testing.T) {
 		assert.True(t, decodeActivatedKeyRow(t, output).Status)
 
 		// checking key status
-		key, err := rootKStore.GetKeyByID(ctx, keyID, tenantID)
+		key, err := rootKStore.GetKeyByID(ctx, rootKeyID, tenantID)
 		require.NoError(t, err)
 		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
 		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
@@ -73,7 +67,7 @@ func TestActivateKey(t *testing.T) {
 		// check key version status
 		kvr, err := rootKVStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID: tenantID,
-			KeyID:    keyID,
+			KeyID:    rootKeyID,
 			OrderBy: []store.KeyVersionOrder{
 				store.KeyVersionOrderVersionDesc,
 				store.KeyVersionOrderRevisionDesc,
@@ -84,17 +78,17 @@ func TestActivateKey(t *testing.T) {
 		kv := kvr.KeyVersions[0]
 		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
 		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
+
+		// call KMIP Server to get the key material
+		actUID := env.PreConfiguredTenant.ID + ":" + kv.KeyID + ":1"
+
+		kmipResp, err := env.PreConfiguredKMIPClient.Get(actUID).ExecContext(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, kmipResp)
 	})
 
-	t.Run("should activate intermediate key", func(t *testing.T) {
+	t.Run("should activate intermediate keys (K1)", func(t *testing.T) {
 		// given
-		// Create a tenant
-		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
-			Name: "announce-root-test-" + uuid.NewString(),
-		})
-		require.NoError(t, err)
-		tenantID := tenantResp.GetTenant().GetId()
-
 		// announce key root key
 		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenantID,
@@ -104,7 +98,7 @@ func TestActivateKey(t *testing.T) {
 			Labels:     map[string]string{"cloud": "aws"},
 		})
 		require.NoError(t, err)
-		keyID := resp.GetKey().GetId()
+		rootKeyID := resp.GetKey().GetId()
 
 		// activate root key
 		cmd := newCLICommand(
@@ -113,34 +107,34 @@ func TestActivateKey(t *testing.T) {
 			"activate",
 			"key",
 			"--tenant-id", tenantID,
-			"--key-id", keyID,
+			"--key-id", rootKeyID,
 			"--json",
 			"--server", "localhost:"+env.RootPort)
 		output, err := cmd.CombinedOutput()
 		require.NoError(t, err, "command should succeed, output: %s", string(output))
 		assert.True(t, decodeActivatedKeyRow(t, output).Status)
 
-		// announce intermediate key
+		// announce k1 key
 		resp, err = keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenantID,
 			Kind:       "K1",
 			Name:       "k1-key-" + uuid.NewString(),
 			TargetName: "",
-			ParentId:   keyID,
+			ParentId:   rootKeyID,
 			Labels:     map[string]string{"cloud": "aws"},
 		})
 		require.NoError(t, err)
-		keyID = resp.GetKey().GetId()
+		k1KeyID := resp.GetKey().GetId()
 
 		// when
-		// activate intermediate key
+		// activate k1 key
 		cmd = newCLICommand(
 			t.Context(),
 			t.TempDir(),
 			"activate",
 			"key",
 			"--tenant-id", tenantID,
-			"--key-id", keyID,
+			"--key-id", k1KeyID,
 			"--json",
 			"--server", "localhost:"+env.RootPort)
 		output, err = cmd.CombinedOutput()
@@ -150,7 +144,7 @@ func TestActivateKey(t *testing.T) {
 		assert.True(t, decodeActivatedKeyRow(t, output).Status)
 
 		// checking key status
-		key, err := rootKStore.GetKeyByID(ctx, keyID, tenantID)
+		key, err := rootKStore.GetKeyByID(ctx, k1KeyID, tenantID)
 		require.NoError(t, err)
 		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
 		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
@@ -158,7 +152,7 @@ func TestActivateKey(t *testing.T) {
 		// check key version status
 		kvr, err := rootKVStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
 			TenantID: tenantID,
-			KeyID:    keyID,
+			KeyID:    k1KeyID,
 			OrderBy: []store.KeyVersionOrder{
 				store.KeyVersionOrderVersionDesc,
 				store.KeyVersionOrderRevisionDesc,
@@ -169,17 +163,118 @@ func TestActivateKey(t *testing.T) {
 		kv := kvr.KeyVersions[0]
 		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
 		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
+
+		assertKMIPKeyRetrievable(t, env, kv)
+	})
+
+	t.Run("should activate all keys", func(t *testing.T) {
+		// given
+		// announce key root key
+		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K0",
+			Name:       "root-key-" + uuid.NewString(),
+			TargetName: "",
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		rootKeyID := resp.GetKey().GetId()
+
+		// activate root key
+		cmd := newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", rootKeyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// announce k1 key
+		resp, err = keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K1",
+			Name:       "k1-key-" + uuid.NewString(),
+			TargetName: "",
+			ParentId:   rootKeyID,
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		k1KeyID := resp.GetKey().GetId()
+
+		// activate k1 key
+		cmd = newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", k1KeyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err = cmd.CombinedOutput()
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// announce k2 key
+		resp, err = keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
+			TenantId:   tenantID,
+			Kind:       "K2",
+			Name:       "k2-key-" + uuid.NewString(),
+			TargetName: "",
+			ParentId:   k1KeyID,
+			Labels:     map[string]string{"cloud": "aws"},
+		})
+		require.NoError(t, err)
+		k2KeyID := resp.GetKey().GetId()
+
+		// when
+		// activate k2 key
+		cmd = newCLICommand(
+			t.Context(),
+			t.TempDir(),
+			"activate",
+			"key",
+			"--tenant-id", tenantID,
+			"--key-id", k2KeyID,
+			"--json",
+			"--server", "localhost:"+env.RootPort)
+		output, err = cmd.CombinedOutput()
+
+		// then
+		require.NoError(t, err, "command should succeed, output: %s", string(output))
+		assert.True(t, decodeActivatedKeyRow(t, output).Status)
+
+		// checking key status
+		key, err := rootKStore.GetKeyByID(ctx, k2KeyID, tenantID)
+		require.NoError(t, err)
+		assert.Equal(t, model.KeyLifeCycleActive, key.LifeCycleState)
+		assert.Equal(t, model.KeyProcessingCompleted, key.KeyProcessingState.Status)
+
+		// check key version status
+		kvr, err := rootKVStore.ListKeyVersions(ctx, store.ListKeyVersionsQuery{
+			TenantID: tenantID,
+			KeyID:    k2KeyID,
+			OrderBy: []store.KeyVersionOrder{
+				store.KeyVersionOrderVersionDesc,
+				store.KeyVersionOrderRevisionDesc,
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, kvr.KeyVersions, 1, "there should be exactly one key version after activation")
+		kv := kvr.KeyVersions[0]
+		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
+		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
+
+		assertKMIPKeyRetrievable(t, env, kv)
 	})
 
 	t.Run("should return error if activate key is called on already activated key", func(t *testing.T) {
 		// given
-		// Create a tenant
-		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
-			Name: "announce-root-test-" + uuid.NewString(),
-		})
-		require.NoError(t, err)
-		tenantID := tenantResp.GetTenant().GetId()
-
 		// announce key root key
 		resp, err := keyCli.AnnounceKey(ctx, &keypb.AnnounceKeyRequest{
 			TenantId:   tenantID,
@@ -225,13 +320,6 @@ func TestActivateKey(t *testing.T) {
 
 	t.Run("should return error if activate key is called on non-existent key", func(t *testing.T) {
 		// given
-		// Create a tenant
-		tenantResp, err := tenantCli.CreateTenant(ctx, &admin.CreateTenantRequest{
-			Name: "announce-root-test-" + uuid.NewString(),
-		})
-		require.NoError(t, err)
-		tenantID := tenantResp.GetTenant().GetId()
-
 		// when
 		cmd := newCLICommand(
 			t.Context(),
@@ -295,6 +383,24 @@ func TestActivateKey(t *testing.T) {
 			})
 		}
 	})
+}
+
+func assertKMIPKeyRetrievable(t *testing.T, env *testEnvWithRootKMIP, kv model.KeyVersion) {
+	t.Helper()
+
+	ctx := t.Context()
+	actUID := env.PreConfiguredTenant.ID + ":" + kv.KeyID + ":1"
+
+	kmipResp, err := env.PreConfiguredKMIPClient.Get(actUID).ExecContext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, actUID, kmipResp.UniqueIdentifier)
+
+	sk, ok := kmipResp.Object.(*ovhkmip.SymmetricKey)
+	require.True(t, ok, "Object type = %T", kmipResp.Object)
+
+	mat, err := sk.KeyMaterial()
+	require.NoError(t, err, "KeyMaterial")
+	assert.NotNil(t, mat)
 }
 
 func decodeActivatedKeyRow(t *testing.T, output []byte) activatedKeyRow {

--- a/integration/activate_key_test.go
+++ b/integration/activate_key_test.go
@@ -82,9 +82,14 @@ func TestActivateKey(t *testing.T) {
 		// call KMIP Server to get the key material
 		actUID := env.PreConfiguredTenant.ID + ":" + kv.KeyID + ":1"
 
+		// below errors are due to configuration now, but later it should be authorization errors
+		_, err = env.PreConfiguredKMIPClient.GetAttributes(actUID).ExecContext(ctx)
+		assert.Error(t, err)
+
 		kmipResp, err := env.PreConfiguredKMIPClient.Get(actUID).ExecContext(ctx)
 		assert.Error(t, err)
 		assert.Nil(t, kmipResp)
+
 	})
 
 	t.Run("should activate intermediate keys (K1)", func(t *testing.T) {
@@ -164,7 +169,8 @@ func TestActivateKey(t *testing.T) {
 		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
 		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
 
-		assertKMIPKeyRetrievable(t, env, kv)
+		assertKMIPGetAttributes(t, env, kv)
+		assertKMIPGet(t, env, kv)
 	})
 
 	t.Run("should activate all keys", func(t *testing.T) {
@@ -270,7 +276,8 @@ func TestActivateKey(t *testing.T) {
 		assert.Equal(t, model.KeyLifeCycleActive, kv.LifeCycleState)
 		assert.Equal(t, model.KeyVersionUsable, kv.ProcessingState)
 
-		assertKMIPKeyRetrievable(t, env, kv)
+		assertKMIPGetAttributes(t, env, kv)
+		assertKMIPGet(t, env, kv)
 	})
 
 	t.Run("should return error if activate key is called on already activated key", func(t *testing.T) {
@@ -385,18 +392,35 @@ func TestActivateKey(t *testing.T) {
 	})
 }
 
-func assertKMIPKeyRetrievable(t *testing.T, env *testEnvWithRootKMIP, kv model.KeyVersion) {
+func assertKMIPGetAttributes(t *testing.T, env *testEnvWithRootKMIP, kv model.KeyVersion) {
 	t.Helper()
 
 	ctx := t.Context()
 	actUID := env.PreConfiguredTenant.ID + ":" + kv.KeyID + ":1"
 
-	kmipResp, err := env.PreConfiguredKMIPClient.Get(actUID).ExecContext(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, actUID, kmipResp.UniqueIdentifier)
+	resp, err := env.PreConfiguredKMIPClient.GetAttributes(actUID).ExecContext(ctx)
+	require.NoError(t, err, "GetAttributes")
+	assert.Equal(t, actUID, resp.UniqueIdentifier)
+	got := indexAttrs(resp.Attribute)
+	assert.Len(t, got, 4)
+	assert.Equal(t, ovhkmip.StateActive, got[ovhkmip.AttributeNameState])
+	assert.Equal(t, ovhkmip.CryptographicAlgorithmAES, got[ovhkmip.AttributeNameCryptographicAlgorithm])
+	assert.Equal(t, int32(256), got[ovhkmip.AttributeNameCryptographicLength])
+	assert.Equal(t, ovhkmip.ObjectTypeSymmetricKey, got[ovhkmip.AttributeNameObjectType])
+}
 
-	sk, ok := kmipResp.Object.(*ovhkmip.SymmetricKey)
-	require.True(t, ok, "Object type = %T", kmipResp.Object)
+func assertKMIPGet(t *testing.T, env *testEnvWithRootKMIP, kv model.KeyVersion) {
+	t.Helper()
+
+	ctx := t.Context()
+	actUID := env.PreConfiguredTenant.ID + ":" + kv.KeyID + ":1"
+
+	resp, err := env.PreConfiguredKMIPClient.Get(actUID).ExecContext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, actUID, resp.UniqueIdentifier)
+
+	sk, ok := resp.Object.(*ovhkmip.SymmetricKey)
+	require.True(t, ok, "Object type = %T", resp.Object)
 
 	mat, err := sk.KeyMaterial()
 	require.NoError(t, err, "KeyMaterial")
@@ -412,4 +436,12 @@ func decodeActivatedKeyRow(t *testing.T, output []byte) activatedKeyRow {
 	}
 	require.Len(t, ar, 1, "expected exactly one activated key row in the output")
 	return ar[0]
+}
+
+func indexAttrs(attrs []ovhkmip.Attribute) map[ovhkmip.AttributeName]any {
+	m := make(map[ovhkmip.AttributeName]any, len(attrs))
+	for _, a := range attrs {
+		m[a.AttributeName] = a.AttributeValue
+	}
+	return m
 }

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -5,17 +5,21 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/ovh/kmip-go/kmipclient"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/openkcm/krypton/pkg/api/v1/proto/admin/keys"
+	"github.com/openkcm/krypton/pkg/model"
+	"github.com/openkcm/krypton/pkg/store"
 )
 
 // testEnvironment holds the shared infrastructure for tests that require root + agent.
@@ -25,6 +29,15 @@ type testEnvironment struct {
 	RootPort  string
 	AgentPort string
 	Conn      *grpc.ClientConn
+}
+
+// testEnvWithRootKMIP holds the shared infrastructure for tests that require root and kmip server.
+type testEnvWithRootKMIP struct {
+	RootDB                  *sql.DB
+	RootPort                string
+	Conn                    *grpc.ClientConn
+	PreConfiguredTenant     model.Tenant
+	PreConfiguredKMIPClient *kmipclient.Client
 }
 
 // testKey is a 32-byte AES-256 key for testing.
@@ -83,8 +96,55 @@ func setupEnvironment(t *testing.T) *testEnvironment {
 	}
 }
 
-// writeRootConfig writes a valid root config YAML to a temp file with the given
-// agent as a reconciler target and returns the file path.
+func setupRootEnvWithKMIP(t *testing.T) *testEnvWithRootKMIP {
+	t.Helper()
+
+	rootDB, rootConnStr := createDatabase(t)
+	rootPort := freePort(t)
+	kmipRootPort := freePort(t)
+
+	// preconfiguring a tenant
+	ctr, err := newTenantStore(t, rootDB).CreateTenant(t.Context(), store.CreateTenantQuery{
+		Tenant: model.NewTenant("preconfigured-tenant-"+uuid.NewString(), nil),
+	})
+	require.NoError(t, err)
+	tenant := ctr.Tenant
+
+	pki := newTestPKI(t, tenant.ID)
+	rootCfgPath := writeRootConfigWithKMIP(t, kmipRootPort, pki.serverCertPath, pki.serverKeyPath, pki.caCertFilePath)
+
+	rootBinary := buildBinary(t, "root", "../cmd/root")
+
+	rootCmd := createCmd(t, rootBinary, []string{
+		"ROOT_CONFIG_PATH=" + rootCfgPath,
+		"DATABASE_URL=" + rootConnStr,
+		"SERVER_PORT=" + rootPort,
+		"KRYPTON_ROOT_KEY=" + testKeyBase64,
+	})
+	require.NoError(t, rootCmd.Start(), "failed to start root server")
+	waitForPort(t, rootPort)
+
+	conn, err := grpc.NewClient(
+		"localhost:"+rootPort,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	kmipAddr := "localhost:" + kmipRootPort
+	waitTCPReady(t, kmipAddr)
+
+	kmipCli := dialAs(t, kmipAddr, pki, tenant.ID)
+	t.Cleanup(func() { _ = kmipCli.Close() })
+	return &testEnvWithRootKMIP{
+		RootDB:                  rootDB,
+		RootPort:                rootPort,
+		Conn:                    conn,
+		PreConfiguredTenant:     tenant,
+		PreConfiguredKMIPClient: kmipCli,
+	}
+}
+
 func writeRootConfig(t *testing.T, agentName, agentPort string) string {
 	t.Helper()
 
@@ -174,6 +234,72 @@ reconciler:
     - name: %s
       address: localhost:%s
 `, agentName, agentName, agentPort)
+
+	return writeTempFile(t, "root-config-*.yaml", content)
+}
+
+// writeRootConfigWithKMIP writes a root config YAML with KMIP settings to a temp file and returns the path.
+func writeRootConfigWithKMIP(t *testing.T, kmipPort, kmipServerCertPath, kmipServerKeyPath, kmipClientCAPath string) string {
+	t.Helper()
+
+	content := fmt.Sprintf(`name: root
+role: root
+segment:
+  start_kind: K0
+  end_kind: K2
+selector_labels:
+  environment: production
+key_bindings:
+  K0:
+    sealer:
+      name: root-sealer
+      type: aes256gcm-staticsecret
+      config:
+        secret:
+          type: envvar
+          config:
+            name: KRYPTON_ROOT_KEY
+  K1:
+    crypto:
+      name: kek-crypto
+      type: aes256gcm
+    vault:
+      name: k1-vault
+      type: unsafe-sqlite-memory
+  K2:
+    crypto:
+      name: dek-crypto
+      type: aes256gcm
+    vault:
+      name: k2-vault
+      type: unsafe-sqlite-memory
+hierarchy:
+  name: test-hierarchy
+  key_specs:
+    - kind: K0
+      role: root
+      algorithm: AES256
+      labels_spec:
+        allow_user_labels: true
+    - kind: K1
+      role: kek
+      algorithm: AES256
+      labels_spec:
+        allow_user_labels: true
+    - kind: K2
+      role: dek
+      algorithm: AES256
+      labels_spec:
+        allow_user_labels: true
+topology:
+kmip:
+  bind_addr: localhost
+  port: %s
+  tls:
+    server_cert: %s
+    server_key: %s
+    client_ca: %s
+`, kmipPort, kmipServerCertPath, kmipServerKeyPath, kmipClientCAPath)
 
 	return writeTempFile(t, "root-config-*.yaml", content)
 }
@@ -332,4 +458,35 @@ func seedSelectedTenant(t *testing.T, homeDir, tenantID, tenantName string) {
 	require.NoError(t, os.MkdirAll(dir, 0700))
 	payload := fmt.Appendf(nil, `{"tenant":{"id":%q,"name":%q}}`, tenantID, tenantName)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "state.lock"), payload, 0600))
+}
+
+func waitTCPReady(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var d net.Dialer
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		cancel()
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("KMIP server did not start listening on %s in time", addr)
+}
+
+func dialAs(t *testing.T, addr string, pki *testPKI, cn string) *kmipclient.Client {
+	t.Helper()
+	cc, ok := pki.clientCerts[cn]
+	require.True(t, ok, "no client cert for CN %q", cn)
+	c, err := kmipclient.Dial(
+		addr,
+		kmipclient.WithRootCAPem(pki.caPEM),
+		kmipclient.WithClientCertPEM(cc.certPEM, cc.keyPEM),
+		kmipclient.WithServerName("127.0.0.1"),
+	)
+	require.NoError(t, err, "Dial as %s", cn)
+	return c
 }

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -2,7 +2,14 @@ package integration
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"database/sql"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"os"
 	"os/exec"
@@ -10,6 +17,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/openkcm/orbital"
@@ -244,4 +252,101 @@ func (*noopJobPreparer) PrepareJob(_ context.Context, job orbital.Job) (orbital.
 		job.ID = uuid.Must(uuid.NewUUID())
 	}
 	return job, nil
+}
+
+// testPKI is a self-contained CA + server cert + client cert(s) suitable for
+// exercising mTLS in tests without touching the network.
+type testPKI struct {
+	caPEM          []byte
+	caCertFilePath string
+	serverCertPEM  []byte
+	serverCertPath string
+	serverKeyPEM   []byte
+	serverKeyPath  string
+	clientCerts    map[string]testClientCert
+}
+type testClientCert struct {
+	certPEM []byte
+	keyPEM  []byte
+}
+
+func newTestPKI(t *testing.T, clientCNs ...string) *testPKI {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "gen CA key")
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err, "sign CA")
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err, "parse CA")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	serverCertPEM, serverKeyPEM := issueCert(t, caCert, caKey, pkix.Name{CommonName: "kmip-server"}, false, []net.IP{net.ParseIP("127.0.0.1")})
+
+	pki := &testPKI{
+		caPEM:         caPEM,
+		serverCertPEM: serverCertPEM,
+		serverKeyPEM:  serverKeyPEM,
+		clientCerts:   make(map[string]testClientCert, len(clientCNs)),
+	}
+	for _, cn := range clientCNs {
+		certPEM, keyPEM := issueCert(t, caCert, caKey, pkix.Name{CommonName: cn}, true, nil)
+		pki.clientCerts[cn] = testClientCert{certPEM: certPEM, keyPEM: keyPEM}
+	}
+
+	dir := t.TempDir()
+	pki.caCertFilePath = filepath.Join(dir, "ca.pem")
+	writeFile(t, pki.caCertFilePath, caPEM)
+
+	certPath := filepath.Join(dir, "server.pem")
+	pki.serverCertPath = certPath
+	writeFile(t, certPath, pki.serverCertPEM)
+
+	keyPath := filepath.Join(dir, "server-key.pem")
+	pki.serverKeyPath = keyPath
+	writeFile(t, keyPath, pki.serverKeyPEM)
+
+	return pki
+}
+
+func issueCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, subject pkix.Name, client bool, ips []net.IP) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "gen key for %s", subject.CommonName)
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err, "gen serial")
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      subject,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		IPAddresses:  ips,
+	}
+	if client {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	require.NoError(t, err, "sign cert for %s", subject.CommonName)
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err, "marshal key for %s", subject.CommonName)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, data, 0o600), "write %s", path)
 }


### PR DESCRIPTION
This covers the main substance: the tests now verify that activated keys (K1, K2) are retrievable via KMIP after activation, with full PKI infrastructure (setup_test.go) and a new testEnvWithRootKMIP helper. 